### PR TITLE
fix: Strip leading whitespace from .dev.vars heredoc

### DIFF
--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -62,6 +62,8 @@ jobs:
           ADMIN_EMAILS=test@example.com
           ALLOWED_ORIGINS=http://127.0.0.1:3333
           EOF
+          # Remove leading whitespace from each line (heredoc preserves indentation)
+          sed -i 's/^[[:space:]]*//' ../een-oauth-proxy/proxy/.dev.vars
 
       - name: Start OAuth proxy
         run: |

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -56,14 +56,17 @@ jobs:
 
       - name: Create proxy secrets file
         run: |
-          cat > ../een-oauth-proxy/proxy/.dev.vars << EOF
+          cat > ../een-oauth-proxy/proxy/.dev.vars << 'EOF'
           CLIENT_ID=${{ secrets.VITE_EEN_CLIENT_ID }}
           CLIENT_SECRET=${{ secrets.CLIENT_SECRET }}
           ADMIN_EMAILS=test@example.com
           ALLOWED_ORIGINS=http://127.0.0.1:3333
           EOF
-          # Remove leading whitespace from each line (heredoc preserves indentation)
+          # Remove leading whitespace (heredoc preserves YAML indentation)
           sed -i 's/^[[:space:]]*//' ../een-oauth-proxy/proxy/.dev.vars
+          # Verify file was created correctly (mask secrets)
+          echo "Created .dev.vars:"
+          sed 's/CLIENT_ID=.*/CLIENT_ID=***/' ../een-oauth-proxy/proxy/.dev.vars | sed 's/CLIENT_SECRET=.*/CLIENT_SECRET=***/'
 
       - name: Start OAuth proxy
         run: |


### PR DESCRIPTION
## Summary
- Fix heredoc indentation issue in test-release.yml that caused proxy env vars to not be parsed

## Problem
The `.dev.vars` heredoc content was indented for YAML readability, but those leading spaces became part of the file content:
```
          CLIENT_ID=xxx
          ALLOWED_ORIGINS=http://127.0.0.1:3333
```

This caused wrangler to not recognize the environment variables, so `ALLOWED_ORIGINS` was empty and the proxy rejected OAuth callback requests with "Invalid redirect_uri: domain not allowed".

## Fix
Added `sed -i 's/^[[:space:]]*//'` to strip leading whitespace after creating the file.

## Test plan
- [ ] Verify test-release workflow passes
- [ ] Verify OAuth e2e tests complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)