### PR TITLE
docs: Add In-Place Login pattern for single-page OAuth callbacks

### DIFF
--- a/docs/AI-CONTEXT.md
+++ b/docs/AI-CONTEXT.md
@@ -538,6 +538,8 @@ onMounted(async () => {
 
 When handling the OAuth callback on the same page that displays user data (without navigation), you must manually refresh the composable after authentication:
 
+> **⚠️ Important:** When handling OAuth callbacks on the same page, you must call `refresh()` after `handleAuthCallback()` to update the user data.
+
 ```vue
 <script setup lang="ts">
 import { onMounted } from 'vue'
@@ -552,7 +554,6 @@ onMounted(async () => {
   const state = urlParams.get('state')
 
   if (code && state) {
-    // 1. Exchange code for token
     const result = await handleAuthCallback(code, state)
 
     if (result.error) {
@@ -560,15 +561,13 @@ onMounted(async () => {
       return
     }
 
-    // 2. CRITICAL: Refresh user data now that we have a token
-    await refresh()
-
-    // 3. Clean URL (remove OAuth params)
+    // Clean URL after successful auth
     window.history.replaceState({}, document.title, window.location.pathname)
-  } else {
-    // No OAuth params - fetch user if already authenticated
-    await refresh()
   }
+
+  // Refresh user data - runs after successful auth callback,
+  // or on initial load if no callback was processed
+  await refresh()
 })
 </script>
 

--- a/docs/AI-CONTEXT.md
+++ b/docs/AI-CONTEXT.md
@@ -1,7 +1,7 @@
 # EEN API Toolkit - AI Reference
 
 > **Version:** 0.0.11
-> **Generated:** 2025-12-28
+> **Generated:** 2025-12-29
 >
 > This file is optimized for AI assistants. It contains all API signatures,
 > types, and usage patterns in a single, parseable document.
@@ -533,6 +533,57 @@ onMounted(async () => {
 })
 </script>
 ```
+
+### In-Place Login (Single Page Callback)
+
+When handling the OAuth callback on the same page that displays user data (without navigation), you must manually refresh the composable after authentication:
+
+```vue
+<script setup lang="ts">
+import { onMounted } from 'vue'
+import { useCurrentUser, handleAuthCallback } from 'een-api-toolkit'
+
+// Composable initializes before token exists
+const { user, loading, error, refresh } = useCurrentUser({ immediate: false })
+
+onMounted(async () => {
+  const urlParams = new URLSearchParams(window.location.search)
+  const code = urlParams.get('code')
+  const state = urlParams.get('state')
+
+  if (code && state) {
+    // 1. Exchange code for token
+    const result = await handleAuthCallback(code, state)
+
+    if (result.error) {
+      console.error('Login failed:', result.error.message)
+      return
+    }
+
+    // 2. CRITICAL: Refresh user data now that we have a token
+    await refresh()
+
+    // 3. Clean URL (remove OAuth params)
+    window.history.replaceState({}, document.title, window.location.pathname)
+  } else {
+    // No OAuth params - fetch user if already authenticated
+    await refresh()
+  }
+})
+</script>
+
+<template>
+  <div v-if="loading">Loading...</div>
+  <div v-else-if="error">{{ error.message }}</div>
+  <div v-else-if="user">Welcome, {{ user.firstName }}!</div>
+  <div v-else>Please log in</div>
+</template>
+```
+
+**Key Points:**
+- `useCurrentUser()` initializes with the auth state at the moment it's called
+- `handleAuthCallback()` updates the token but doesn't trigger composable re-fetch
+- Always call `refresh()` after auth state changes if staying on the same page
 
 ---
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -293,6 +293,8 @@ export default router
 
 If you want to handle the OAuth callback on the same page that displays user data (without navigating to a separate callback route), you must manually refresh the composable after authentication completes:
 
+> **⚠️ Important:** When handling OAuth callbacks on the same page, you must call `refresh()` after `handleAuthCallback()` to update the user data.
+
 ```vue
 <script setup lang="ts">
 import { onMounted } from 'vue'
@@ -307,7 +309,6 @@ onMounted(async () => {
   const state = urlParams.get('state')
 
   if (code && state) {
-    // Handle OAuth callback
     const result = await handleAuthCallback(code, state)
 
     if (result.error) {
@@ -315,15 +316,13 @@ onMounted(async () => {
       return
     }
 
-    // CRITICAL: Refresh user data now that we have a token
-    await refresh()
-
-    // Clean URL (remove OAuth params)
+    // Clean URL after successful auth
     window.history.replaceState({}, document.title, window.location.pathname)
-  } else {
-    // No OAuth params - fetch user if already authenticated
-    await refresh()
   }
+
+  // Refresh user data - runs after successful auth callback,
+  // or on initial load if no callback was processed
+  await refresh()
 })
 
 function login() {

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -289,6 +289,62 @@ router.beforeEach((to, from, next) => {
 export default router
 ```
 
+### In-Place Login (Single Page Callback)
+
+If you want to handle the OAuth callback on the same page that displays user data (without navigating to a separate callback route), you must manually refresh the composable after authentication completes:
+
+```vue
+<script setup lang="ts">
+import { onMounted } from 'vue'
+import { useCurrentUser, handleAuthCallback, getAuthUrl } from 'een-api-toolkit'
+
+// Initialize composable - don't fetch immediately since we may not be authenticated yet
+const { user, loading, error, refresh } = useCurrentUser({ immediate: false })
+
+onMounted(async () => {
+  const urlParams = new URLSearchParams(window.location.search)
+  const code = urlParams.get('code')
+  const state = urlParams.get('state')
+
+  if (code && state) {
+    // Handle OAuth callback
+    const result = await handleAuthCallback(code, state)
+
+    if (result.error) {
+      console.error('Login failed:', result.error.message)
+      return
+    }
+
+    // CRITICAL: Refresh user data now that we have a token
+    await refresh()
+
+    // Clean URL (remove OAuth params)
+    window.history.replaceState({}, document.title, window.location.pathname)
+  } else {
+    // No OAuth params - fetch user if already authenticated
+    await refresh()
+  }
+})
+
+function login() {
+  window.location.href = getAuthUrl()
+}
+</script>
+
+<template>
+  <div v-if="loading">Loading...</div>
+  <div v-else-if="error">{{ error.message }}</div>
+  <div v-else-if="user">Welcome, {{ user.firstName }}!</div>
+  <button v-else @click="login">Login with EEN</button>
+</template>
+```
+
+**Why is `refresh()` needed?**
+
+- `useCurrentUser()` initializes with the authentication state at the moment it's called
+- `handleAuthCallback()` updates the token in the auth store, but doesn't automatically trigger a re-fetch in existing composable instances
+- Always call `refresh()` after operations that change authentication state (login, logout) if you're staying on the same page
+
 ## Using the API
 
 ### Vue Composables (Reactive)

--- a/scripts/generate-ai-context.ts
+++ b/scripts/generate-ai-context.ts
@@ -590,6 +590,8 @@ onMounted(async () => {
 
 When handling the OAuth callback on the same page that displays user data (without navigation), you must manually refresh the composable after authentication:
 
+> **⚠️ Important:** When handling OAuth callbacks on the same page, you must call \`refresh()\` after \`handleAuthCallback()\` to update the user data.
+
 \`\`\`vue
 <script setup lang="ts">
 import { onMounted } from 'vue'
@@ -604,7 +606,6 @@ onMounted(async () => {
   const state = urlParams.get('state')
 
   if (code && state) {
-    // 1. Exchange code for token
     const result = await handleAuthCallback(code, state)
 
     if (result.error) {
@@ -612,15 +613,13 @@ onMounted(async () => {
       return
     }
 
-    // 2. CRITICAL: Refresh user data now that we have a token
-    await refresh()
-
-    // 3. Clean URL (remove OAuth params)
+    // Clean URL after successful auth
     window.history.replaceState({}, document.title, window.location.pathname)
-  } else {
-    // No OAuth params - fetch user if already authenticated
-    await refresh()
   }
+
+  // Refresh user data - runs after successful auth callback,
+  // or on initial load if no callback was processed
+  await refresh()
 })
 </script>
 

--- a/scripts/generate-ai-context.ts
+++ b/scripts/generate-ai-context.ts
@@ -586,6 +586,57 @@ onMounted(async () => {
 </script>
 \`\`\`
 
+### In-Place Login (Single Page Callback)
+
+When handling the OAuth callback on the same page that displays user data (without navigation), you must manually refresh the composable after authentication:
+
+\`\`\`vue
+<script setup lang="ts">
+import { onMounted } from 'vue'
+import { useCurrentUser, handleAuthCallback } from 'een-api-toolkit'
+
+// Composable initializes before token exists
+const { user, loading, error, refresh } = useCurrentUser({ immediate: false })
+
+onMounted(async () => {
+  const urlParams = new URLSearchParams(window.location.search)
+  const code = urlParams.get('code')
+  const state = urlParams.get('state')
+
+  if (code && state) {
+    // 1. Exchange code for token
+    const result = await handleAuthCallback(code, state)
+
+    if (result.error) {
+      console.error('Login failed:', result.error.message)
+      return
+    }
+
+    // 2. CRITICAL: Refresh user data now that we have a token
+    await refresh()
+
+    // 3. Clean URL (remove OAuth params)
+    window.history.replaceState({}, document.title, window.location.pathname)
+  } else {
+    // No OAuth params - fetch user if already authenticated
+    await refresh()
+  }
+})
+</script>
+
+<template>
+  <div v-if="loading">Loading...</div>
+  <div v-else-if="error">{{ error.message }}</div>
+  <div v-else-if="user">Welcome, {{ user.firstName }}!</div>
+  <div v-else>Please log in</div>
+</template>
+\`\`\`
+
+**Key Points:**
+- \`useCurrentUser()\` initializes with the auth state at the moment it's called
+- \`handleAuthCallback()\` updates the token but doesn't trigger composable re-fetch
+- Always call \`refresh()\` after auth state changes if staying on the same page
+
 ---
 
 `


### PR DESCRIPTION
## Summary

This PR adds documentation for the "In-Place Login" pattern - handling OAuth callbacks on the same page that displays user data without navigation.

## Changes

- **AI-CONTEXT.md**: Added "In-Place Login (Single Page Callback)" to Common Patterns section
- **USER-GUIDE.md**: Added same pattern to Authentication Flow section with expanded explanation
- **generate-ai-context.ts**: Updated script to include the pattern in future regenerations

## Problem Addressed

Developers implementing single-page OAuth flows were encountering issues where `useCurrentUser()` didn't update after successful login. The documentation now explains:
- Why `refresh()` must be called after `handleAuthCallback()` when staying on the same page
- That composables don't auto-refresh when auth state changes
- Complete working example with login button and callback handling

## New Commits

- `3b7b6a0` docs: Add In-Place Login pattern for single-page OAuth callbacks

## Test Results

- ✅ Lint: Passed (1 expected warning)
- ✅ Unit tests: 7/7 passed
- ✅ Build: Successful

## Version

`0.0.11`

🤖 Generated with [Claude Code](https://claude.com/claude-code)