### PR TITLE
Release v0.0.13: Fix localStorage access errors in CI

### DIFF
--- a/examples/vue-basic/e2e/auth.spec.ts
+++ b/examples/vue-basic/e2e/auth.spec.ts
@@ -89,13 +89,26 @@ async function performLogin(page: Page, username: string, password: string): Pro
 }
 
 /**
- * Clears browser storage to reset auth state
+ * Clears browser storage to reset auth state.
+ * Handles cases where localStorage isn't accessible (e.g., about:blank, cross-origin).
  */
 async function clearAuthState(page: Page): Promise<void> {
-  await page.evaluate(() => {
-    localStorage.clear()
-    sessionStorage.clear()
-  })
+  try {
+    // Only try to clear storage if we're on a page that allows it
+    const url = page.url()
+    if (url && url.startsWith('http')) {
+      await page.evaluate(() => {
+        try {
+          localStorage.clear()
+          sessionStorage.clear()
+        } catch {
+          // Ignore errors - storage may not be accessible
+        }
+      })
+    }
+  } catch {
+    // Ignore errors - page may be closed or in an inaccessible state
+  }
 }
 
 test.describe('Vue Basic Example', () => {

--- a/examples/vue-basic/package-lock.json
+++ b/examples/vue-basic/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-api-toolkit-example",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit-example",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "dependencies": {
         "een-api-toolkit": "file:../..",
         "pinia": "^2.1.7",

--- a/examples/vue-basic/package.json
+++ b/examples/vue-basic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit-example",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
Fix test failures in CI caused by localStorage access errors when tests are skipped.

## Problem
The `afterEach` hook called `clearAuthState()` which tried to access `localStorage`, but when tests are skipped (because OAuth proxy isn't accessible in CI), the page might be on `about:blank` where localStorage access throws a `SecurityError`.

## Solution
Made `clearAuthState()` robust by:
- Checking if URL starts with `http` before attempting storage access
- Wrapping both outer and inner code in try-catch to handle all error cases

## Test plan
- [x] OAuth tests properly skip in CI (no proxy available)
- [x] Non-OAuth tests (9 tests) pass without errors
- [x] All 14 tests pass locally with proxy running

🤖 Generated with [Claude Code](https://claude.com/claude-code)