### PR TITLE
docs: Regenerate API documentation for v0.0.13

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,8 +1,8 @@
-**EEN API Toolkit v0.0.11**
+**EEN API Toolkit v0.0.13**
 
 ***
 
-# EEN API Toolkit v0.0.11
+# EEN API Toolkit v0.0.13
 
 ## Interfaces
 

--- a/docs/api/functions/getAccessToken.md
+++ b/docs/api/functions/getAccessToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.11**](../README.md)
+[**EEN API Toolkit v0.0.13**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAuthUrl.md
+++ b/docs/api/functions/getAuthUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.11**](../README.md)
+[**EEN API Toolkit v0.0.13**](../README.md)
 
 ***
 

--- a/docs/api/functions/getClientId.md
+++ b/docs/api/functions/getClientId.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.11**](../README.md)
+[**EEN API Toolkit v0.0.13**](../README.md)
 
 ***
 

--- a/docs/api/functions/getConfig.md
+++ b/docs/api/functions/getConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.11**](../README.md)
+[**EEN API Toolkit v0.0.13**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCurrentUser.md
+++ b/docs/api/functions/getCurrentUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.11**](../README.md)
+[**EEN API Toolkit v0.0.13**](../README.md)
 
 ***
 

--- a/docs/api/functions/getProxyUrl.md
+++ b/docs/api/functions/getProxyUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.11**](../README.md)
+[**EEN API Toolkit v0.0.13**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRedirectUri.md
+++ b/docs/api/functions/getRedirectUri.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.11**](../README.md)
+[**EEN API Toolkit v0.0.13**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUser.md
+++ b/docs/api/functions/getUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.11**](../README.md)
+[**EEN API Toolkit v0.0.13**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUsers.md
+++ b/docs/api/functions/getUsers.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.11**](../README.md)
+[**EEN API Toolkit v0.0.13**](../README.md)
 
 ***
 

--- a/docs/api/functions/handleAuthCallback.md
+++ b/docs/api/functions/handleAuthCallback.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.11**](../README.md)
+[**EEN API Toolkit v0.0.13**](../README.md)
 
 ***
 

--- a/docs/api/functions/initEenToolkit.md
+++ b/docs/api/functions/initEenToolkit.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.11**](../README.md)
+[**EEN API Toolkit v0.0.13**](../README.md)
 
 ***
 

--- a/docs/api/functions/refreshToken.md
+++ b/docs/api/functions/refreshToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.11**](../README.md)
+[**EEN API Toolkit v0.0.13**](../README.md)
 
 ***
 

--- a/docs/api/functions/revokeToken.md
+++ b/docs/api/functions/revokeToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.11**](../README.md)
+[**EEN API Toolkit v0.0.13**](../README.md)
 
 ***
 

--- a/docs/api/functions/useCurrentUser.md
+++ b/docs/api/functions/useCurrentUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.11**](../README.md)
+[**EEN API Toolkit v0.0.13**](../README.md)
 
 ***
 

--- a/docs/api/functions/useUser.md
+++ b/docs/api/functions/useUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.11**](../README.md)
+[**EEN API Toolkit v0.0.13**](../README.md)
 
 ***
 

--- a/docs/api/functions/useUsers.md
+++ b/docs/api/functions/useUsers.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.11**](../README.md)
+[**EEN API Toolkit v0.0.13**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenError.md
+++ b/docs/api/interfaces/EenError.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.11**](../README.md)
+[**EEN API Toolkit v0.0.13**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenToolkitConfig.md
+++ b/docs/api/interfaces/EenToolkitConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.11**](../README.md)
+[**EEN API Toolkit v0.0.13**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetUserParams.md
+++ b/docs/api/interfaces/GetUserParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.11**](../README.md)
+[**EEN API Toolkit v0.0.13**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListUsersParams.md
+++ b/docs/api/interfaces/ListUsersParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.11**](../README.md)
+[**EEN API Toolkit v0.0.13**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginatedResult.md
+++ b/docs/api/interfaces/PaginatedResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.11**](../README.md)
+[**EEN API Toolkit v0.0.13**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginationParams.md
+++ b/docs/api/interfaces/PaginationParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.11**](../README.md)
+[**EEN API Toolkit v0.0.13**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/TokenResponse.md
+++ b/docs/api/interfaces/TokenResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.11**](../README.md)
+[**EEN API Toolkit v0.0.13**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UseCurrentUserOptions.md
+++ b/docs/api/interfaces/UseCurrentUserOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.11**](../README.md)
+[**EEN API Toolkit v0.0.13**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UseUserOptions.md
+++ b/docs/api/interfaces/UseUserOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.11**](../README.md)
+[**EEN API Toolkit v0.0.13**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UseUsersOptions.md
+++ b/docs/api/interfaces/UseUsersOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.11**](../README.md)
+[**EEN API Toolkit v0.0.13**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/User.md
+++ b/docs/api/interfaces/User.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.11**](../README.md)
+[**EEN API Toolkit v0.0.13**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UserProfile.md
+++ b/docs/api/interfaces/UserProfile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.11**](../README.md)
+[**EEN API Toolkit v0.0.13**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ErrorCode.md
+++ b/docs/api/type-aliases/ErrorCode.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.11**](../README.md)
+[**EEN API Toolkit v0.0.13**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/Result.md
+++ b/docs/api/type-aliases/Result.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.11**](../README.md)
+[**EEN API Toolkit v0.0.13**](../README.md)
 
 ***
 

--- a/docs/api/variables/useAuthStore.md
+++ b/docs/api/variables/useAuthStore.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.11**](../README.md)
+[**EEN API Toolkit v0.0.13**](../README.md)
 
 ***
 


### PR DESCRIPTION
## Summary

Regenerates TypeDoc API documentation to match package.json version 0.0.13.

The previous PR #24 failed the test-release workflow because `docs/api/` files still showed version 0.0.11 while package.json was at 0.0.13.

### Changes
- Regenerated all `docs/api/` files with `npm run docs:api`
- All 32 documentation files now show correct version (0.0.13)

### Root Cause
When version bumped from 0.0.11 → 0.0.13, the TypeDoc-generated API documentation wasn't regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)