### PR TITLE
fix: Use printf with quoted values for .dev.vars

### DIFF
--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -56,13 +56,21 @@ jobs:
 
       - name: Create proxy secrets file
         run: |
+          set -euo pipefail
           # Use printf with quoted values to handle special characters (e.g., # in passwords)
           printf 'CLIENT_ID="%s"\n' "$CLIENT_ID" > ../een-oauth-proxy/proxy/.dev.vars
           printf 'CLIENT_SECRET="%s"\n' "$CLIENT_SECRET" >> ../een-oauth-proxy/proxy/.dev.vars
           printf 'ADMIN_EMAILS="%s"\n' "test@example.com" >> ../een-oauth-proxy/proxy/.dev.vars
           printf 'ALLOWED_ORIGINS="%s"\n' "http://127.0.0.1:3333" >> ../een-oauth-proxy/proxy/.dev.vars
-          # Verify file was created correctly (mask secrets)
-          echo "Created .dev.vars:"
+          # Restrict file permissions
+          chmod 600 ../een-oauth-proxy/proxy/.dev.vars
+          # Validate file structure before masking
+          echo "Validating .dev.vars structure:"
+          grep -q '^CLIENT_ID=' ../een-oauth-proxy/proxy/.dev.vars && echo "✓ CLIENT_ID present"
+          grep -q '^CLIENT_SECRET=' ../een-oauth-proxy/proxy/.dev.vars && echo "✓ CLIENT_SECRET present"
+          grep -q '^ADMIN_EMAILS=' ../een-oauth-proxy/proxy/.dev.vars && echo "✓ ADMIN_EMAILS present"
+          grep -q '^ALLOWED_ORIGINS=' ../een-oauth-proxy/proxy/.dev.vars && echo "✓ ALLOWED_ORIGINS present"
+          echo "Created .dev.vars (masked):"
           sed 's/=.*/=***/' ../een-oauth-proxy/proxy/.dev.vars
         env:
           CLIENT_ID: ${{ secrets.VITE_EEN_CLIENT_ID }}

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -56,17 +56,17 @@ jobs:
 
       - name: Create proxy secrets file
         run: |
-          cat > ../een-oauth-proxy/proxy/.dev.vars << 'EOF'
-          CLIENT_ID=${{ secrets.VITE_EEN_CLIENT_ID }}
-          CLIENT_SECRET=${{ secrets.CLIENT_SECRET }}
-          ADMIN_EMAILS=test@example.com
-          ALLOWED_ORIGINS=http://127.0.0.1:3333
-          EOF
-          # Remove leading whitespace (heredoc preserves YAML indentation)
-          sed -i 's/^[[:space:]]*//' ../een-oauth-proxy/proxy/.dev.vars
+          # Use printf with quoted values to handle special characters (e.g., # in passwords)
+          printf 'CLIENT_ID="%s"\n' "$CLIENT_ID" > ../een-oauth-proxy/proxy/.dev.vars
+          printf 'CLIENT_SECRET="%s"\n' "$CLIENT_SECRET" >> ../een-oauth-proxy/proxy/.dev.vars
+          printf 'ADMIN_EMAILS="%s"\n' "test@example.com" >> ../een-oauth-proxy/proxy/.dev.vars
+          printf 'ALLOWED_ORIGINS="%s"\n' "http://127.0.0.1:3333" >> ../een-oauth-proxy/proxy/.dev.vars
           # Verify file was created correctly (mask secrets)
           echo "Created .dev.vars:"
-          sed 's/CLIENT_ID=.*/CLIENT_ID=***/' ../een-oauth-proxy/proxy/.dev.vars | sed 's/CLIENT_SECRET=.*/CLIENT_SECRET=***/'
+          sed 's/=.*/=***/' ../een-oauth-proxy/proxy/.dev.vars
+        env:
+          CLIENT_ID: ${{ secrets.VITE_EEN_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
 
       - name: Start OAuth proxy
         run: |


### PR DESCRIPTION
## Summary
Fix special character handling in `.dev.vars` secrets file creation.

## Problem
The `CLIENT_SECRET` contains special characters (like `#`) that were being interpreted as comment markers when written to `.dev.vars` without proper quoting, causing the value to be truncated.

## Solution
Use `printf` with double-quoted values, matching the pattern from `een-oauth-proxy/test-demo1-pr.yml`:

```bash
printf 'CLIENT_ID="%s"\n' "$CLIENT_ID" > .dev.vars
printf 'CLIENT_SECRET="%s"\n' "$CLIENT_SECRET" >> .dev.vars
```

This properly escapes special characters in secret values.

## Test plan
- [ ] Verify test-release workflow passes
- [ ] Verify OAuth e2e tests complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)