### PR TITLE
feat: Enhanced release notifications and GitHub Releases

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -57,11 +57,39 @@ jobs:
         if: success() && !inputs.dry_run
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          TZ: America/Chicago
         run: |
           if [ -n "$SLACK_WEBHOOK" ]; then
             VERSION=$(node -p "require('./package.json').version")
+            PACKAGE_NAME=$(node -p "require('./package.json').name")
+            NPM_URL="https://www.npmjs.com/package/${PACKAGE_NAME}"
+            RELEASE_TIME=$(date '+%Y-%m-%d %H:%M:%S %Z')
+            # Get package size from the tarball
+            TARBALL=$(npm pack --dry-run 2>&1 | grep -E 'package size' | sed 's/.*package size: *//' | cut -d' ' -f1-2)
+            if [ -z "$TARBALL" ]; then
+              TARBALL="unknown"
+            fi
             curl -X POST -H 'Content-type: application/json' \
-              --data "{\"text\":\"een-api-toolkit v${VERSION} published to npm\"}" \
+              --data "{
+                \"blocks\": [
+                  {
+                    \"type\": \"section\",
+                    \"text\": {
+                      \"type\": \"mrkdwn\",
+                      \"text\": \":package: *${PACKAGE_NAME} v${VERSION}* published to npm\"
+                    }
+                  },
+                  {
+                    \"type\": \"section\",
+                    \"fields\": [
+                      {\"type\": \"mrkdwn\", \"text\": \"*Package:*\n<${NPM_URL}|${PACKAGE_NAME}>\"},
+                      {\"type\": \"mrkdwn\", \"text\": \"*Version:*\n${VERSION}\"},
+                      {\"type\": \"mrkdwn\", \"text\": \"*Size:*\n${TARBALL}\"},
+                      {\"type\": \"mrkdwn\", \"text\": \"*Released:*\n${RELEASE_TIME}\"}
+                    ]
+                  }
+                ]
+              }" \
               "$SLACK_WEBHOOK"
           fi
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -58,13 +58,15 @@ jobs:
             COMPARE_URL="https://github.com/${{ github.repository }}/commits/v${VERSION}"
           fi
 
-          # Generate changelog from commits, excluding merge commits and sync commits
-          CHANGELOG=$(git log $COMMIT_RANGE --pretty=format:"- %s" --no-merges | grep -v "chore: Sync develop" | grep -v "^\s*$" || echo "- Initial release")
+          # Generate changelog from commits safely (write to file first to avoid shell injection)
+          git log $COMMIT_RANGE --pretty=format:"- %s" --no-merges > commits_raw.txt 2>/dev/null || echo "- Initial release" > commits_raw.txt
+          grep -v "chore: Sync develop" commits_raw.txt | grep -v "^\s*$" > commits_filtered.txt || echo "- Initial release" > commits_filtered.txt
 
-          # Categorize commits
-          FEATURES=$(echo "$CHANGELOG" | grep -iE "^- (feat|add|new)" || true)
-          FIXES=$(echo "$CHANGELOG" | grep -iE "^- (fix|bug|patch)" || true)
-          OTHER=$(echo "$CHANGELOG" | grep -viE "^- (feat|add|new|fix|bug|patch)" || true)
+          # Categorize commits (read from file to avoid shell injection)
+          FEATURES=$(grep -iE "^- (feat|add|new)" commits_filtered.txt || true)
+          FIXES=$(grep -iE "^- (fix|bug|patch)" commits_filtered.txt || true)
+          OTHER=$(grep -viE "^- (feat|add|new|fix|bug|patch)" commits_filtered.txt || true)
+          rm -f commits_raw.txt commits_filtered.txt
 
           # Generate CHANGELOG.md
           cat > CHANGELOG.md << 'HEADER'
@@ -130,14 +132,36 @@ jobs:
         run: |
           VERSION=$(node -p "require('./package.json').version")
 
-          # Create the tarball for the release (CHANGELOG.md is already included)
+          # Create the tarball for the release (CHANGELOG.md is included via package.json files array)
           TARBALL=$(npm pack 2>&1 | grep -E '\.tgz$' | tail -1)
 
-          # Create the release with the tarball attached, using CHANGELOG.md as release notes
-          gh release create "v${VERSION}" \
-            --title "v${VERSION}" \
-            --notes-file CHANGELOG.md \
-            "$TARBALL"
+          # Validate tarball was created
+          if [ -z "$TARBALL" ] || [ ! -f "$TARBALL" ]; then
+            echo "Error: Failed to create tarball"
+            exit 1
+          fi
+          echo "Created tarball: $TARBALL"
+
+          # Store tarball size for Slack notification
+          TARBALL_SIZE=$(du -h "$TARBALL" | cut -f1)
+          echo "TARBALL_SIZE=$TARBALL_SIZE" >> $GITHUB_ENV
+          echo "TARBALL_NAME=$TARBALL" >> $GITHUB_ENV
+
+          # Check if release already exists (idempotent - for workflow re-runs)
+          if gh release view "v${VERSION}" > /dev/null 2>&1; then
+            echo "Release v${VERSION} already exists, updating..."
+            gh release upload "v${VERSION}" "$TARBALL" --clobber
+            gh release edit "v${VERSION}" --notes-file CHANGELOG.md
+          else
+            echo "Creating new release v${VERSION}..."
+            gh release create "v${VERSION}" \
+              --title "v${VERSION}" \
+              --notes-file CHANGELOG.md \
+              "$TARBALL"
+          fi
+
+          # Clean up tarball
+          rm -f "$TARBALL"
 
       - name: Notify Slack on success
         if: success() && !inputs.dry_run
@@ -151,11 +175,8 @@ jobs:
             NPM_URL="https://www.npmjs.com/package/${PACKAGE_NAME}"
             GITHUB_RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/v${VERSION}"
             RELEASE_TIME=$(date '+%Y-%m-%d %H:%M:%S %Z')
-            # Get package size from the tarball
-            PACKAGE_SIZE=$(npm pack --dry-run 2>&1 | grep -E 'package size' | sed 's/.*package size: *//' | cut -d' ' -f1-2)
-            if [ -z "$PACKAGE_SIZE" ]; then
-              PACKAGE_SIZE="unknown"
-            fi
+            # Use package size from GitHub Release step (stored in GITHUB_ENV)
+            PACKAGE_SIZE="${TARBALL_SIZE:-unknown}"
             curl -X POST -H 'Content-type: application/json' \
               --data "{
                 \"blocks\": [

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -39,6 +39,76 @@ jobs:
       - name: Run tests
         run: npm test
 
+      - name: Generate CHANGELOG.md from commits
+        env:
+          TZ: America/Chicago
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          NPM_URL="https://www.npmjs.com/package/${PACKAGE_NAME}"
+          RELEASE_TIME=$(date '+%Y-%m-%d %H:%M:%S %Z')
+
+          # Get commits since last tag for changelog
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -n "$LAST_TAG" ]; then
+            COMMIT_RANGE="${LAST_TAG}..HEAD"
+            COMPARE_URL="https://github.com/${{ github.repository }}/compare/${LAST_TAG}...v${VERSION}"
+          else
+            COMMIT_RANGE="HEAD"
+            COMPARE_URL="https://github.com/${{ github.repository }}/commits/v${VERSION}"
+          fi
+
+          # Generate changelog from commits, excluding merge commits and sync commits
+          CHANGELOG=$(git log $COMMIT_RANGE --pretty=format:"- %s" --no-merges | grep -v "chore: Sync develop" | grep -v "^\s*$" || echo "- Initial release")
+
+          # Categorize commits
+          FEATURES=$(echo "$CHANGELOG" | grep -iE "^- (feat|add|new)" || true)
+          FIXES=$(echo "$CHANGELOG" | grep -iE "^- (fix|bug|patch)" || true)
+          OTHER=$(echo "$CHANGELOG" | grep -viE "^- (feat|add|new|fix|bug|patch)" || true)
+
+          # Generate CHANGELOG.md
+          cat > CHANGELOG.md << 'HEADER'
+          # Changelog
+
+          All notable changes to this project will be documented in this file.
+
+          HEADER
+
+          echo "## [${VERSION}] - $(date '+%Y-%m-%d')" >> CHANGELOG.md
+          echo "" >> CHANGELOG.md
+
+          # Add categorized changes
+          if [ -n "$FEATURES" ]; then
+            echo "### ✨ Features" >> CHANGELOG.md
+            echo "$FEATURES" >> CHANGELOG.md
+            echo "" >> CHANGELOG.md
+          fi
+
+          if [ -n "$FIXES" ]; then
+            echo "### 🐛 Bug Fixes" >> CHANGELOG.md
+            echo "$FIXES" >> CHANGELOG.md
+            echo "" >> CHANGELOG.md
+          fi
+
+          if [ -n "$OTHER" ]; then
+            echo "### 📝 Other Changes" >> CHANGELOG.md
+            echo "$OTHER" >> CHANGELOG.md
+            echo "" >> CHANGELOG.md
+          fi
+
+          # Add links section
+          cat >> CHANGELOG.md << LINKS
+          ### Links
+          - [npm package](${NPM_URL})
+          - [Full Changelog](${COMPARE_URL})
+
+          ---
+          *Released: ${RELEASE_TIME}*
+          LINKS
+
+          echo "Generated CHANGELOG.md:"
+          cat CHANGELOG.md
+
       - name: Build and verify package
         run: npm run verify-package
 
@@ -57,47 +127,17 @@ jobs:
         if: success() && !inputs.dry_run
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TZ: America/Chicago
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          PACKAGE_NAME=$(node -p "require('./package.json').name")
-          NPM_URL="https://www.npmjs.com/package/${PACKAGE_NAME}"
-          RELEASE_TIME=$(date '+%Y-%m-%d %H:%M:%S %Z')
 
-          # Create the tarball for the release
+          # Create the tarball for the release (CHANGELOG.md is already included)
           TARBALL=$(npm pack 2>&1 | grep -E '\.tgz$' | tail -1)
-          PACKAGE_SIZE=$(du -h "$TARBALL" | cut -f1)
 
-          # Generate release notes
-          cat > release-notes.md << EOF
-          ## 📦 ${PACKAGE_NAME} v${VERSION}
-
-          ### Installation
-          \`\`\`bash
-          npm install ${PACKAGE_NAME}@${VERSION}
-          \`\`\`
-
-          ### Package Details
-          | | |
-          |---|---|
-          | **npm** | [${PACKAGE_NAME}](${NPM_URL}) |
-          | **Version** | ${VERSION} |
-          | **Size** | ${PACKAGE_SIZE} |
-          | **Released** | ${RELEASE_TIME} |
-
-          ### Links
-          - [npm package](${NPM_URL})
-          - [Documentation](https://github.com/${{ github.repository }}#readme)
-          - [Changelog](https://github.com/${{ github.repository }}/commits/production)
-          EOF
-
-          # Create the release with the tarball attached
+          # Create the release with the tarball attached, using CHANGELOG.md as release notes
           gh release create "v${VERSION}" \
             --title "v${VERSION}" \
-            --notes-file release-notes.md \
+            --notes-file CHANGELOG.md \
             "$TARBALL"
-
-          rm -f release-notes.md
 
       - name: Notify Slack on success
         if: success() && !inputs.dry_run

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,7 +20,7 @@ jobs:
     if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write  # Required for creating GitHub releases
 
     steps:
       - name: Checkout repository
@@ -53,6 +53,52 @@ jobs:
         if: ${{ inputs.dry_run }}
         run: echo "Dry run mode - skipping npm publish"
 
+      - name: Create GitHub Release
+        if: success() && !inputs.dry_run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TZ: America/Chicago
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          NPM_URL="https://www.npmjs.com/package/${PACKAGE_NAME}"
+          RELEASE_TIME=$(date '+%Y-%m-%d %H:%M:%S %Z')
+
+          # Create the tarball for the release
+          TARBALL=$(npm pack 2>&1 | grep -E '\.tgz$' | tail -1)
+          PACKAGE_SIZE=$(du -h "$TARBALL" | cut -f1)
+
+          # Generate release notes
+          cat > release-notes.md << EOF
+          ## 📦 ${PACKAGE_NAME} v${VERSION}
+
+          ### Installation
+          \`\`\`bash
+          npm install ${PACKAGE_NAME}@${VERSION}
+          \`\`\`
+
+          ### Package Details
+          | | |
+          |---|---|
+          | **npm** | [${PACKAGE_NAME}](${NPM_URL}) |
+          | **Version** | ${VERSION} |
+          | **Size** | ${PACKAGE_SIZE} |
+          | **Released** | ${RELEASE_TIME} |
+
+          ### Links
+          - [npm package](${NPM_URL})
+          - [Documentation](https://github.com/${{ github.repository }}#readme)
+          - [Changelog](https://github.com/${{ github.repository }}/commits/production)
+          EOF
+
+          # Create the release with the tarball attached
+          gh release create "v${VERSION}" \
+            --title "v${VERSION}" \
+            --notes-file release-notes.md \
+            "$TARBALL"
+
+          rm -f release-notes.md
+
       - name: Notify Slack on success
         if: success() && !inputs.dry_run
         env:
@@ -63,11 +109,12 @@ jobs:
             VERSION=$(node -p "require('./package.json').version")
             PACKAGE_NAME=$(node -p "require('./package.json').name")
             NPM_URL="https://www.npmjs.com/package/${PACKAGE_NAME}"
+            GITHUB_RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/v${VERSION}"
             RELEASE_TIME=$(date '+%Y-%m-%d %H:%M:%S %Z')
             # Get package size from the tarball
-            TARBALL=$(npm pack --dry-run 2>&1 | grep -E 'package size' | sed 's/.*package size: *//' | cut -d' ' -f1-2)
-            if [ -z "$TARBALL" ]; then
-              TARBALL="unknown"
+            PACKAGE_SIZE=$(npm pack --dry-run 2>&1 | grep -E 'package size' | sed 's/.*package size: *//' | cut -d' ' -f1-2)
+            if [ -z "$PACKAGE_SIZE" ]; then
+              PACKAGE_SIZE="unknown"
             fi
             curl -X POST -H 'Content-type: application/json' \
               --data "{
@@ -76,15 +123,15 @@ jobs:
                     \"type\": \"section\",
                     \"text\": {
                       \"type\": \"mrkdwn\",
-                      \"text\": \":package: *${PACKAGE_NAME} v${VERSION}* published to npm\"
+                      \"text\": \":package: *${PACKAGE_NAME} v${VERSION}* published\"
                     }
                   },
                   {
                     \"type\": \"section\",
                     \"fields\": [
-                      {\"type\": \"mrkdwn\", \"text\": \"*Package:*\n<${NPM_URL}|${PACKAGE_NAME}>\"},
-                      {\"type\": \"mrkdwn\", \"text\": \"*Version:*\n${VERSION}\"},
-                      {\"type\": \"mrkdwn\", \"text\": \"*Size:*\n${TARBALL}\"},
+                      {\"type\": \"mrkdwn\", \"text\": \"*npm:*\n<${NPM_URL}|${PACKAGE_NAME}>\"},
+                      {\"type\": \"mrkdwn\", \"text\": \"*GitHub:*\n<${GITHUB_RELEASE_URL}|v${VERSION}>\"},
+                      {\"type\": \"mrkdwn\", \"text\": \"*Size:*\n${PACKAGE_SIZE}\"},
                       {\"type\": \"mrkdwn\", \"text\": \"*Released:*\n${RELEASE_TIME}\"}
                     ]
                   }

--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,6 @@ test-results/
 examples/**/node_modules
 examples/**/.env
 !examples/**/.env.example
+
+# Generated during publish
+CHANGELOG.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,8 +287,10 @@ Located in `.github/workflows/`.
 ### npm Publish (`npm-publish.yml`)
 - Triggers when PR is merged to production, or manually
 - Runs tests and package verification before publish
+- Publishes to npm registry
+- Creates GitHub Release with tarball attached
 - Supports dry-run mode for testing
-- Sends Slack notifications on success/failure
+- Sends Slack notifications with links to npm and GitHub Release
 
 ### Future Workflows (to be added)
 Reference `../een-oauth-proxy/.github/workflows/` for examples:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,9 +288,9 @@ Located in `.github/workflows/`.
 - Triggers when PR is merged to production, or manually
 - Runs tests and package verification before publish
 - Publishes to npm registry
-- Creates GitHub Release with tarball attached
+- Creates GitHub Release with tarball and auto-generated CHANGELOG
+- Sends Slack notifications on success (with links to npm and GitHub Release) or on failure
 - Supports dry-run mode for testing
-- Sends Slack notifications with links to npm and GitHub Release
 
 ### Future Workflows (to be added)
 Reference `../een-oauth-proxy/.github/workflows/` for examples:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # een-api-toolkit
 
-A TypeScript library implementing the Eagle Eye Networks (EEN) Video platform API v3.0 for Vue 3 Composition API applications.
+A TypeScript library implementing the [Eagle Eye Networks (EEN)](https://een.com/) Video platform API v3.0 for Vue 3 Composition API applications. See also the [EEN Developer Portal](https://developer.eagleeyenetworks.com). 
 
 This repository is provided as-is without any warranty, functionality guarantee, or assurance of availability. This repository uses EEN services, but it is not associated with EEN.
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Add GitHub Release creation alongside npm publish
- Enhance Slack notifications with more details and links

## Changes

### GitHub Release (`npm-publish.yml`)
- Creates GitHub Release with version tag (e.g., `v0.0.6`)
- Attaches npm tarball to the release
- Generates release notes with:
  - Installation command
  - Package details (npm link, version, size, release time in CST)
  - Links to npm, documentation, and changelog

### Enhanced Slack Notification
- Clickable link to npm package
- Clickable link to GitHub Release
- Package size
- Release timestamp in America/Chicago timezone

### Documentation
- Updated CLAUDE.md to document GitHub Release functionality

## Test plan
- [ ] Merge PR and verify GitHub Release is created
- [ ] Verify Slack notification includes all new fields
- [ ] Verify release notes are properly formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)