### PR TITLE
ci: Add npm publish workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -49,7 +49,9 @@ jobs:
 
             Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
 
-            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+            IMPORTANT: Before posting a new review comment, check if there is an existing review comment from a previous run (look for "## Code Review" in PR comments). If found, UPDATE that comment instead of creating a new one using `gh pr comment --edit-last`. If no previous comment exists, create a new one with `gh pr comment`.
+
+            Include the commit SHA in your review header so it's clear which commit was reviewed.
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,75 @@
+name: Publish to npm
+
+# Publish to npm when a PR is merged to production, or manually triggered
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - production
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (build only, do not publish)'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  publish:
+    # Run if: PR was merged, OR manually triggered
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build package
+        run: npm run build
+
+      - name: Publish to npm
+        if: ${{ !inputs.dry_run }}
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Dry run - skip publish
+        if: ${{ inputs.dry_run }}
+        run: echo "Dry run mode - skipping npm publish"
+
+      - name: Notify Slack on success
+        if: success() && !inputs.dry_run
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        run: |
+          if [ -n "$SLACK_WEBHOOK" ]; then
+            VERSION=$(node -p "require('./package.json').version")
+            curl -X POST -H 'Content-type: application/json' \
+              --data "{\"text\":\"een-api-toolkit v${VERSION} published to npm\"}" \
+              "$SLACK_WEBHOOK"
+          fi
+
+      - name: Notify Slack on failure
+        if: failure() && !inputs.dry_run
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        run: |
+          if [ -n "$SLACK_WEBHOOK" ]; then
+            curl -X POST -H 'Content-type: application/json' \
+              --data '{"text":"een-api-toolkit npm publish failed! Check GitHub Actions."}' \
+              "$SLACK_WEBHOOK"
+          fi

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
@@ -43,7 +44,8 @@ jobs:
 
       - name: Publish to npm
         if: ${{ !inputs.dry_run }}
-        run: npm publish
+        # Use --ignore-scripts to skip prepublishOnly since we already built via verify-package
+        run: npm publish --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Run tests
         run: npm test
 
-      - name: Build package
-        run: npm run build
+      - name: Build and verify package
+        run: npm run verify-package
 
       - name: Publish to npm
         if: ${{ !inputs.dry_run }}

--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -30,5 +30,18 @@ jobs:
       - name: Sync develop with production
         run: |
           git checkout develop
+          # Pull latest to handle race condition if another PR just merged
+          git pull origin develop --rebase
           git merge origin/production -m "chore: Sync develop with production after PR #${{ github.event.pull_request.number }}"
-          git push origin develop
+          # Retry push with pull if another workflow pushed first
+          for i in 1 2 3; do
+            if git push origin develop; then
+              echo "Push successful"
+              exit 0
+            fi
+            echo "Push failed, attempt $i/3. Pulling and retrying..."
+            git pull origin develop --rebase
+            sleep 2
+          done
+          echo "Push failed after 3 attempts"
+          exit 1

--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -1,0 +1,34 @@
+name: Sync Develop with Production
+
+# Automatically sync develop branch after PR merges to production
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - production
+
+jobs:
+  sync:
+    # Only run if PR was merged (not just closed)
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Sync develop with production
+        run: |
+          git checkout develop
+          git merge origin/production -m "chore: Sync develop with production after PR #${{ github.event.pull_request.number }}"
+          git push origin develop

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,12 +279,21 @@ Located in `.github/workflows/`.
 - Triggers when @claude is mentioned in issues/PRs
 - Responds to requests in comments and reviews
 
+### Branch Sync (`sync-develop.yml`)
+- Triggers when PR is merged to production
+- Automatically merges production into develop
+- Keeps branches in sync after releases
+
+### npm Publish (`npm-publish.yml`)
+- Triggers when PR is merged to production, or manually
+- Runs tests and package verification before publish
+- Supports dry-run mode for testing
+- Sends Slack notifications on success/failure
+
 ### Future Workflows (to be added)
 Reference `../een-oauth-proxy/.github/workflows/` for examples:
 - `validate-branch-protection.yml` - Enforce branch rules
 - `test-pr.yml` - Run tests on PRs
-- `release.yml` - npm publish + GitHub release
-- `sync-develop.yml` - Auto-sync branches after merge
 
 ## Code Review
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,22 @@ Isolated Vue 3 app that imports `een-api-toolkit` via npm. Use this to verify th
 - Version number tracked in `./package.json`
 - Husky auto-increments patch version on commit; minor/major updated manually
 
+### Branch Sync Best Practices
+
+**After merging a PR to production**, the develop branch must be synced to include the merge commit. This is automated via `.github/workflows/sync-develop.yml`, but if working locally:
+
+```bash
+# Before creating a new branch or making commits
+git fetch origin
+git merge origin/production
+
+# Or if on a feature branch, rebase on updated develop
+git fetch origin
+git rebase origin/develop
+```
+
+**Why this matters**: GitHub's "Create a merge commit" option creates a new commit on production. If develop doesn't have this commit, PRs from develop will show "branch is out-of-date" and may be blocked by branch protection (`strict: true`).
+
 ## Husky Setup
 
 Pre-commit hook auto-increments patch version when source files change:

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "docs": "npm run docs:api && npm run docs:ai-context",
     "docs:api": "typedoc",
     "docs:ai-context": "npx tsx scripts/generate-ai-context.ts",
+    "verify-package": "./scripts/verify-package.sh",
     "prepublishOnly": "npm run build && npm run docs",
     "prepare": "husky"
   },

--- a/scripts/verify-package.sh
+++ b/scripts/verify-package.sh
@@ -9,7 +9,11 @@ echo ""
 
 # Step 1: Build the package
 echo "1. Building package..."
-npm run build > /dev/null 2>&1
+if ! npm run build > /tmp/build-output.log 2>&1; then
+  echo "   ✗ Build failed:"
+  cat /tmp/build-output.log
+  exit 1
+fi
 echo "   ✓ Build successful"
 echo ""
 
@@ -29,6 +33,16 @@ echo ""
 echo "3. Creating and verifying tarball..."
 # npm pack outputs the tarball name on the last line; filter out other output
 TARBALL=$(npm pack 2>&1 | grep -E '\.tgz$' | tail -1)
+
+# Validate tarball was created
+if [ -z "$TARBALL" ]; then
+  echo "   ✗ Failed to create tarball (empty filename)"
+  exit 1
+fi
+if [ ! -f "$TARBALL" ]; then
+  echo "   ✗ Tarball file not found: $TARBALL"
+  exit 1
+fi
 echo "   Created: $TARBALL"
 
 # Check tarball contains expected files

--- a/scripts/verify-package.sh
+++ b/scripts/verify-package.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# Verify the built package works correctly before publishing
+# Tests: build output, tarball creation, TypeScript declarations
+
+set -e
+
+echo "=== Package Verification ==="
+echo ""
+
+# Step 1: Build the package
+echo "1. Building package..."
+npm run build > /dev/null 2>&1
+echo "   ✓ Build successful"
+echo ""
+
+# Step 2: Verify dist contents
+echo "2. Verifying dist contents..."
+REQUIRED_FILES=("dist/index.js" "dist/index.cjs" "dist/index.d.ts")
+for file in "${REQUIRED_FILES[@]}"; do
+  if [ ! -f "$file" ]; then
+    echo "   ✗ Missing: $file"
+    exit 1
+  fi
+  echo "   ✓ $file"
+done
+echo ""
+
+# Step 3: Create tarball and verify contents
+echo "3. Creating and verifying tarball..."
+# npm pack outputs the tarball name on the last line; filter out other output
+TARBALL=$(npm pack 2>&1 | grep -E '\.tgz$' | tail -1)
+echo "   Created: $TARBALL"
+
+# Check tarball contains expected files
+tar -tzf "$TARBALL" | grep -q "package/dist/index.js" || { echo "   ✗ Missing index.js in tarball"; exit 1; }
+tar -tzf "$TARBALL" | grep -q "package/dist/index.cjs" || { echo "   ✗ Missing index.cjs in tarball"; exit 1; }
+tar -tzf "$TARBALL" | grep -q "package/dist/index.d.ts" || { echo "   ✗ Missing index.d.ts in tarball"; exit 1; }
+tar -tzf "$TARBALL" | grep -q "package/package.json" || { echo "   ✗ Missing package.json in tarball"; exit 1; }
+echo "   ✓ Tarball contents verified"
+rm -f "$TARBALL"
+echo ""
+
+# Step 4: Verify TypeScript declarations are valid
+echo "4. Verifying TypeScript declarations..."
+# Check that the .d.ts file has expected exports
+if grep -q "export.*initEenToolkit" dist/index.d.ts && \
+   grep -q "export.*getAuthUrl" dist/index.d.ts && \
+   grep -q "export.*useCurrentUser" dist/index.d.ts && \
+   grep -q "export.*Result" dist/index.d.ts; then
+  echo "   ✓ Key exports found in declarations"
+else
+  echo "   ✗ Missing expected exports in declarations"
+  exit 1
+fi
+echo ""
+
+# Step 5: Verify ESM and CJS syntax
+echo "5. Verifying module formats..."
+# ESM should have export statements
+if grep -q "^export" dist/index.js; then
+  echo "   ✓ ESM format valid (dist/index.js)"
+else
+  echo "   ✗ ESM format invalid"
+  exit 1
+fi
+
+# CJS should have exports or module.exports
+if grep -q "exports\." dist/index.cjs || grep -q "module.exports" dist/index.cjs; then
+  echo "   ✓ CJS format valid (dist/index.cjs)"
+else
+  echo "   ✗ CJS format invalid"
+  exit 1
+fi
+echo ""
+
+# Step 6: Check package.json exports configuration
+echo "6. Verifying package.json exports..."
+node -e "
+const pkg = require('./package.json');
+const checks = [
+  [pkg.main === './dist/index.cjs', 'main points to CJS'],
+  [pkg.module === './dist/index.js', 'module points to ESM'],
+  [pkg.types === './dist/index.d.ts', 'types points to declarations'],
+  [pkg.exports['.'].import === './dist/index.js', 'exports.import configured'],
+  [pkg.exports['.'].require === './dist/index.cjs', 'exports.require configured'],
+  [pkg.exports['.'].types === './dist/index.d.ts', 'exports.types configured'],
+];
+let failed = false;
+checks.forEach(([ok, msg]) => {
+  if (ok) console.log('   ✓', msg);
+  else { console.log('   ✗', msg); failed = true; }
+});
+if (failed) process.exit(1);
+"
+echo ""
+
+echo "=== Package verification passed! ==="
+echo ""
+echo "Ready to publish v$(node -p "require('./package.json').version")"


### PR DESCRIPTION
## Summary
- Add automated npm publish workflow triggered when PRs merge to production
- Include manual trigger option with dry run mode for testing
- Slack notifications for publish success/failure

## Changes
- New `.github/workflows/npm-publish.yml` workflow

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] After merge, manually trigger with dry_run=true to test
- [ ] Manually trigger without dry_run to publish v0.0.5 to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)