### PR TITLE
Release v0.0.11: Authenticated e2e tests and versioning improvements

### DIFF
--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -47,12 +47,14 @@ jobs:
         run: npm exec playwright install -- --with-deps chromium
         working-directory: examples/vue-basic
 
-      # Note: These e2e tests only cover unauthenticated flows (login page, redirects, etc.)
-      # and do not require the OAuth proxy server. Authenticated flow tests would need
-      # the proxy running or mocked credentials.
       - name: Run example e2e tests
         run: npm run test:e2e
         working-directory: examples/vue-basic
+        env:
+          VITE_PROXY_URL: ${{ secrets.VITE_PROXY_URL }}
+          VITE_EEN_CLIENT_ID: ${{ secrets.VITE_EEN_CLIENT_ID }}
+          TEST_USER: ${{ secrets.TEST_USER }}
+          TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
 
       - name: Upload Playwright report on failure
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,4 @@ examples/**/.env
 
 # Generated during publish
 CHANGELOG.md
+examples/vue-basic/e2e/.auth-state.json

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,8 +2,8 @@
 
 # Pre-commit hook to increment version when source files change
 
-# Check if src or e2e folder has staged changes
-if git diff --cached --name-only | grep -qE "^(src|e2e)/"; then
+# Check if src, e2e, examples, or workflows folder has staged changes
+if git diff --cached --name-only | grep -qE "^(src|e2e|examples|\.github/workflows)/"; then
     echo "Incrementing version in package.json..."
 
     # Increment patch version

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-# Pre-commit hook to increment version when source files change
+# Pre-commit hook to increment versions when source files change
 
-# Check if src, e2e, examples, or workflows folder has staged changes
-if git diff --cached --name-only | grep -qE "^(src|e2e|examples|\.github/workflows)/"; then
-    echo "Incrementing version in package.json..."
+# Check if main package files have staged changes (src, e2e, workflows)
+if git diff --cached --name-only | grep -qE "^(src|e2e|\.github/workflows)/"; then
+    echo "Incrementing main package version..."
 
     # Increment patch version
     npm version patch --no-git-tag-version || exit 1
@@ -15,7 +15,23 @@ if git diff --cached --name-only | grep -qE "^(src|e2e|examples|\.github/workflo
         git add package-lock.json
     fi
 
-    echo "Version incremented successfully"
+    echo "Main package version incremented successfully"
+fi
+
+# Check if example files have staged changes (independently versioned)
+if git diff --cached --name-only | grep -qE "^examples/vue-basic/"; then
+    echo "Incrementing example version..."
+
+    # Increment example patch version
+    (cd examples/vue-basic && npm version patch --no-git-tag-version) || exit 1
+
+    # Stage the updated example package files
+    git add examples/vue-basic/package.json
+    if [ -f "examples/vue-basic/package-lock.json" ]; then
+        git add examples/vue-basic/package-lock.json
+    fi
+
+    echo "Example version incremented successfully"
 fi
 
 exit 0

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,8 +2,9 @@
 
 # Pre-commit hook to increment versions when source files change
 
-# Check if main package files have staged changes (src, e2e, workflows)
-if git diff --cached --name-only | grep -qE "^(src|e2e|\.github/workflows)/"; then
+# Check if main package files have staged changes (src, e2e only)
+# Note: .github/workflows changes don't affect the published npm package
+if git diff --cached --name-only | grep -qE "^(src|e2e)/"; then
     echo "Incrementing main package version..."
 
     # Increment patch version

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,8 +2,9 @@
 
 # Pre-commit hook to increment versions when source files change
 
-# Check if main package files have staged changes (src, e2e only)
+# Check if main package files have staged changes (root src/ and e2e/ only)
 # Note: .github/workflows changes don't affect the published npm package
+# Note: examples/vue-basic/e2e/ does NOT match ^e2e/ - patterns are mutually exclusive
 if git diff --cached --name-only | grep -qE "^(src|e2e)/"; then
     echo "Incrementing main package version..."
 

--- a/examples/vue-basic/e2e/auth.spec.ts
+++ b/examples/vue-basic/e2e/auth.spec.ts
@@ -72,48 +72,17 @@ test.describe('Vue Basic Example - Authenticated', () => {
     }
   })
 
-  test.afterAll(async ({ browser }) => {
-    // Clean up any auth state by closing browser context
-    const contexts = browser.contexts()
-    for (const context of contexts) {
-      await context.clearCookies()
-      await context.clearPermissions()
-    }
-  })
+  // Note: Playwright automatically handles context cleanup between tests,
+  // so no afterAll hook is needed for auth state cleanup
 
   test('complete OAuth login flow shows authenticated state', async ({ page }) => {
     // Verify initially not authenticated
     await page.goto('/')
     await expect(page.locator('[data-testid="not-authenticated"]')).toBeVisible()
+    await expect(page.locator('[data-testid="nav-login"]')).toBeVisible()
 
-    // Navigate to login page first
-    await page.click('[data-testid="nav-login"]')
-    await page.waitForURL('/login')
-
-    // Click login button and wait for OAuth redirect
-    await Promise.all([
-      page.waitForURL(/.*eagleeyenetworks.com.*/, { timeout: TIMEOUTS.OAUTH_REDIRECT }),
-      page.click('[data-testid="login-button"]')
-    ])
-
-    // Fill email
-    const emailInput = page.locator('#authentication--input__email')
-    await emailInput.waitFor({ state: 'visible', timeout: TIMEOUTS.ELEMENT_VISIBLE })
-    await emailInput.fill(TEST_USER!)
-
-    // Click next
-    await page.getByRole('button', { name: 'Next' }).click()
-
-    // Fill password
-    const passwordInput = page.locator('#authentication--input__password')
-    await passwordInput.waitFor({ state: 'visible', timeout: TIMEOUTS.PASSWORD_VISIBLE })
-    await passwordInput.fill(TEST_PASSWORD!)
-
-    // Click sign in - use OR selector for robustness
-    await page.locator('#next, button:has-text("Sign in")').first().click()
-
-    // Wait for redirect back to app
-    await page.waitForURL('**/', { timeout: TIMEOUTS.AUTH_COMPLETE })
+    // Perform login using helper
+    await performLogin(page, TEST_USER!, TEST_PASSWORD!)
 
     // Verify authenticated state - should see user info
     await expect(page.locator('[data-testid="not-authenticated"]')).not.toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
@@ -134,10 +103,9 @@ test.describe('Vue Basic Example - Authenticated', () => {
     await page.click('[data-testid="nav-users"]')
     await page.waitForURL('/users')
 
-    // Should see users list or loading state
-    await expect(
-      page.locator('.users-list, .loading, .error').first()
-    ).toBeVisible({ timeout: TIMEOUTS.ELEMENT_VISIBLE })
+    // Should see users list (not error state)
+    await expect(page.locator('.users-list')).toBeVisible({ timeout: TIMEOUTS.ELEMENT_VISIBLE })
+    await expect(page.locator('.error')).not.toBeVisible()
   })
 
   test('authenticated user can logout', async ({ page }) => {
@@ -172,14 +140,64 @@ test.describe('Vue Basic Example - Negative Auth Tests', () => {
     ).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
   })
 
-  test('OAuth page handles missing credentials gracefully', async ({ page }) => {
-    // This test verifies the app doesn't crash when OAuth flow is cancelled
+  test('login button initiates OAuth redirect', async ({ page }) => {
+    // Verify login button works and redirects to OAuth provider
     await page.goto('/')
     await expect(page.locator('[data-testid="login-button"]')).toBeVisible()
+    await expect(page.locator('[data-testid="login-button"]')).toBeEnabled()
 
-    // Clicking login should redirect to OAuth page
-    // We just verify the button exists and is clickable (don't complete OAuth)
-    const loginButton = page.locator('[data-testid="login-button"]')
-    await expect(loginButton).toBeEnabled()
+    // Click login and verify redirect to OAuth page
+    await Promise.all([
+      page.waitForURL(/.*eagleeyenetworks.com.*/, { timeout: TIMEOUTS.OAUTH_REDIRECT }),
+      page.click('[data-testid="login-button"]')
+    ])
+
+    // Verify we're on the OAuth page by checking for email input
+    const emailInput = page.locator('#authentication--input__email')
+    await expect(emailInput).toBeVisible({ timeout: TIMEOUTS.ELEMENT_VISIBLE })
+  })
+})
+
+test.describe('Vue Basic Example - Failed Login', () => {
+  const TEST_USER = process.env.TEST_USER
+
+  test.beforeEach(async () => {
+    // Skip if no test user (we need a valid email format)
+    if (!TEST_USER) {
+      test.skip()
+    }
+  })
+
+  test('invalid password shows error on OAuth page', async ({ page }) => {
+    await page.goto('/')
+
+    // Click login and wait for OAuth redirect
+    await Promise.all([
+      page.waitForURL(/.*eagleeyenetworks.com.*/, { timeout: TIMEOUTS.OAUTH_REDIRECT }),
+      page.click('[data-testid="login-button"]')
+    ])
+
+    // Fill valid email
+    const emailInput = page.locator('#authentication--input__email')
+    await emailInput.waitFor({ state: 'visible', timeout: TIMEOUTS.ELEMENT_VISIBLE })
+    await emailInput.fill(TEST_USER!)
+    await page.getByRole('button', { name: 'Next' }).click()
+
+    // Fill invalid password
+    const passwordInput = page.locator('#authentication--input__password')
+    await passwordInput.waitFor({ state: 'visible', timeout: TIMEOUTS.PASSWORD_VISIBLE })
+    await passwordInput.fill('invalid-password-12345!')
+
+    // Click sign in
+    await page.locator('#next, button:has-text("Sign in")').first().click()
+
+    // Should show error message on OAuth page (not redirect to app)
+    // The OAuth page should display an error for invalid credentials
+    await expect(
+      page.locator('.error, [class*="error"], [data-testid*="error"], #error, .alert-danger').first()
+    ).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+
+    // Should still be on OAuth page, not redirected to app
+    await expect(page).not.toHaveURL(/127\.0\.0\.1/)
   })
 })

--- a/examples/vue-basic/e2e/auth.spec.ts
+++ b/examples/vue-basic/e2e/auth.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, Page } from '@playwright/test'
 
 /**
  * Authenticated E2E tests for the Vue Basic Example
@@ -15,6 +15,52 @@ import { test, expect } from '@playwright/test'
  * - TEST_USER: Test user email
  * - TEST_PASSWORD: Test user password
  */
+
+// Timeout constants for consistent behavior
+const TIMEOUTS = {
+  OAUTH_REDIRECT: 30000,
+  ELEMENT_VISIBLE: 15000,
+  PASSWORD_VISIBLE: 10000,
+  AUTH_COMPLETE: 30000,
+  UI_UPDATE: 10000
+} as const
+
+/**
+ * Performs OAuth login flow through the UI
+ * @param page - Playwright page object
+ * @param username - Test user email
+ * @param password - Test user password
+ */
+async function performLogin(page: Page, username: string, password: string): Promise<void> {
+  // Start at home page
+  await page.goto('/')
+
+  // Click login button and wait for OAuth redirect
+  await Promise.all([
+    page.waitForURL(/.*eagleeyenetworks.com.*/, { timeout: TIMEOUTS.OAUTH_REDIRECT }),
+    page.click('[data-testid="login-button"]')
+  ])
+
+  // Fill email
+  const emailInput = page.locator('#authentication--input__email')
+  await emailInput.waitFor({ state: 'visible', timeout: TIMEOUTS.ELEMENT_VISIBLE })
+  await emailInput.fill(username)
+
+  // Click next
+  await page.getByRole('button', { name: 'Next' }).click()
+
+  // Fill password
+  const passwordInput = page.locator('#authentication--input__password')
+  await passwordInput.waitFor({ state: 'visible', timeout: TIMEOUTS.PASSWORD_VISIBLE })
+  await passwordInput.fill(password)
+
+  // Click sign in - use OR selector for robustness
+  await page.locator('#next, button:has-text("Sign in")').first().click()
+
+  // Wait for auth to complete and redirect to app
+  await page.waitForURL('**/', { timeout: TIMEOUTS.AUTH_COMPLETE })
+}
+
 test.describe('Vue Basic Example - Authenticated', () => {
   const TEST_USER = process.env.TEST_USER
   const TEST_PASSWORD = process.env.TEST_PASSWORD
@@ -26,27 +72,33 @@ test.describe('Vue Basic Example - Authenticated', () => {
     }
   })
 
-  test('complete OAuth login flow shows authenticated state', async ({ page }) => {
-    // Start at home page
-    await page.goto('/')
+  test.afterAll(async ({ browser }) => {
+    // Clean up any auth state by closing browser context
+    const contexts = browser.contexts()
+    for (const context of contexts) {
+      await context.clearCookies()
+      await context.clearPermissions()
+    }
+  })
 
+  test('complete OAuth login flow shows authenticated state', async ({ page }) => {
     // Verify initially not authenticated
+    await page.goto('/')
     await expect(page.locator('[data-testid="not-authenticated"]')).toBeVisible()
 
     // Navigate to login page first
     await page.click('[data-testid="nav-login"]')
     await page.waitForURL('/login')
 
-    // Click login button to start OAuth flow
-    // Use Promise.all to handle navigation
+    // Click login button and wait for OAuth redirect
     await Promise.all([
-      page.waitForURL(/.*eagleeyenetworks.com.*/, { timeout: 30000 }),
+      page.waitForURL(/.*eagleeyenetworks.com.*/, { timeout: TIMEOUTS.OAUTH_REDIRECT }),
       page.click('[data-testid="login-button"]')
     ])
 
     // Fill email
     const emailInput = page.locator('#authentication--input__email')
-    await emailInput.waitFor({ state: 'visible', timeout: 15000 })
+    await emailInput.waitFor({ state: 'visible', timeout: TIMEOUTS.ELEMENT_VISIBLE })
     await emailInput.fill(TEST_USER!)
 
     // Click next
@@ -54,25 +106,17 @@ test.describe('Vue Basic Example - Authenticated', () => {
 
     // Fill password
     const passwordInput = page.locator('#authentication--input__password')
-    await passwordInput.waitFor({ state: 'visible', timeout: 10000 })
+    await passwordInput.waitFor({ state: 'visible', timeout: TIMEOUTS.PASSWORD_VISIBLE })
     await passwordInput.fill(TEST_PASSWORD!)
 
-    // Click sign in
-    try {
-      await page.locator('#next').click()
-    } catch {
-      await page.getByRole('button', { name: 'Sign in' }).click()
-    }
+    // Click sign in - use OR selector for robustness
+    await page.locator('#next, button:has-text("Sign in")').first().click()
 
-    // Wait for redirect back to app (callback will be handled by the app)
-    await page.waitForURL(/127\.0\.0\.1:3333/, { timeout: 30000 })
-
-    // Wait for authentication to complete (callback processing)
-    // The app should redirect to home page after successful auth
-    await page.waitForURL('http://127.0.0.1:3333/', { timeout: 15000 })
+    // Wait for redirect back to app
+    await page.waitForURL('**/', { timeout: TIMEOUTS.AUTH_COMPLETE })
 
     // Verify authenticated state - should see user info
-    await expect(page.locator('[data-testid="not-authenticated"]')).not.toBeVisible({ timeout: 10000 })
+    await expect(page.locator('[data-testid="not-authenticated"]')).not.toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
 
     // Should see navigation links for authenticated users
     await expect(page.locator('[data-testid="nav-users"]')).toBeVisible()
@@ -83,78 +127,59 @@ test.describe('Vue Basic Example - Authenticated', () => {
   })
 
   test('authenticated user can view users list', async ({ page }) => {
-    // Start at home page
-    await page.goto('/')
-
-    // Click login button
-    await page.click('[data-testid="login-button"]')
-
-    // Complete OAuth flow
-    await page.waitForURL(/.*eagleeyenetworks.com.*/, { timeout: 15000 })
-
-    const emailInput = page.locator('#authentication--input__email')
-    await emailInput.waitFor({ state: 'visible', timeout: 15000 })
-    await emailInput.fill(TEST_USER!)
-    await page.getByRole('button', { name: 'Next' }).click()
-
-    const passwordInput = page.locator('#authentication--input__password')
-    await passwordInput.waitFor({ state: 'visible', timeout: 10000 })
-    await passwordInput.fill(TEST_PASSWORD!)
-
-    try {
-      await page.locator('#next').click()
-    } catch {
-      await page.getByRole('button', { name: 'Sign in' }).click()
-    }
-
-    // Wait for auth to complete
-    await page.waitForURL('http://127.0.0.1:3333/', { timeout: 30000 })
-    await expect(page.locator('[data-testid="nav-users"]')).toBeVisible({ timeout: 10000 })
+    await performLogin(page, TEST_USER!, TEST_PASSWORD!)
+    await expect(page.locator('[data-testid="nav-users"]')).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
 
     // Navigate to users page
     await page.click('[data-testid="nav-users"]')
     await page.waitForURL('/users')
 
     // Should see users list or loading state
-    // Wait for either users to load or an error message
     await expect(
       page.locator('.users-list, .loading, .error').first()
-    ).toBeVisible({ timeout: 15000 })
+    ).toBeVisible({ timeout: TIMEOUTS.ELEMENT_VISIBLE })
   })
 
   test('authenticated user can logout', async ({ page }) => {
-    // Start at home page and login
-    await page.goto('/')
-    await page.click('[data-testid="login-button"]')
-
-    // Complete OAuth flow
-    await page.waitForURL(/.*eagleeyenetworks.com.*/, { timeout: 15000 })
-
-    const emailInput = page.locator('#authentication--input__email')
-    await emailInput.waitFor({ state: 'visible', timeout: 15000 })
-    await emailInput.fill(TEST_USER!)
-    await page.getByRole('button', { name: 'Next' }).click()
-
-    const passwordInput = page.locator('#authentication--input__password')
-    await passwordInput.waitFor({ state: 'visible', timeout: 10000 })
-    await passwordInput.fill(TEST_PASSWORD!)
-
-    try {
-      await page.locator('#next').click()
-    } catch {
-      await page.getByRole('button', { name: 'Sign in' }).click()
-    }
-
-    // Wait for auth to complete
-    await page.waitForURL('http://127.0.0.1:3333/', { timeout: 30000 })
-    await expect(page.locator('[data-testid="nav-logout"]')).toBeVisible({ timeout: 10000 })
+    await performLogin(page, TEST_USER!, TEST_PASSWORD!)
+    await expect(page.locator('[data-testid="nav-logout"]')).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
 
     // Click logout
     await page.click('[data-testid="nav-logout"]')
 
     // Should redirect back to home and show not authenticated
-    await page.waitForURL('http://127.0.0.1:3333/')
-    await expect(page.locator('[data-testid="not-authenticated"]')).toBeVisible({ timeout: 10000 })
+    await page.waitForURL('**/')
+    await expect(page.locator('[data-testid="not-authenticated"]')).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
     await expect(page.locator('[data-testid="nav-login"]')).toBeVisible()
+  })
+})
+
+test.describe('Vue Basic Example - Negative Auth Tests', () => {
+  test('login button shows when not authenticated', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.locator('[data-testid="not-authenticated"]')).toBeVisible()
+    await expect(page.locator('[data-testid="nav-login"]')).toBeVisible()
+    await expect(page.locator('[data-testid="nav-logout"]')).not.toBeVisible()
+  })
+
+  test('users page redirects or shows error when not authenticated', async ({ page }) => {
+    // Try to access users page directly without auth
+    await page.goto('/users')
+
+    // Should either redirect to login or show an error/not-authenticated message
+    await expect(
+      page.locator('[data-testid="not-authenticated"], [data-testid="nav-login"], .error, .auth-required').first()
+    ).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+  })
+
+  test('OAuth page handles missing credentials gracefully', async ({ page }) => {
+    // This test verifies the app doesn't crash when OAuth flow is cancelled
+    await page.goto('/')
+    await expect(page.locator('[data-testid="login-button"]')).toBeVisible()
+
+    // Clicking login should redirect to OAuth page
+    // We just verify the button exists and is clickable (don't complete OAuth)
+    const loginButton = page.locator('[data-testid="login-button"]')
+    await expect(loginButton).toBeEnabled()
   })
 })

--- a/examples/vue-basic/e2e/auth.spec.ts
+++ b/examples/vue-basic/e2e/auth.spec.ts
@@ -1,0 +1,160 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Authenticated E2E tests for the Vue Basic Example
+ *
+ * These tests perform the actual OAuth login flow through the UI:
+ * 1. Click login button in the example app
+ * 2. Enter credentials on EEN OAuth page
+ * 3. Complete the OAuth callback
+ * 4. Verify authenticated state
+ *
+ * Required environment variables:
+ * - VITE_PROXY_URL: OAuth proxy URL
+ * - VITE_EEN_CLIENT_ID: EEN OAuth client ID
+ * - TEST_USER: Test user email
+ * - TEST_PASSWORD: Test user password
+ */
+test.describe('Vue Basic Example - Authenticated', () => {
+  const TEST_USER = process.env.TEST_USER
+  const TEST_PASSWORD = process.env.TEST_PASSWORD
+
+  test.beforeEach(async () => {
+    // Skip all tests if credentials are not available
+    if (!TEST_USER || !TEST_PASSWORD) {
+      test.skip()
+    }
+  })
+
+  test('complete OAuth login flow shows authenticated state', async ({ page }) => {
+    // Start at home page
+    await page.goto('/')
+
+    // Verify initially not authenticated
+    await expect(page.locator('[data-testid="not-authenticated"]')).toBeVisible()
+
+    // Navigate to login page first
+    await page.click('[data-testid="nav-login"]')
+    await page.waitForURL('/login')
+
+    // Click login button to start OAuth flow
+    // Use Promise.all to handle navigation
+    await Promise.all([
+      page.waitForURL(/.*eagleeyenetworks.com.*/, { timeout: 30000 }),
+      page.click('[data-testid="login-button"]')
+    ])
+
+    // Fill email
+    const emailInput = page.locator('#authentication--input__email')
+    await emailInput.waitFor({ state: 'visible', timeout: 15000 })
+    await emailInput.fill(TEST_USER!)
+
+    // Click next
+    await page.getByRole('button', { name: 'Next' }).click()
+
+    // Fill password
+    const passwordInput = page.locator('#authentication--input__password')
+    await passwordInput.waitFor({ state: 'visible', timeout: 10000 })
+    await passwordInput.fill(TEST_PASSWORD!)
+
+    // Click sign in
+    try {
+      await page.locator('#next').click()
+    } catch {
+      await page.getByRole('button', { name: 'Sign in' }).click()
+    }
+
+    // Wait for redirect back to app (callback will be handled by the app)
+    await page.waitForURL(/127\.0\.0\.1:3333/, { timeout: 30000 })
+
+    // Wait for authentication to complete (callback processing)
+    // The app should redirect to home page after successful auth
+    await page.waitForURL('http://127.0.0.1:3333/', { timeout: 15000 })
+
+    // Verify authenticated state - should see user info
+    await expect(page.locator('[data-testid="not-authenticated"]')).not.toBeVisible({ timeout: 10000 })
+
+    // Should see navigation links for authenticated users
+    await expect(page.locator('[data-testid="nav-users"]')).toBeVisible()
+    await expect(page.locator('[data-testid="nav-logout"]')).toBeVisible()
+
+    // Login link should not be visible
+    await expect(page.locator('[data-testid="nav-login"]')).not.toBeVisible()
+  })
+
+  test('authenticated user can view users list', async ({ page }) => {
+    // Start at home page
+    await page.goto('/')
+
+    // Click login button
+    await page.click('[data-testid="login-button"]')
+
+    // Complete OAuth flow
+    await page.waitForURL(/.*eagleeyenetworks.com.*/, { timeout: 15000 })
+
+    const emailInput = page.locator('#authentication--input__email')
+    await emailInput.waitFor({ state: 'visible', timeout: 15000 })
+    await emailInput.fill(TEST_USER!)
+    await page.getByRole('button', { name: 'Next' }).click()
+
+    const passwordInput = page.locator('#authentication--input__password')
+    await passwordInput.waitFor({ state: 'visible', timeout: 10000 })
+    await passwordInput.fill(TEST_PASSWORD!)
+
+    try {
+      await page.locator('#next').click()
+    } catch {
+      await page.getByRole('button', { name: 'Sign in' }).click()
+    }
+
+    // Wait for auth to complete
+    await page.waitForURL('http://127.0.0.1:3333/', { timeout: 30000 })
+    await expect(page.locator('[data-testid="nav-users"]')).toBeVisible({ timeout: 10000 })
+
+    // Navigate to users page
+    await page.click('[data-testid="nav-users"]')
+    await page.waitForURL('/users')
+
+    // Should see users list or loading state
+    // Wait for either users to load or an error message
+    await expect(
+      page.locator('.users-list, .loading, .error').first()
+    ).toBeVisible({ timeout: 15000 })
+  })
+
+  test('authenticated user can logout', async ({ page }) => {
+    // Start at home page and login
+    await page.goto('/')
+    await page.click('[data-testid="login-button"]')
+
+    // Complete OAuth flow
+    await page.waitForURL(/.*eagleeyenetworks.com.*/, { timeout: 15000 })
+
+    const emailInput = page.locator('#authentication--input__email')
+    await emailInput.waitFor({ state: 'visible', timeout: 15000 })
+    await emailInput.fill(TEST_USER!)
+    await page.getByRole('button', { name: 'Next' }).click()
+
+    const passwordInput = page.locator('#authentication--input__password')
+    await passwordInput.waitFor({ state: 'visible', timeout: 10000 })
+    await passwordInput.fill(TEST_PASSWORD!)
+
+    try {
+      await page.locator('#next').click()
+    } catch {
+      await page.getByRole('button', { name: 'Sign in' }).click()
+    }
+
+    // Wait for auth to complete
+    await page.waitForURL('http://127.0.0.1:3333/', { timeout: 30000 })
+    await expect(page.locator('[data-testid="nav-logout"]')).toBeVisible({ timeout: 10000 })
+
+    // Click logout
+    await page.click('[data-testid="nav-logout"]')
+
+    // Should redirect back to home and show not authenticated
+    await page.waitForURL('http://127.0.0.1:3333/')
+    await expect(page.locator('[data-testid="not-authenticated"]')).toBeVisible({ timeout: 10000 })
+    await expect(page.locator('[data-testid="nav-login"]')).toBeVisible()
+  })
+})

--- a/examples/vue-basic/package-lock.json
+++ b/examples/vue-basic/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-api-toolkit-example",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit-example",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dependencies": {
         "een-api-toolkit": "file:../..",
         "pinia": "^2.1.7",

--- a/examples/vue-basic/package-lock.json
+++ b/examples/vue-basic/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-api-toolkit-example",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit-example",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "een-api-toolkit": "file:../..",
         "pinia": "^2.1.7",

--- a/examples/vue-basic/package-lock.json
+++ b/examples/vue-basic/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-api-toolkit-example",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit-example",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "dependencies": {
         "een-api-toolkit": "file:../..",
         "pinia": "^2.1.7",

--- a/examples/vue-basic/package-lock.json
+++ b/examples/vue-basic/package-lock.json
@@ -16,13 +16,14 @@
       "devDependencies": {
         "@playwright/test": "^1.57.0",
         "@vitejs/plugin-vue": "^6.0.0",
+        "dotenv": "^17.2.3",
         "typescript": "~5.8.0",
         "vite": "^7.3.0",
         "vue-tsc": "^3.2.1"
       }
     },
     "../..": {
-      "version": "0.0.8",
+      "version": "0.0.10",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.57.0",
@@ -1067,6 +1068,19 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/een-api-toolkit": {
       "resolved": "../..",

--- a/examples/vue-basic/package.json
+++ b/examples/vue-basic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit-example",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/vue-basic/package.json
+++ b/examples/vue-basic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit-example",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "type": "module",
   "scripts": {
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@playwright/test": "^1.57.0",
     "@vitejs/plugin-vue": "^6.0.0",
+    "dotenv": "^17.2.3",
     "typescript": "~5.8.0",
     "vite": "^7.3.0",
     "vue-tsc": "^3.2.1"

--- a/examples/vue-basic/package.json
+++ b/examples/vue-basic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit-example",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/vue-basic/playwright.config.ts
+++ b/examples/vue-basic/playwright.config.ts
@@ -5,10 +5,10 @@ import { fileURLToPath } from 'url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
-// Load .env from local directory first, then fall back to parent
+// Load .env from parent directory first as fallback, then local overrides
 // In CI, env vars are passed directly
-dotenv.config({ path: path.resolve(__dirname, '.env') })
 dotenv.config({ path: path.resolve(__dirname, '../../.env') })
+dotenv.config({ path: path.resolve(__dirname, '.env'), override: true })
 
 const redirectUri = process.env.VITE_REDIRECT_URI || 'http://127.0.0.1:3333'
 if (!redirectUri.startsWith('http://127.0.0.1:') && !redirectUri.startsWith('http://localhost:')) {

--- a/examples/vue-basic/playwright.config.ts
+++ b/examples/vue-basic/playwright.config.ts
@@ -5,8 +5,8 @@ import { fileURLToPath } from 'url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
-// Load .env from parent directory first as fallback, then local overrides
-// In CI, env vars are passed directly
+// Load .env files: parent first, then local with override to replace any conflicts
+// In CI, env vars are passed directly via workflow
 dotenv.config({ path: path.resolve(__dirname, '../../.env') })
 dotenv.config({ path: path.resolve(__dirname, '.env'), override: true })
 

--- a/examples/vue-basic/playwright.config.ts
+++ b/examples/vue-basic/playwright.config.ts
@@ -1,4 +1,14 @@
 import { defineConfig, devices } from '@playwright/test'
+import dotenv from 'dotenv'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+// Load .env from local directory first, then fall back to parent
+// In CI, env vars are passed directly
+dotenv.config({ path: path.resolve(__dirname, '.env') })
+dotenv.config({ path: path.resolve(__dirname, '../../.env') })
 
 const redirectUri = process.env.VITE_REDIRECT_URI || 'http://127.0.0.1:3333'
 if (!redirectUri.startsWith('http://127.0.0.1:') && !redirectUri.startsWith('http://localhost:')) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.0.8",
+  "version": "0.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit",
-      "version": "0.0.8",
+      "version": "0.0.10",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.57.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.57.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "EEN Video platform API v3.0 library for Vue 3",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.0.8",
+  "version": "0.0.10",
   "description": "EEN Video platform API v3.0 library for Vue 3",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary
- Add authenticated e2e tests for vue-basic example that perform actual OAuth login through the UI
- Fix version bump trigger to include examples/ and .github/workflows/ changes
- Implement independent versioning for example app (separate from main package)

## Changes
- **examples/vue-basic/e2e/auth.spec.ts**: 3 new authenticated test cases using real OAuth login flow
- **.husky/pre-commit**: Separate version bumps for main package vs example
- **.github/workflows/test-release.yml**: Pass auth secrets to example e2e tests
- **examples/vue-basic/playwright.config.ts**: dotenv loading for local development

## Test plan
- [ ] Verify unauthenticated e2e tests pass
- [ ] Verify authenticated e2e tests pass (require TEST_USER/TEST_PASSWORD secrets)
- [ ] Verify tests skip gracefully when credentials not available
- [ ] Verify version bumping works for both main package and example changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)