### PR TITLE
feat: Add Camera API support (v0.0.14)

### DIFF
--- a/docs/AI-CONTEXT.md
+++ b/docs/AI-CONTEXT.md
@@ -1,6 +1,6 @@
 # EEN API Toolkit - AI Reference
 
-> **Version:** 0.0.13
+> **Version:** 0.0.14
 > **Generated:** 2025-12-29
 >
 > This file is optimized for AI assistants. It contains all API signatures,
@@ -643,10 +643,10 @@ function showOnlineCameras() {
 - `nextPageToken: Ref<string | undefined>` - Next page token
 - `totalSize: Ref<number | undefined>` - Total count
 - `params: Ref<ListCamerasParams>` - Current params
-- `fetch(params?): Promise<Result>` - Fetch with params
-- `refresh(): Promise<Result>` - Refresh current page
-- `fetchNextPage(): Promise<Result | undefined>` - Fetch next page
-- `fetchPrevPage(): Promise<Result | undefined>` - Fetch previous page
+- `fetch(params?): Promise<Result<PaginatedResult<Camera>>>` - Fetch with params
+- `refresh(): Promise<Result<PaginatedResult<Camera>>>` - Refresh current page
+- `fetchNextPage(): Promise<Result<PaginatedResult<Camera>> | undefined>` - Fetch next page
+- `fetchPrevPage(): Promise<Result<PaginatedResult<Camera>> | undefined>` - Fetch previous page
 - `setParams(params): void` - Update default params
 
 ### useCamera

--- a/docs/AI-CONTEXT.md
+++ b/docs/AI-CONTEXT.md
@@ -1,6 +1,6 @@
 # EEN API Toolkit - AI Reference
 
-> **Version:** 0.0.14
+> **Version:** 0.0.15
 > **Generated:** 2025-12-29
 >
 > This file is optimized for AI assistants. It contains all API signatures,

--- a/docs/AI-CONTEXT.md
+++ b/docs/AI-CONTEXT.md
@@ -36,6 +36,13 @@
 | `getUsers(params?)` | List all users (paginated) | `Result<PaginatedResult<User>>` |
 | `getUser(userId, params?)` | Get a specific user | `Result<User>` |
 
+### Camera Functions
+
+| Function | Purpose | Returns |
+|----------|---------|---------|
+| `getCameras(params?)` | List all cameras (paginated) | `Result<PaginatedResult<Camera>>` |
+| `getCamera(cameraId, params?)` | Get a specific camera | `Result<Camera>` |
+
 ### Vue 3 Composables
 
 | Composable | Purpose | Returns |
@@ -43,6 +50,8 @@
 | `useCurrentUser(options?)` | Reactive current user | `{ user, loading, error, refresh }` |
 | `useUsers(params?, options?)` | Reactive user list with pagination | `{ users, loading, hasNextPage, fetchNextPage, ... }` |
 | `useUser(userId, options?)` | Reactive single user | `{ user, loading, error, refresh }` |
+| `useCameras(params?, options?)` | Reactive camera list with pagination | `{ cameras, loading, hasNextPage, fetchNextPage, ... }` |
+| `useCamera(cameraId, options?)` | Reactive single camera | `{ camera, loading, error, refresh }` |
 
 ---
 
@@ -205,7 +214,65 @@ interface UserProfile {
 }
 ```
 
-### Parameter Types
+### Camera
+
+```typescript
+type CameraStatus =
+  | 'online' | 'offline' | 'deviceOffline' | 'bridgeOffline'
+  | 'invalidCredentials' | 'error' | 'streaming' | 'registered'
+  | 'attaching' | 'initializing'
+
+interface Camera {
+  id: string
+  name: string
+  accountId: string
+  bridgeId?: string | null
+  locationId?: string | null
+  status?: CameraStatus
+  timezone?: string
+  guid?: string
+  ipAddress?: string
+  macAddress?: string
+  tags?: string[]
+  notes?: string
+  multiCameraId?: string
+  recordingModes?: CameraRecordingModes
+  deviceInfo?: CameraDeviceInfo
+  shareDetails?: CameraShareDetails
+  devicePosition?: CameraDevicePosition
+  enabledAnalytics?: string[]
+  packages?: string[]
+  createdAt?: string
+  updatedAt?: string
+}
+
+interface CameraDeviceInfo {
+  make?: string           // Manufacturer (e.g., "Axis", "Hikvision")
+  model?: string          // Model name
+  firmwareVersion?: string
+  directToCloud?: boolean // Direct-to-cloud camera (no bridge)
+  serialNumber?: string
+  resolution?: string
+  type?: string           // Camera type (e.g., "IP", "Analog")
+}
+
+interface CameraShareDetails {
+  shared?: boolean
+  accountId?: string      // Sharing account ID
+  firstResponder?: boolean
+  permissions?: string[]
+}
+
+interface CameraDevicePosition {
+  latitude?: number
+  longitude?: number
+  altitude?: number
+  floor?: number
+  azimuth?: number
+}
+```
+
+### User Parameter Types
 
 ```typescript
 interface ListUsersParams {
@@ -216,6 +283,41 @@ interface ListUsersParams {
 
 interface GetUserParams {
   include?: string[]   // Additional fields to include
+}
+```
+
+### Camera Parameter Types
+
+```typescript
+interface ListCamerasParams {
+  pageSize?: number           // Results per page
+  pageToken?: string          // Pagination token
+  include?: string[]          // Additional fields to include
+  sort?: string[]             // Sort order
+  status__in?: CameraStatus[] // Filter by status
+  status__ne?: CameraStatus   // Exclude by status
+  tags__contains?: string[]   // Filter by tags (all must match)
+  tags__any?: string[]        // Filter by tags (any match)
+  name?: string               // Exact name match
+  name__contains?: string     // Partial name match
+  name__in?: string[]         // Name in list
+  id__in?: string[]           // ID in list
+  id__notIn?: string[]        // ID not in list
+  bridgeId__in?: string[]     // Bridge ID filter
+  locationId__in?: string[]   // Location ID filter
+  shared?: boolean            // Shared camera filter
+  directToCloud?: boolean     // Direct-to-cloud filter
+  q?: string                  // Full-text search
+  // ... and more filter parameters
+}
+
+interface GetCameraParams {
+  include?: string[]  // Valid values: bridge, account, status, locationSummary,
+                      // deviceAddress, timeZone, notes, tags, devicePosition,
+                      // networkInfo, deviceInfo, effectivePermissions, firmware,
+                      // shareDetails, visibleByBridges, capabilities, analog,
+                      // packages, dewarpConfig, adminCredentials,
+                      // publicSafetySharing, enabledAnalytics
 }
 ```
 
@@ -341,6 +443,54 @@ const { data: userWithPerms } = await getUser('user-id-123', {
 })
 ```
 
+### getCameras
+
+List cameras with optional pagination and filtering.
+
+```typescript
+import { getCameras } from 'een-api-toolkit'
+
+// Basic usage
+const { data, error } = await getCameras()
+
+// With pagination
+const { data } = await getCameras({ pageSize: 50 })
+
+// With status filter
+const { data } = await getCameras({
+  pageSize: 20,
+  status__in: ['online', 'streaming']
+})
+
+// With search
+const { data } = await getCameras({
+  q: 'front door',
+  include: ['deviceInfo', 'status']
+})
+```
+
+### getCamera
+
+Get a specific camera by ID.
+
+```typescript
+import { getCamera } from 'een-api-toolkit'
+
+const { data, error } = await getCamera('camera-id-123')
+
+if (error) {
+  if (error.code === 'NOT_FOUND') {
+    console.log('Camera not found')
+  }
+  return
+}
+
+// With additional fields
+const { data: cameraWithDetails } = await getCamera('camera-id-123', {
+  include: ['deviceInfo', 'status', 'shareDetails']
+})
+```
+
 ---
 
 ## Vue 3 Composables
@@ -448,6 +598,87 @@ const { user: userWithPerms } = useUser('user-123', {
 - `error: Ref<EenError | null>` - Last error
 - `fetch(params?): Promise<Result<User>>` - Fetch user
 - `refresh(): Promise<Result<User>>` - Refresh user
+
+### useCameras
+
+Reactive composable for listing cameras with pagination and filtering.
+
+```vue
+<script setup>
+import { useCameras } from 'een-api-toolkit'
+
+const {
+  cameras,
+  loading,
+  error,
+  hasNextPage,
+  fetchNextPage,
+  refresh,
+  setParams
+} = useCameras({ pageSize: 20 })
+
+// Filter by status
+function showOnlineCameras() {
+  setParams({ status__in: ['online', 'streaming'] })
+  refresh()
+}
+</script>
+
+<template>
+  <ul>
+    <li v-for="camera in cameras" :key="camera.id">
+      {{ camera.name }} - {{ camera.status || 'Unknown' }}
+    </li>
+  </ul>
+  <button v-if="hasNextPage" @click="fetchNextPage">Load More</button>
+</template>
+```
+
+**Returns:**
+- `cameras: Ref<Camera[]>` - Array of cameras
+- `loading: Ref<boolean>` - Fetch in progress
+- `error: Ref<EenError | null>` - Last error
+- `hasNextPage: ComputedRef<boolean>` - More pages available
+- `hasPrevPage: ComputedRef<boolean>` - Previous page available
+- `nextPageToken: Ref<string | undefined>` - Next page token
+- `totalSize: Ref<number | undefined>` - Total count
+- `params: Ref<ListCamerasParams>` - Current params
+- `fetch(params?): Promise<Result>` - Fetch with params
+- `refresh(): Promise<Result>` - Refresh current page
+- `fetchNextPage(): Promise<Result | undefined>` - Fetch next page
+- `fetchPrevPage(): Promise<Result | undefined>` - Fetch previous page
+- `setParams(params): void` - Update default params
+
+### useCamera
+
+Reactive composable for a single camera by ID.
+
+```vue
+<script setup>
+import { useCamera } from 'een-api-toolkit'
+import { useRoute } from 'vue-router'
+
+const route = useRoute()
+
+// Static ID
+const { camera, loading, error } = useCamera('camera-123')
+
+// Reactive ID from route
+const { camera: routeCamera } = useCamera(() => route.params.id as string)
+
+// With additional fields
+const { camera: cameraWithDetails } = useCamera('camera-123', {
+  include: ['deviceInfo', 'status', 'shareDetails']
+})
+</script>
+```
+
+**Returns:**
+- `camera: Ref<Camera | null>` - The camera
+- `loading: Ref<boolean>` - Fetch in progress
+- `error: Ref<EenError | null>` - Last error
+- `fetch(params?): Promise<Result<Camera>>` - Fetch camera
+- `refresh(): Promise<Result<Camera>>` - Refresh camera
 
 ---
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,8 +1,8 @@
-**EEN API Toolkit v0.0.13**
+**EEN API Toolkit v0.0.14**
 
 ***
 
-# EEN API Toolkit v0.0.13
+# EEN API Toolkit v0.0.14
 
 ## Interfaces
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -26,6 +26,20 @@
 - [PaginationParams](interfaces/PaginationParams.md)
 - [PaginatedResult](interfaces/PaginatedResult.md)
 
+### Cameras
+
+- [UseCamerasOptions](interfaces/UseCamerasOptions.md)
+- [UseCameraOptions](interfaces/UseCameraOptions.md)
+- [CameraDeviceInfo](interfaces/CameraDeviceInfo.md)
+- [CameraShareDetails](interfaces/CameraShareDetails.md)
+- [CameraStreamUrls](interfaces/CameraStreamUrls.md)
+- [CameraRtspConnectionSettings](interfaces/CameraRtspConnectionSettings.md)
+- [CameraDevicePosition](interfaces/CameraDevicePosition.md)
+- [CameraRecordingModes](interfaces/CameraRecordingModes.md)
+- [Camera](interfaces/Camera.md)
+- [ListCamerasParams](interfaces/ListCamerasParams.md)
+- [GetCameraParams](interfaces/GetCameraParams.md)
+
 ### Configuration
 
 - [EenToolkitConfig](interfaces/EenToolkitConfig.md)
@@ -36,6 +50,10 @@
 
 - [ErrorCode](type-aliases/ErrorCode.md)
 - [Result](type-aliases/Result.md)
+
+### Cameras
+
+- [CameraStatus](type-aliases/CameraStatus.md)
 
 ## Variables
 
@@ -51,6 +69,13 @@
 - [getCurrentUser](functions/getCurrentUser.md)
 - [getUsers](functions/getUsers.md)
 - [getUser](functions/getUser.md)
+
+### Cameras
+
+- [useCameras](functions/useCameras.md)
+- [useCamera](functions/useCamera.md)
+- [getCameras](functions/getCameras.md)
+- [getCamera](functions/getCamera.md)
 
 ### Other
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,8 +1,8 @@
-**EEN API Toolkit v0.0.14**
+**EEN API Toolkit v0.0.15**
 
 ***
 
-# EEN API Toolkit v0.0.14
+# EEN API Toolkit v0.0.15
 
 ## Interfaces
 

--- a/docs/api/functions/getAccessToken.md
+++ b/docs/api/functions/getAccessToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAccessToken.md
+++ b/docs/api/functions/getAccessToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAuthUrl.md
+++ b/docs/api/functions/getAuthUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAuthUrl.md
+++ b/docs/api/functions/getAuthUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCamera.md
+++ b/docs/api/functions/getCamera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **getCamera**(`cameraId`, `params?`): `Promise`\<[`Result`](../type-aliases/Result.md)\<[`Camera`](../interfaces/Camera.md)\>\>
 
-Defined in: src/cameras/service.ts:240
+Defined in: [src/cameras/service.ts:240](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/cameras/service.ts#L240)
 
 Get a specific camera by ID.
 

--- a/docs/api/functions/getCamera.md
+++ b/docs/api/functions/getCamera.md
@@ -1,0 +1,63 @@
+[**EEN API Toolkit v0.0.13**](../README.md)
+
+***
+
+[EEN API Toolkit](../README.md) / getCamera
+
+# Function: getCamera()
+
+> **getCamera**(`cameraId`, `params?`): `Promise`\<[`Result`](../type-aliases/Result.md)\<[`Camera`](../interfaces/Camera.md)\>\>
+
+Defined in: src/cameras/service.ts:240
+
+Get a specific camera by ID.
+
+## Parameters
+
+### cameraId
+
+`string`
+
+The unique identifier of the camera to fetch
+
+### params?
+
+[`GetCameraParams`](../interfaces/GetCameraParams.md)
+
+Optional parameters (e.g., include additional fields)
+
+## Returns
+
+`Promise`\<[`Result`](../type-aliases/Result.md)\<[`Camera`](../interfaces/Camera.md)\>\>
+
+A Result containing the camera or an error
+
+## Remarks
+
+Fetches a single camera from `/api/v3.0/cameras/{cameraId}`. Use the `include`
+parameter to request additional fields.
+
+For more details, see the
+[EEN API Documentation](https://developer.eagleeyenetworks.com/reference/getcamera).
+
+## Example
+
+```typescript
+import { getCamera } from 'een-api-toolkit'
+
+const { data, error } = await getCamera('camera-123')
+
+if (error) {
+  if (error.code === 'NOT_FOUND') {
+    console.log('Camera not found')
+  }
+  return
+}
+
+console.log(`Camera: ${data.name} (${data.status})`)
+
+// With additional fields
+const { data: cameraWithDetails } = await getCamera('camera-123', {
+  include: ['deviceInfo', 'streamUrls', 'shareDetails']
+})
+```

--- a/docs/api/functions/getCamera.md
+++ b/docs/api/functions/getCamera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameras.md
+++ b/docs/api/functions/getCameras.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **getCameras**(`params?`): `Promise`\<[`Result`](../type-aliases/Result.md)\<[`PaginatedResult`](../interfaces/PaginatedResult.md)\<[`Camera`](../interfaces/Camera.md)\>\>\>
 
-Defined in: src/cameras/service.ts:49
+Defined in: [src/cameras/service.ts:49](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/cameras/service.ts#L49)
 
 List cameras with optional pagination and filtering.
 

--- a/docs/api/functions/getCameras.md
+++ b/docs/api/functions/getCameras.md
@@ -1,0 +1,64 @@
+[**EEN API Toolkit v0.0.13**](../README.md)
+
+***
+
+[EEN API Toolkit](../README.md) / getCameras
+
+# Function: getCameras()
+
+> **getCameras**(`params?`): `Promise`\<[`Result`](../type-aliases/Result.md)\<[`PaginatedResult`](../interfaces/PaginatedResult.md)\<[`Camera`](../interfaces/Camera.md)\>\>\>
+
+Defined in: src/cameras/service.ts:49
+
+List cameras with optional pagination and filtering.
+
+## Parameters
+
+### params?
+
+[`ListCamerasParams`](../interfaces/ListCamerasParams.md)
+
+Optional pagination and filtering parameters
+
+## Returns
+
+`Promise`\<[`Result`](../type-aliases/Result.md)\<[`PaginatedResult`](../interfaces/PaginatedResult.md)\<[`Camera`](../interfaces/Camera.md)\>\>\>
+
+A Result containing a paginated list of cameras or an error
+
+## Remarks
+
+Fetches a paginated list of cameras from `/api/v3.0/cameras`. Supports
+extensive filtering options for location, status, tags, and more.
+
+For more details, see the
+[EEN API Documentation](https://developer.eagleeyenetworks.com/reference/listcameras).
+
+## Example
+
+```typescript
+import { getCameras } from 'een-api-toolkit'
+
+// Basic usage
+const { data, error } = await getCameras()
+if (data) {
+  console.log(`Found ${data.results.length} cameras`)
+}
+
+// With filters
+const { data } = await getCameras({
+  pageSize: 50,
+  status__in: ['online'],
+  include: ['deviceInfo', 'streamUrls']
+})
+
+// Fetch all cameras
+let allCameras: Camera[] = []
+let pageToken: string | undefined
+do {
+  const { data, error } = await getCameras({ pageSize: 100, pageToken })
+  if (error) break
+  allCameras.push(...data.results)
+  pageToken = data.nextPageToken
+} while (pageToken)
+```

--- a/docs/api/functions/getCameras.md
+++ b/docs/api/functions/getCameras.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/functions/getClientId.md
+++ b/docs/api/functions/getClientId.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 

--- a/docs/api/functions/getClientId.md
+++ b/docs/api/functions/getClientId.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/functions/getConfig.md
+++ b/docs/api/functions/getConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 

--- a/docs/api/functions/getConfig.md
+++ b/docs/api/functions/getConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCurrentUser.md
+++ b/docs/api/functions/getCurrentUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCurrentUser.md
+++ b/docs/api/functions/getCurrentUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/functions/getProxyUrl.md
+++ b/docs/api/functions/getProxyUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 

--- a/docs/api/functions/getProxyUrl.md
+++ b/docs/api/functions/getProxyUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRedirectUri.md
+++ b/docs/api/functions/getRedirectUri.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRedirectUri.md
+++ b/docs/api/functions/getRedirectUri.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUser.md
+++ b/docs/api/functions/getUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUser.md
+++ b/docs/api/functions/getUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUsers.md
+++ b/docs/api/functions/getUsers.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUsers.md
+++ b/docs/api/functions/getUsers.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/functions/handleAuthCallback.md
+++ b/docs/api/functions/handleAuthCallback.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 

--- a/docs/api/functions/handleAuthCallback.md
+++ b/docs/api/functions/handleAuthCallback.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/functions/initEenToolkit.md
+++ b/docs/api/functions/initEenToolkit.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 

--- a/docs/api/functions/initEenToolkit.md
+++ b/docs/api/functions/initEenToolkit.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/functions/refreshToken.md
+++ b/docs/api/functions/refreshToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 

--- a/docs/api/functions/refreshToken.md
+++ b/docs/api/functions/refreshToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/functions/revokeToken.md
+++ b/docs/api/functions/revokeToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 

--- a/docs/api/functions/revokeToken.md
+++ b/docs/api/functions/revokeToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/functions/useCamera.md
+++ b/docs/api/functions/useCamera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **useCamera**(`cameraId`, `options?`): `object`
 
-Defined in: src/cameras/composables.ts:231
+Defined in: [src/cameras/composables.ts:231](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/cameras/composables.ts#L231)
 
 Vue 3 composable for getting a single camera by ID.
 
@@ -32,7 +32,7 @@ Reactive camera state and control functions
 
 ### camera
 
-> **camera**: `Ref`\<\{ `id`: `string`; `name`: `string`; `accountId`: `string`; `bridgeId?`: `string` \| `null`; `locationId?`: `string` \| `null`; `guid?`: `string`; `macAddress?`: `string`; `ipAddress?`: `string`; `timezone?`: `string`; `status?`: [`CameraStatus`](../type-aliases/CameraStatus.md); `tags?`: `string`[]; `packages?`: `string`[]; `multiCameraId?`: `string` \| `null`; `speakerId?`: `string` \| `null`; `deviceInfo?`: \{ `make?`: `string`; `model?`: `string`; `firmwareVersion?`: `string`; `directToCloud?`: `boolean`; `serialNumber?`: `string`; `resolution?`: `string`; `type?`: `string`; \}; `shareDetails?`: \{ `shared?`: `boolean`; `accountId?`: `string`; `firstResponder?`: `boolean`; `permissions?`: `string`[]; \}; `streamUrls?`: \{ `hls?`: `string`; `rtsp?`: `string`; `webrtc?`: `string`; `jpeg?`: `string`; \}; `rtspConnectionSettings?`: \{ `url?`: `string`; `username?`: `string`; `password?`: `string`; `transport?`: `"tcp"` \| `"udp"`; \}; `devicePosition?`: \{ `latitude?`: `number`; `longitude?`: `number`; `altitude?`: `number`; `floor?`: `number`; `azimuth?`: `number`; \}; `enabledAnalytics?`: `string`[]; `recordingModes?`: \{ `continuous?`: `boolean`; `motion?`: `boolean`; `scheduled?`: `boolean`; \}; `createdAt?`: `string`; `updatedAt?`: `string`; \} \| `null`, [`Camera`](../interfaces/Camera.md) \| \{ `id`: `string`; `name`: `string`; `accountId`: `string`; `bridgeId?`: `string` \| `null`; `locationId?`: `string` \| `null`; `guid?`: `string`; `macAddress?`: `string`; `ipAddress?`: `string`; `timezone?`: `string`; `status?`: [`CameraStatus`](../type-aliases/CameraStatus.md); `tags?`: `string`[]; `packages?`: `string`[]; `multiCameraId?`: `string` \| `null`; `speakerId?`: `string` \| `null`; `deviceInfo?`: \{ `make?`: `string`; `model?`: `string`; `firmwareVersion?`: `string`; `directToCloud?`: `boolean`; `serialNumber?`: `string`; `resolution?`: `string`; `type?`: `string`; \}; `shareDetails?`: \{ `shared?`: `boolean`; `accountId?`: `string`; `firstResponder?`: `boolean`; `permissions?`: `string`[]; \}; `streamUrls?`: \{ `hls?`: `string`; `rtsp?`: `string`; `webrtc?`: `string`; `jpeg?`: `string`; \}; `rtspConnectionSettings?`: \{ `url?`: `string`; `username?`: `string`; `password?`: `string`; `transport?`: `"tcp"` \| `"udp"`; \}; `devicePosition?`: \{ `latitude?`: `number`; `longitude?`: `number`; `altitude?`: `number`; `floor?`: `number`; `azimuth?`: `number`; \}; `enabledAnalytics?`: `string`[]; `recordingModes?`: \{ `continuous?`: `boolean`; `motion?`: `boolean`; `scheduled?`: `boolean`; \}; `createdAt?`: `string`; `updatedAt?`: `string`; \} \| `null`\>
+> **camera**: `Ref`\<\{ `id`: `string`; `name`: `string`; `accountId`: `string`; `bridgeId?`: `string` \| `null`; `locationId?`: `string` \| `null`; `guid?`: `string`; `macAddress?`: `string`; `ipAddress?`: `string`; `timezone?`: `string`; `status?`: [`CameraStatus`](../type-aliases/CameraStatus.md) \| \{ `connectionStatus?`: CameraStatus \| undefined; \}; `tags?`: `string`[]; `packages?`: `string`[]; `multiCameraId?`: `string` \| `null`; `speakerId?`: `string` \| `null`; `deviceInfo?`: \{ `make?`: `string`; `model?`: `string`; `firmwareVersion?`: `string`; `directToCloud?`: `boolean`; `serialNumber?`: `string`; `resolution?`: `string`; `type?`: `string`; \}; `shareDetails?`: \{ `shared?`: `boolean`; `accountId?`: `string`; `firstResponder?`: `boolean`; `permissions?`: `string`[]; \}; `streamUrls?`: \{ `hls?`: `string`; `rtsp?`: `string`; `webrtc?`: `string`; `jpeg?`: `string`; \}; `rtspConnectionSettings?`: \{ `url?`: `string`; `username?`: `string`; `password?`: `string`; `transport?`: `"tcp"` \| `"udp"`; \}; `devicePosition?`: \{ `latitude?`: `number`; `longitude?`: `number`; `altitude?`: `number`; `floor?`: `number`; `azimuth?`: `number`; \}; `enabledAnalytics?`: `string`[]; `recordingModes?`: \{ `continuous?`: `boolean`; `motion?`: `boolean`; `scheduled?`: `boolean`; \}; `createdAt?`: `string`; `updatedAt?`: `string`; \} \| `null`, [`Camera`](../interfaces/Camera.md) \| \{ `id`: `string`; `name`: `string`; `accountId`: `string`; `bridgeId?`: `string` \| `null`; `locationId?`: `string` \| `null`; `guid?`: `string`; `macAddress?`: `string`; `ipAddress?`: `string`; `timezone?`: `string`; `status?`: [`CameraStatus`](../type-aliases/CameraStatus.md) \| \{ `connectionStatus?`: CameraStatus \| undefined; \}; `tags?`: `string`[]; `packages?`: `string`[]; `multiCameraId?`: `string` \| `null`; `speakerId?`: `string` \| `null`; `deviceInfo?`: \{ `make?`: `string`; `model?`: `string`; `firmwareVersion?`: `string`; `directToCloud?`: `boolean`; `serialNumber?`: `string`; `resolution?`: `string`; `type?`: `string`; \}; `shareDetails?`: \{ `shared?`: `boolean`; `accountId?`: `string`; `firstResponder?`: `boolean`; `permissions?`: `string`[]; \}; `streamUrls?`: \{ `hls?`: `string`; `rtsp?`: `string`; `webrtc?`: `string`; `jpeg?`: `string`; \}; `rtspConnectionSettings?`: \{ `url?`: `string`; `username?`: `string`; `password?`: `string`; `transport?`: `"tcp"` \| `"udp"`; \}; `devicePosition?`: \{ `latitude?`: `number`; `longitude?`: `number`; `altitude?`: `number`; `floor?`: `number`; `azimuth?`: `number`; \}; `enabledAnalytics?`: `string`[]; `recordingModes?`: \{ `continuous?`: `boolean`; `motion?`: `boolean`; `scheduled?`: `boolean`; \}; `createdAt?`: `string`; `updatedAt?`: `string`; \} \| `null`\>
 
 The camera, or null if not loaded
 
@@ -106,7 +106,7 @@ const { camera: routeCamera } = useCamera(() => route.params.id as string)
 ```typescript
 // With additional fields
 const { camera } = useCamera('camera-123', {
-  include: ['deviceInfo', 'streamUrls']
+  include: ['deviceInfo', 'status', 'shareDetails']
 })
 
 // Access device info when loaded

--- a/docs/api/functions/useCamera.md
+++ b/docs/api/functions/useCamera.md
@@ -1,0 +1,118 @@
+[**EEN API Toolkit v0.0.13**](../README.md)
+
+***
+
+[EEN API Toolkit](../README.md) / useCamera
+
+# Function: useCamera()
+
+> **useCamera**(`cameraId`, `options?`): `object`
+
+Defined in: src/cameras/composables.ts:231
+
+Vue 3 composable for getting a single camera by ID.
+
+## Parameters
+
+### cameraId
+
+The camera ID (string or getter function)
+
+`string` | () => `string`
+
+### options?
+
+[`UseCameraOptions`](../interfaces/UseCameraOptions.md)
+
+Configuration options
+
+## Returns
+
+Reactive camera state and control functions
+
+### camera
+
+> **camera**: `Ref`\<\{ `id`: `string`; `name`: `string`; `accountId`: `string`; `bridgeId?`: `string` \| `null`; `locationId?`: `string` \| `null`; `guid?`: `string`; `macAddress?`: `string`; `ipAddress?`: `string`; `timezone?`: `string`; `status?`: [`CameraStatus`](../type-aliases/CameraStatus.md); `tags?`: `string`[]; `packages?`: `string`[]; `multiCameraId?`: `string` \| `null`; `speakerId?`: `string` \| `null`; `deviceInfo?`: \{ `make?`: `string`; `model?`: `string`; `firmwareVersion?`: `string`; `directToCloud?`: `boolean`; `serialNumber?`: `string`; `resolution?`: `string`; `type?`: `string`; \}; `shareDetails?`: \{ `shared?`: `boolean`; `accountId?`: `string`; `firstResponder?`: `boolean`; `permissions?`: `string`[]; \}; `streamUrls?`: \{ `hls?`: `string`; `rtsp?`: `string`; `webrtc?`: `string`; `jpeg?`: `string`; \}; `rtspConnectionSettings?`: \{ `url?`: `string`; `username?`: `string`; `password?`: `string`; `transport?`: `"tcp"` \| `"udp"`; \}; `devicePosition?`: \{ `latitude?`: `number`; `longitude?`: `number`; `altitude?`: `number`; `floor?`: `number`; `azimuth?`: `number`; \}; `enabledAnalytics?`: `string`[]; `recordingModes?`: \{ `continuous?`: `boolean`; `motion?`: `boolean`; `scheduled?`: `boolean`; \}; `createdAt?`: `string`; `updatedAt?`: `string`; \} \| `null`, [`Camera`](../interfaces/Camera.md) \| \{ `id`: `string`; `name`: `string`; `accountId`: `string`; `bridgeId?`: `string` \| `null`; `locationId?`: `string` \| `null`; `guid?`: `string`; `macAddress?`: `string`; `ipAddress?`: `string`; `timezone?`: `string`; `status?`: [`CameraStatus`](../type-aliases/CameraStatus.md); `tags?`: `string`[]; `packages?`: `string`[]; `multiCameraId?`: `string` \| `null`; `speakerId?`: `string` \| `null`; `deviceInfo?`: \{ `make?`: `string`; `model?`: `string`; `firmwareVersion?`: `string`; `directToCloud?`: `boolean`; `serialNumber?`: `string`; `resolution?`: `string`; `type?`: `string`; \}; `shareDetails?`: \{ `shared?`: `boolean`; `accountId?`: `string`; `firstResponder?`: `boolean`; `permissions?`: `string`[]; \}; `streamUrls?`: \{ `hls?`: `string`; `rtsp?`: `string`; `webrtc?`: `string`; `jpeg?`: `string`; \}; `rtspConnectionSettings?`: \{ `url?`: `string`; `username?`: `string`; `password?`: `string`; `transport?`: `"tcp"` \| `"udp"`; \}; `devicePosition?`: \{ `latitude?`: `number`; `longitude?`: `number`; `altitude?`: `number`; `floor?`: `number`; `azimuth?`: `number`; \}; `enabledAnalytics?`: `string`[]; `recordingModes?`: \{ `continuous?`: `boolean`; `motion?`: `boolean`; `scheduled?`: `boolean`; \}; `createdAt?`: `string`; `updatedAt?`: `string`; \} \| `null`\>
+
+The camera, or null if not loaded
+
+### loading
+
+> **loading**: `Ref`\<`boolean`, `boolean`\>
+
+Whether a fetch is in progress
+
+### error
+
+> **error**: `Ref`\<\{ `code`: [`ErrorCode`](../type-aliases/ErrorCode.md); `message`: `string`; `status?`: `number`; `details?`: `unknown`; \} \| `null`, [`EenError`](../interfaces/EenError.md) \| \{ `code`: [`ErrorCode`](../type-aliases/ErrorCode.md); `message`: `string`; `status?`: `number`; `details?`: `unknown`; \} \| `null`\>
+
+The last error that occurred, or null if successful
+
+### fetch()
+
+> **fetch**: (`params?`) => `Promise`\<[`Result`](../type-aliases/Result.md)\<[`Camera`](../interfaces/Camera.md)\>\>
+
+#### Parameters
+
+##### params?
+
+[`GetCameraParams`](../interfaces/GetCameraParams.md)
+
+#### Returns
+
+`Promise`\<[`Result`](../type-aliases/Result.md)\<[`Camera`](../interfaces/Camera.md)\>\>
+
+### refresh()
+
+> **refresh**: () => `Promise`\<[`Result`](../type-aliases/Result.md)\<[`Camera`](../interfaces/Camera.md)\>\>
+
+Refresh the camera data
+
+#### Returns
+
+`Promise`\<[`Result`](../type-aliases/Result.md)\<[`Camera`](../interfaces/Camera.md)\>\>
+
+## Remarks
+
+Provides reactive access to a specific camera. The camera ID can be provided
+as a string or a getter function (useful for reactive route params).
+
+## Examples
+
+```vue
+<script setup>
+import { useCamera } from 'een-api-toolkit'
+import { useRoute } from 'vue-router'
+
+const route = useRoute()
+
+// Static ID
+const { camera, loading, error } = useCamera('camera-123')
+
+// Or reactive ID from route
+const { camera: routeCamera } = useCamera(() => route.params.id as string)
+</script>
+
+<template>
+  <div v-if="loading">Loading...</div>
+  <div v-else-if="error">Error: {{ error.message }}</div>
+  <div v-else-if="camera">
+    <h1>{{ camera.name }}</h1>
+    <p>Status: {{ camera.status }}</p>
+  </div>
+</template>
+```
+
+```typescript
+// With additional fields
+const { camera } = useCamera('camera-123', {
+  include: ['deviceInfo', 'streamUrls']
+})
+
+// Access device info when loaded
+watchEffect(() => {
+  if (camera.value?.deviceInfo) {
+    console.log('Camera make:', camera.value.deviceInfo.make)
+  }
+})
+```

--- a/docs/api/functions/useCamera.md
+++ b/docs/api/functions/useCamera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/functions/useCameras.md
+++ b/docs/api/functions/useCameras.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **useCameras**(`initialParams?`, `options?`): `object`
 
-Defined in: src/cameras/composables.ts:72
+Defined in: [src/cameras/composables.ts:72](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/cameras/composables.ts#L72)
 
 Vue 3 composable for listing cameras with pagination.
 

--- a/docs/api/functions/useCameras.md
+++ b/docs/api/functions/useCameras.md
@@ -1,0 +1,191 @@
+[**EEN API Toolkit v0.0.13**](../README.md)
+
+***
+
+[EEN API Toolkit](../README.md) / useCameras
+
+# Function: useCameras()
+
+> **useCameras**(`initialParams?`, `options?`): `object`
+
+Defined in: src/cameras/composables.ts:72
+
+Vue 3 composable for listing cameras with pagination.
+
+## Parameters
+
+### initialParams?
+
+[`ListCamerasParams`](../interfaces/ListCamerasParams.md)
+
+Initial pagination/filter parameters
+
+### options?
+
+[`UseCamerasOptions`](../interfaces/UseCamerasOptions.md)
+
+Configuration options
+
+## Returns
+
+Reactive cameras state and pagination controls
+
+### cameras
+
+> **cameras**: `Ref`\<`object`[], [`Camera`](../interfaces/Camera.md)[] \| `object`[]\>
+
+Array of cameras for the current page
+
+### loading
+
+> **loading**: `Ref`\<`boolean`, `boolean`\>
+
+Whether a fetch is in progress
+
+### error
+
+> **error**: `Ref`\<\{ `code`: [`ErrorCode`](../type-aliases/ErrorCode.md); `message`: `string`; `status?`: `number`; `details?`: `unknown`; \} \| `null`, [`EenError`](../interfaces/EenError.md) \| \{ `code`: [`ErrorCode`](../type-aliases/ErrorCode.md); `message`: `string`; `status?`: `number`; `details?`: `unknown`; \} \| `null`\>
+
+The last error that occurred, or null if successful
+
+### nextPageToken
+
+> **nextPageToken**: `Ref`\<`string` \| `undefined`, `string` \| `undefined`\>
+
+Token for fetching the next page
+
+### prevPageToken
+
+> **prevPageToken**: `Ref`\<`string` \| `undefined`, `string` \| `undefined`\>
+
+Token for fetching the previous page
+
+### totalSize
+
+> **totalSize**: `Ref`\<`number` \| `undefined`, `number` \| `undefined`\>
+
+Total number of cameras (if provided by API)
+
+### hasNextPage
+
+> **hasNextPage**: `ComputedRef`\<`boolean`\>
+
+Whether there is a next page available
+
+### hasPrevPage
+
+> **hasPrevPage**: `ComputedRef`\<`boolean`\>
+
+Whether there is a previous page available
+
+### params
+
+> **params**: `Ref`\<\{ `pageSize?`: `number`; `pageToken?`: `string`; `include?`: `string`[]; `sort?`: `string`[]; `locationId__in?`: `string`[]; `bridgeId__in?`: `string`[]; `multiCameraId?`: `string`; `multiCameraId__ne?`: `string`; `multiCameraId__in?`: `string`[]; `tags__contains?`: `string`[]; `tags__any?`: `string`[]; `packages__contains?`: `string`[]; `name?`: `string`; `name__contains?`: `string`; `name__in?`: `string`[]; `id__in?`: `string`[]; `id__notIn?`: `string`[]; `id__contains?`: `string`; `layoutId?`: `string`; `shared?`: `boolean`; `sharedCameraAccount?`: `string`; `firstResponder?`: `boolean`; `directToCloud?`: `boolean`; `speakerId__in?`: `string`[]; `q?`: `string`; `qRelevance__gte?`: `number`; `enabledAnalytics__contains?`: `string`[]; `status__in?`: [`CameraStatus`](../type-aliases/CameraStatus.md)[]; `status__ne?`: [`CameraStatus`](../type-aliases/CameraStatus.md); \}, [`ListCamerasParams`](../interfaces/ListCamerasParams.md) \| \{ `pageSize?`: `number`; `pageToken?`: `string`; `include?`: `string`[]; `sort?`: `string`[]; `locationId__in?`: `string`[]; `bridgeId__in?`: `string`[]; `multiCameraId?`: `string`; `multiCameraId__ne?`: `string`; `multiCameraId__in?`: `string`[]; `tags__contains?`: `string`[]; `tags__any?`: `string`[]; `packages__contains?`: `string`[]; `name?`: `string`; `name__contains?`: `string`; `name__in?`: `string`[]; `id__in?`: `string`[]; `id__notIn?`: `string`[]; `id__contains?`: `string`; `layoutId?`: `string`; `shared?`: `boolean`; `sharedCameraAccount?`: `string`; `firstResponder?`: `boolean`; `directToCloud?`: `boolean`; `speakerId__in?`: `string`[]; `q?`: `string`; `qRelevance__gte?`: `number`; `enabledAnalytics__contains?`: `string`[]; `status__in?`: [`CameraStatus`](../type-aliases/CameraStatus.md)[]; `status__ne?`: [`CameraStatus`](../type-aliases/CameraStatus.md); \}\>
+
+Current pagination/filter parameters
+
+### fetch()
+
+> **fetch**: (`fetchParams?`) => `Promise`\<[`Result`](../type-aliases/Result.md)\<[`PaginatedResult`](../interfaces/PaginatedResult.md)\<[`Camera`](../interfaces/Camera.md)\>\>\>
+
+#### Parameters
+
+##### fetchParams?
+
+[`ListCamerasParams`](../interfaces/ListCamerasParams.md)
+
+#### Returns
+
+`Promise`\<[`Result`](../type-aliases/Result.md)\<[`PaginatedResult`](../interfaces/PaginatedResult.md)\<[`Camera`](../interfaces/Camera.md)\>\>\>
+
+### refresh()
+
+> **refresh**: () => `Promise`\<[`Result`](../type-aliases/Result.md)\<[`PaginatedResult`](../interfaces/PaginatedResult.md)\<[`Camera`](../interfaces/Camera.md)\>\>\>
+
+Refresh the current page
+
+#### Returns
+
+`Promise`\<[`Result`](../type-aliases/Result.md)\<[`PaginatedResult`](../interfaces/PaginatedResult.md)\<[`Camera`](../interfaces/Camera.md)\>\>\>
+
+### fetchNextPage()
+
+> **fetchNextPage**: () => `Promise`\<[`Result`](../type-aliases/Result.md)\<[`PaginatedResult`](../interfaces/PaginatedResult.md)\<[`Camera`](../interfaces/Camera.md)\>\> \| `undefined`\>
+
+Fetch the next page of results
+
+#### Returns
+
+`Promise`\<[`Result`](../type-aliases/Result.md)\<[`PaginatedResult`](../interfaces/PaginatedResult.md)\<[`Camera`](../interfaces/Camera.md)\>\> \| `undefined`\>
+
+### fetchPrevPage()
+
+> **fetchPrevPage**: () => `Promise`\<[`Result`](../type-aliases/Result.md)\<[`PaginatedResult`](../interfaces/PaginatedResult.md)\<[`Camera`](../interfaces/Camera.md)\>\> \| `undefined`\>
+
+Fetch the previous page of results
+
+#### Returns
+
+`Promise`\<[`Result`](../type-aliases/Result.md)\<[`PaginatedResult`](../interfaces/PaginatedResult.md)\<[`Camera`](../interfaces/Camera.md)\>\> \| `undefined`\>
+
+### setParams()
+
+> **setParams**: (`newParams`) => `void`
+
+Update the pagination/filter parameters
+
+#### Parameters
+
+##### newParams
+
+[`ListCamerasParams`](../interfaces/ListCamerasParams.md)
+
+#### Returns
+
+`void`
+
+## Remarks
+
+Provides reactive access to a paginated list of cameras with built-in
+pagination controls. Automatically fetches on mount unless disabled.
+
+## Examples
+
+```vue
+<script setup>
+import { useCameras } from 'een-api-toolkit'
+
+const {
+  cameras,
+  loading,
+  error,
+  hasNextPage,
+  fetchNextPage,
+  refresh
+} = useCameras({ pageSize: 20, status__in: ['online'] })
+</script>
+
+<template>
+  <div v-if="loading">Loading...</div>
+  <div v-else-if="error">Error: {{ error.message }}</div>
+  <div v-else>
+    <ul>
+      <li v-for="camera in cameras" :key="camera.id">
+        {{ camera.name }} ({{ camera.status }})
+      </li>
+    </ul>
+    <button v-if="hasNextPage" @click="fetchNextPage">Load More</button>
+    <button @click="refresh">Refresh</button>
+  </div>
+</template>
+```
+
+```typescript
+// Change parameters dynamically
+const { cameras, setParams, fetch } = useCameras()
+
+async function filterByStatus(status: string) {
+  setParams({ pageSize: 50, status__in: [status] })
+  await fetch()
+}
+```

--- a/docs/api/functions/useCameras.md
+++ b/docs/api/functions/useCameras.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/functions/useCurrentUser.md
+++ b/docs/api/functions/useCurrentUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 

--- a/docs/api/functions/useCurrentUser.md
+++ b/docs/api/functions/useCurrentUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/functions/useUser.md
+++ b/docs/api/functions/useUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 

--- a/docs/api/functions/useUser.md
+++ b/docs/api/functions/useUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/functions/useUsers.md
+++ b/docs/api/functions/useUsers.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 

--- a/docs/api/functions/useUsers.md
+++ b/docs/api/functions/useUsers.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Camera.md
+++ b/docs/api/interfaces/Camera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: Camera
 
-Defined in: src/types/camera.ts:166
+Defined in: [src/types/camera.ts:166](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L166)
 
 Camera entity from EEN API v3.0.
 
@@ -38,7 +38,7 @@ if (data) {
 
 > **id**: `string`
 
-Defined in: src/types/camera.ts:168
+Defined in: [src/types/camera.ts:168](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L168)
 
 Unique identifier for the camera
 
@@ -48,7 +48,7 @@ Unique identifier for the camera
 
 > **name**: `string`
 
-Defined in: src/types/camera.ts:170
+Defined in: [src/types/camera.ts:170](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L170)
 
 Display name of the camera
 
@@ -58,7 +58,7 @@ Display name of the camera
 
 > **accountId**: `string`
 
-Defined in: src/types/camera.ts:172
+Defined in: [src/types/camera.ts:172](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L172)
 
 ID of the account this camera belongs to
 
@@ -68,7 +68,7 @@ ID of the account this camera belongs to
 
 > `optional` **bridgeId**: `string` \| `null`
 
-Defined in: src/types/camera.ts:174
+Defined in: [src/types/camera.ts:174](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L174)
 
 ID of the bridge this camera is connected to (null for direct-to-cloud)
 
@@ -78,7 +78,7 @@ ID of the bridge this camera is connected to (null for direct-to-cloud)
 
 > `optional` **locationId**: `string` \| `null`
 
-Defined in: src/types/camera.ts:176
+Defined in: [src/types/camera.ts:176](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L176)
 
 ID of the location where the camera is installed
 
@@ -88,7 +88,7 @@ ID of the location where the camera is installed
 
 > `optional` **guid**: `string`
 
-Defined in: src/types/camera.ts:178
+Defined in: [src/types/camera.ts:178](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L178)
 
 Globally unique identifier
 
@@ -98,7 +98,7 @@ Globally unique identifier
 
 > `optional` **macAddress**: `string`
 
-Defined in: src/types/camera.ts:180
+Defined in: [src/types/camera.ts:180](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L180)
 
 MAC address of the camera
 
@@ -108,7 +108,7 @@ MAC address of the camera
 
 > `optional` **ipAddress**: `string`
 
-Defined in: src/types/camera.ts:182
+Defined in: [src/types/camera.ts:182](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L182)
 
 IP address of the camera on the local network
 
@@ -118,7 +118,7 @@ IP address of the camera on the local network
 
 > `optional` **timezone**: `string`
 
-Defined in: src/types/camera.ts:184
+Defined in: [src/types/camera.ts:184](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L184)
 
 Timezone of the camera location (IANA timezone name)
 
@@ -126,11 +126,11 @@ Timezone of the camera location (IANA timezone name)
 
 ### status?
 
-> `optional` **status**: [`CameraStatus`](../type-aliases/CameraStatus.md)
+> `optional` **status**: [`CameraStatus`](../type-aliases/CameraStatus.md) \| \{ `connectionStatus?`: CameraStatus \| undefined; \}
 
-Defined in: src/types/camera.ts:186
+Defined in: [src/types/camera.ts:186](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L186)
 
-Current status of the camera
+Current status of the camera (string or object with connectionStatus)
 
 ***
 
@@ -138,7 +138,7 @@ Current status of the camera
 
 > `optional` **tags**: `string`[]
 
-Defined in: src/types/camera.ts:188
+Defined in: [src/types/camera.ts:188](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L188)
 
 Tags assigned to this camera for organization
 
@@ -148,7 +148,7 @@ Tags assigned to this camera for organization
 
 > `optional` **packages**: `string`[]
 
-Defined in: src/types/camera.ts:190
+Defined in: [src/types/camera.ts:190](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L190)
 
 Feature packages enabled for this camera
 
@@ -158,7 +158,7 @@ Feature packages enabled for this camera
 
 > `optional` **multiCameraId**: `string` \| `null`
 
-Defined in: src/types/camera.ts:192
+Defined in: [src/types/camera.ts:192](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L192)
 
 ID of multi-camera group if part of one
 
@@ -168,7 +168,7 @@ ID of multi-camera group if part of one
 
 > `optional` **speakerId**: `string` \| `null`
 
-Defined in: src/types/camera.ts:194
+Defined in: [src/types/camera.ts:194](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L194)
 
 ID of associated speaker device
 
@@ -178,7 +178,7 @@ ID of associated speaker device
 
 > `optional` **deviceInfo**: [`CameraDeviceInfo`](CameraDeviceInfo.md)
 
-Defined in: src/types/camera.ts:196
+Defined in: [src/types/camera.ts:196](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L196)
 
 Device information (make, model, firmware)
 
@@ -188,7 +188,7 @@ Device information (make, model, firmware)
 
 > `optional` **shareDetails**: [`CameraShareDetails`](CameraShareDetails.md)
 
-Defined in: src/types/camera.ts:198
+Defined in: [src/types/camera.ts:198](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L198)
 
 Share details if camera is shared
 
@@ -198,7 +198,7 @@ Share details if camera is shared
 
 > `optional` **streamUrls**: [`CameraStreamUrls`](CameraStreamUrls.md)
 
-Defined in: src/types/camera.ts:200
+Defined in: [src/types/camera.ts:200](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L200)
 
 Stream URLs for accessing camera media
 
@@ -208,7 +208,7 @@ Stream URLs for accessing camera media
 
 > `optional` **rtspConnectionSettings**: [`CameraRtspConnectionSettings`](CameraRtspConnectionSettings.md)
 
-Defined in: src/types/camera.ts:202
+Defined in: [src/types/camera.ts:202](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L202)
 
 RTSP connection settings
 
@@ -218,7 +218,7 @@ RTSP connection settings
 
 > `optional` **devicePosition**: [`CameraDevicePosition`](CameraDevicePosition.md)
 
-Defined in: src/types/camera.ts:204
+Defined in: [src/types/camera.ts:204](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L204)
 
 Physical position of the camera
 
@@ -228,7 +228,7 @@ Physical position of the camera
 
 > `optional` **enabledAnalytics**: `string`[]
 
-Defined in: src/types/camera.ts:206
+Defined in: [src/types/camera.ts:206](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L206)
 
 List of enabled analytics on this camera
 
@@ -238,7 +238,7 @@ List of enabled analytics on this camera
 
 > `optional` **recordingModes**: [`CameraRecordingModes`](CameraRecordingModes.md)
 
-Defined in: src/types/camera.ts:208
+Defined in: [src/types/camera.ts:208](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L208)
 
 Recording mode settings
 
@@ -248,7 +248,7 @@ Recording mode settings
 
 > `optional` **createdAt**: `string`
 
-Defined in: src/types/camera.ts:210
+Defined in: [src/types/camera.ts:210](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L210)
 
 ISO 8601 timestamp when the camera was created
 
@@ -258,6 +258,6 @@ ISO 8601 timestamp when the camera was created
 
 > `optional` **updatedAt**: `string`
 
-Defined in: src/types/camera.ts:212
+Defined in: [src/types/camera.ts:212](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L212)
 
 ISO 8601 timestamp when the camera was last updated

--- a/docs/api/interfaces/Camera.md
+++ b/docs/api/interfaces/Camera.md
@@ -1,0 +1,263 @@
+[**EEN API Toolkit v0.0.13**](../README.md)
+
+***
+
+[EEN API Toolkit](../README.md) / Camera
+
+# Interface: Camera
+
+Defined in: src/types/camera.ts:166
+
+Camera entity from EEN API v3.0.
+
+## Remarks
+
+Represents a camera in the Eagle Eye Networks platform. Cameras can be
+connected via bridges or directly to the cloud. They have various
+properties including status, device info, and stream URLs.
+
+For more details on camera management, see the
+[EEN API Documentation](https://developer.eagleeyenetworks.com/reference/listcameras).
+
+## Example
+
+```typescript
+import { getCameras, type Camera } from 'een-api-toolkit'
+
+const { data, error } = await getCameras({ status__in: ['online'] })
+if (data) {
+  data.results.forEach((camera: Camera) => {
+    console.log(`${camera.name}: ${camera.status}`)
+  })
+}
+```
+
+## Properties
+
+### id
+
+> **id**: `string`
+
+Defined in: src/types/camera.ts:168
+
+Unique identifier for the camera
+
+***
+
+### name
+
+> **name**: `string`
+
+Defined in: src/types/camera.ts:170
+
+Display name of the camera
+
+***
+
+### accountId
+
+> **accountId**: `string`
+
+Defined in: src/types/camera.ts:172
+
+ID of the account this camera belongs to
+
+***
+
+### bridgeId?
+
+> `optional` **bridgeId**: `string` \| `null`
+
+Defined in: src/types/camera.ts:174
+
+ID of the bridge this camera is connected to (null for direct-to-cloud)
+
+***
+
+### locationId?
+
+> `optional` **locationId**: `string` \| `null`
+
+Defined in: src/types/camera.ts:176
+
+ID of the location where the camera is installed
+
+***
+
+### guid?
+
+> `optional` **guid**: `string`
+
+Defined in: src/types/camera.ts:178
+
+Globally unique identifier
+
+***
+
+### macAddress?
+
+> `optional` **macAddress**: `string`
+
+Defined in: src/types/camera.ts:180
+
+MAC address of the camera
+
+***
+
+### ipAddress?
+
+> `optional` **ipAddress**: `string`
+
+Defined in: src/types/camera.ts:182
+
+IP address of the camera on the local network
+
+***
+
+### timezone?
+
+> `optional` **timezone**: `string`
+
+Defined in: src/types/camera.ts:184
+
+Timezone of the camera location (IANA timezone name)
+
+***
+
+### status?
+
+> `optional` **status**: [`CameraStatus`](../type-aliases/CameraStatus.md)
+
+Defined in: src/types/camera.ts:186
+
+Current status of the camera
+
+***
+
+### tags?
+
+> `optional` **tags**: `string`[]
+
+Defined in: src/types/camera.ts:188
+
+Tags assigned to this camera for organization
+
+***
+
+### packages?
+
+> `optional` **packages**: `string`[]
+
+Defined in: src/types/camera.ts:190
+
+Feature packages enabled for this camera
+
+***
+
+### multiCameraId?
+
+> `optional` **multiCameraId**: `string` \| `null`
+
+Defined in: src/types/camera.ts:192
+
+ID of multi-camera group if part of one
+
+***
+
+### speakerId?
+
+> `optional` **speakerId**: `string` \| `null`
+
+Defined in: src/types/camera.ts:194
+
+ID of associated speaker device
+
+***
+
+### deviceInfo?
+
+> `optional` **deviceInfo**: [`CameraDeviceInfo`](CameraDeviceInfo.md)
+
+Defined in: src/types/camera.ts:196
+
+Device information (make, model, firmware)
+
+***
+
+### shareDetails?
+
+> `optional` **shareDetails**: [`CameraShareDetails`](CameraShareDetails.md)
+
+Defined in: src/types/camera.ts:198
+
+Share details if camera is shared
+
+***
+
+### streamUrls?
+
+> `optional` **streamUrls**: [`CameraStreamUrls`](CameraStreamUrls.md)
+
+Defined in: src/types/camera.ts:200
+
+Stream URLs for accessing camera media
+
+***
+
+### rtspConnectionSettings?
+
+> `optional` **rtspConnectionSettings**: [`CameraRtspConnectionSettings`](CameraRtspConnectionSettings.md)
+
+Defined in: src/types/camera.ts:202
+
+RTSP connection settings
+
+***
+
+### devicePosition?
+
+> `optional` **devicePosition**: [`CameraDevicePosition`](CameraDevicePosition.md)
+
+Defined in: src/types/camera.ts:204
+
+Physical position of the camera
+
+***
+
+### enabledAnalytics?
+
+> `optional` **enabledAnalytics**: `string`[]
+
+Defined in: src/types/camera.ts:206
+
+List of enabled analytics on this camera
+
+***
+
+### recordingModes?
+
+> `optional` **recordingModes**: [`CameraRecordingModes`](CameraRecordingModes.md)
+
+Defined in: src/types/camera.ts:208
+
+Recording mode settings
+
+***
+
+### createdAt?
+
+> `optional` **createdAt**: `string`
+
+Defined in: src/types/camera.ts:210
+
+ISO 8601 timestamp when the camera was created
+
+***
+
+### updatedAt?
+
+> `optional` **updatedAt**: `string`
+
+Defined in: src/types/camera.ts:212
+
+ISO 8601 timestamp when the camera was last updated

--- a/docs/api/interfaces/Camera.md
+++ b/docs/api/interfaces/Camera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDeviceInfo.md
+++ b/docs/api/interfaces/CameraDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: CameraDeviceInfo
 
-Defined in: src/types/camera.ts:29
+Defined in: [src/types/camera.ts:29](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L29)
 
 Device information for a camera.
 
@@ -20,7 +20,7 @@ Contains hardware and firmware details about the physical camera device.
 
 > `optional` **make**: `string`
 
-Defined in: src/types/camera.ts:31
+Defined in: [src/types/camera.ts:31](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L31)
 
 Camera manufacturer (e.g., "Axis", "Hikvision")
 
@@ -30,7 +30,7 @@ Camera manufacturer (e.g., "Axis", "Hikvision")
 
 > `optional` **model**: `string`
 
-Defined in: src/types/camera.ts:33
+Defined in: [src/types/camera.ts:33](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L33)
 
 Camera model
 
@@ -40,7 +40,7 @@ Camera model
 
 > `optional` **firmwareVersion**: `string`
 
-Defined in: src/types/camera.ts:35
+Defined in: [src/types/camera.ts:35](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L35)
 
 Firmware version
 
@@ -50,7 +50,7 @@ Firmware version
 
 > `optional` **directToCloud**: `boolean`
 
-Defined in: src/types/camera.ts:37
+Defined in: [src/types/camera.ts:37](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L37)
 
 Whether camera connects directly to cloud (no bridge)
 
@@ -60,7 +60,7 @@ Whether camera connects directly to cloud (no bridge)
 
 > `optional` **serialNumber**: `string`
 
-Defined in: src/types/camera.ts:39
+Defined in: [src/types/camera.ts:39](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L39)
 
 Serial number
 
@@ -70,7 +70,7 @@ Serial number
 
 > `optional` **resolution**: `string`
 
-Defined in: src/types/camera.ts:41
+Defined in: [src/types/camera.ts:41](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L41)
 
 Resolution capabilities
 
@@ -80,6 +80,6 @@ Resolution capabilities
 
 > `optional` **type**: `string`
 
-Defined in: src/types/camera.ts:43
+Defined in: [src/types/camera.ts:43](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L43)
 
 Camera type (e.g., "IP", "Analog")

--- a/docs/api/interfaces/CameraDeviceInfo.md
+++ b/docs/api/interfaces/CameraDeviceInfo.md
@@ -1,0 +1,85 @@
+[**EEN API Toolkit v0.0.13**](../README.md)
+
+***
+
+[EEN API Toolkit](../README.md) / CameraDeviceInfo
+
+# Interface: CameraDeviceInfo
+
+Defined in: src/types/camera.ts:29
+
+Device information for a camera.
+
+## Remarks
+
+Contains hardware and firmware details about the physical camera device.
+
+## Properties
+
+### make?
+
+> `optional` **make**: `string`
+
+Defined in: src/types/camera.ts:31
+
+Camera manufacturer (e.g., "Axis", "Hikvision")
+
+***
+
+### model?
+
+> `optional` **model**: `string`
+
+Defined in: src/types/camera.ts:33
+
+Camera model
+
+***
+
+### firmwareVersion?
+
+> `optional` **firmwareVersion**: `string`
+
+Defined in: src/types/camera.ts:35
+
+Firmware version
+
+***
+
+### directToCloud?
+
+> `optional` **directToCloud**: `boolean`
+
+Defined in: src/types/camera.ts:37
+
+Whether camera connects directly to cloud (no bridge)
+
+***
+
+### serialNumber?
+
+> `optional` **serialNumber**: `string`
+
+Defined in: src/types/camera.ts:39
+
+Serial number
+
+***
+
+### resolution?
+
+> `optional` **resolution**: `string`
+
+Defined in: src/types/camera.ts:41
+
+Resolution capabilities
+
+***
+
+### type?
+
+> `optional` **type**: `string`
+
+Defined in: src/types/camera.ts:43
+
+Camera type (e.g., "IP", "Analog")

--- a/docs/api/interfaces/CameraDeviceInfo.md
+++ b/docs/api/interfaces/CameraDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDevicePosition.md
+++ b/docs/api/interfaces/CameraDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: CameraDevicePosition
 
-Defined in: src/types/camera.ts:111
+Defined in: [src/types/camera.ts:111](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L111)
 
 Camera position/location data.
 
@@ -20,7 +20,7 @@ Physical location and orientation of the camera.
 
 > `optional` **latitude**: `number`
 
-Defined in: src/types/camera.ts:113
+Defined in: [src/types/camera.ts:113](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L113)
 
 Latitude coordinate
 
@@ -30,7 +30,7 @@ Latitude coordinate
 
 > `optional` **longitude**: `number`
 
-Defined in: src/types/camera.ts:115
+Defined in: [src/types/camera.ts:115](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L115)
 
 Longitude coordinate
 
@@ -40,7 +40,7 @@ Longitude coordinate
 
 > `optional` **altitude**: `number`
 
-Defined in: src/types/camera.ts:117
+Defined in: [src/types/camera.ts:117](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L117)
 
 Altitude in meters
 
@@ -50,7 +50,7 @@ Altitude in meters
 
 > `optional` **floor**: `number`
 
-Defined in: src/types/camera.ts:119
+Defined in: [src/types/camera.ts:119](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L119)
 
 Floor level
 
@@ -60,6 +60,6 @@ Floor level
 
 > `optional` **azimuth**: `number`
 
-Defined in: src/types/camera.ts:121
+Defined in: [src/types/camera.ts:121](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L121)
 
 Direction camera is facing (0-360 degrees)

--- a/docs/api/interfaces/CameraDevicePosition.md
+++ b/docs/api/interfaces/CameraDevicePosition.md
@@ -1,0 +1,65 @@
+[**EEN API Toolkit v0.0.13**](../README.md)
+
+***
+
+[EEN API Toolkit](../README.md) / CameraDevicePosition
+
+# Interface: CameraDevicePosition
+
+Defined in: src/types/camera.ts:111
+
+Camera position/location data.
+
+## Remarks
+
+Physical location and orientation of the camera.
+
+## Properties
+
+### latitude?
+
+> `optional` **latitude**: `number`
+
+Defined in: src/types/camera.ts:113
+
+Latitude coordinate
+
+***
+
+### longitude?
+
+> `optional` **longitude**: `number`
+
+Defined in: src/types/camera.ts:115
+
+Longitude coordinate
+
+***
+
+### altitude?
+
+> `optional` **altitude**: `number`
+
+Defined in: src/types/camera.ts:117
+
+Altitude in meters
+
+***
+
+### floor?
+
+> `optional` **floor**: `number`
+
+Defined in: src/types/camera.ts:119
+
+Floor level
+
+***
+
+### azimuth?
+
+> `optional` **azimuth**: `number`
+
+Defined in: src/types/camera.ts:121
+
+Direction camera is facing (0-360 degrees)

--- a/docs/api/interfaces/CameraDevicePosition.md
+++ b/docs/api/interfaces/CameraDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRecordingModes.md
+++ b/docs/api/interfaces/CameraRecordingModes.md
@@ -1,0 +1,45 @@
+[**EEN API Toolkit v0.0.13**](../README.md)
+
+***
+
+[EEN API Toolkit](../README.md) / CameraRecordingModes
+
+# Interface: CameraRecordingModes
+
+Defined in: src/types/camera.ts:132
+
+Recording modes for a camera.
+
+## Remarks
+
+Indicates which recording modes are enabled for the camera.
+
+## Properties
+
+### continuous?
+
+> `optional` **continuous**: `boolean`
+
+Defined in: src/types/camera.ts:134
+
+Whether continuous recording is enabled
+
+***
+
+### motion?
+
+> `optional` **motion**: `boolean`
+
+Defined in: src/types/camera.ts:136
+
+Whether motion-triggered recording is enabled
+
+***
+
+### scheduled?
+
+> `optional` **scheduled**: `boolean`
+
+Defined in: src/types/camera.ts:138
+
+Whether scheduled recording is enabled

--- a/docs/api/interfaces/CameraRecordingModes.md
+++ b/docs/api/interfaces/CameraRecordingModes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: CameraRecordingModes
 
-Defined in: src/types/camera.ts:132
+Defined in: [src/types/camera.ts:132](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L132)
 
 Recording modes for a camera.
 
@@ -20,7 +20,7 @@ Indicates which recording modes are enabled for the camera.
 
 > `optional` **continuous**: `boolean`
 
-Defined in: src/types/camera.ts:134
+Defined in: [src/types/camera.ts:134](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L134)
 
 Whether continuous recording is enabled
 
@@ -30,7 +30,7 @@ Whether continuous recording is enabled
 
 > `optional` **motion**: `boolean`
 
-Defined in: src/types/camera.ts:136
+Defined in: [src/types/camera.ts:136](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L136)
 
 Whether motion-triggered recording is enabled
 
@@ -40,6 +40,6 @@ Whether motion-triggered recording is enabled
 
 > `optional` **scheduled**: `boolean`
 
-Defined in: src/types/camera.ts:138
+Defined in: [src/types/camera.ts:138](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L138)
 
 Whether scheduled recording is enabled

--- a/docs/api/interfaces/CameraRecordingModes.md
+++ b/docs/api/interfaces/CameraRecordingModes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRtspConnectionSettings.md
+++ b/docs/api/interfaces/CameraRtspConnectionSettings.md
@@ -1,0 +1,55 @@
+[**EEN API Toolkit v0.0.13**](../README.md)
+
+***
+
+[EEN API Toolkit](../README.md) / CameraRtspConnectionSettings
+
+# Interface: CameraRtspConnectionSettings
+
+Defined in: src/types/camera.ts:92
+
+RTSP connection settings for RTSP-based cameras.
+
+## Remarks
+
+Configuration for cameras that connect via RTSP protocol.
+
+## Properties
+
+### url?
+
+> `optional` **url**: `string`
+
+Defined in: src/types/camera.ts:94
+
+RTSP URL for the camera stream
+
+***
+
+### username?
+
+> `optional` **username**: `string`
+
+Defined in: src/types/camera.ts:96
+
+Username for RTSP authentication
+
+***
+
+### password?
+
+> `optional` **password**: `string`
+
+Defined in: src/types/camera.ts:98
+
+Password for RTSP authentication (write-only, not returned in responses)
+
+***
+
+### transport?
+
+> `optional` **transport**: `"tcp"` \| `"udp"`
+
+Defined in: src/types/camera.ts:100
+
+Transport protocol (tcp, udp)

--- a/docs/api/interfaces/CameraRtspConnectionSettings.md
+++ b/docs/api/interfaces/CameraRtspConnectionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: CameraRtspConnectionSettings
 
-Defined in: src/types/camera.ts:92
+Defined in: [src/types/camera.ts:92](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L92)
 
 RTSP connection settings for RTSP-based cameras.
 
@@ -20,7 +20,7 @@ Configuration for cameras that connect via RTSP protocol.
 
 > `optional` **url**: `string`
 
-Defined in: src/types/camera.ts:94
+Defined in: [src/types/camera.ts:94](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L94)
 
 RTSP URL for the camera stream
 
@@ -30,7 +30,7 @@ RTSP URL for the camera stream
 
 > `optional` **username**: `string`
 
-Defined in: src/types/camera.ts:96
+Defined in: [src/types/camera.ts:96](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L96)
 
 Username for RTSP authentication
 
@@ -40,7 +40,7 @@ Username for RTSP authentication
 
 > `optional` **password**: `string`
 
-Defined in: src/types/camera.ts:98
+Defined in: [src/types/camera.ts:98](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L98)
 
 Password for RTSP authentication (write-only, not returned in responses)
 
@@ -50,6 +50,6 @@ Password for RTSP authentication (write-only, not returned in responses)
 
 > `optional` **transport**: `"tcp"` \| `"udp"`
 
-Defined in: src/types/camera.ts:100
+Defined in: [src/types/camera.ts:100](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L100)
 
 Transport protocol (tcp, udp)

--- a/docs/api/interfaces/CameraRtspConnectionSettings.md
+++ b/docs/api/interfaces/CameraRtspConnectionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraShareDetails.md
+++ b/docs/api/interfaces/CameraShareDetails.md
@@ -1,0 +1,55 @@
+[**EEN API Toolkit v0.0.13**](../README.md)
+
+***
+
+[EEN API Toolkit](../README.md) / CameraShareDetails
+
+# Interface: CameraShareDetails
+
+Defined in: src/types/camera.ts:54
+
+Share details for shared cameras.
+
+## Remarks
+
+Contains information about camera sharing between accounts.
+
+## Properties
+
+### shared?
+
+> `optional` **shared**: `boolean`
+
+Defined in: src/types/camera.ts:56
+
+Whether the camera is shared
+
+***
+
+### accountId?
+
+> `optional` **accountId**: `string`
+
+Defined in: src/types/camera.ts:58
+
+Account ID of the sharing account
+
+***
+
+### firstResponder?
+
+> `optional` **firstResponder**: `boolean`
+
+Defined in: src/types/camera.ts:60
+
+Whether shared for first responder access
+
+***
+
+### permissions?
+
+> `optional` **permissions**: `string`[]
+
+Defined in: src/types/camera.ts:62
+
+Permissions granted to the share recipient

--- a/docs/api/interfaces/CameraShareDetails.md
+++ b/docs/api/interfaces/CameraShareDetails.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: CameraShareDetails
 
-Defined in: src/types/camera.ts:54
+Defined in: [src/types/camera.ts:54](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L54)
 
 Share details for shared cameras.
 
@@ -20,7 +20,7 @@ Contains information about camera sharing between accounts.
 
 > `optional` **shared**: `boolean`
 
-Defined in: src/types/camera.ts:56
+Defined in: [src/types/camera.ts:56](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L56)
 
 Whether the camera is shared
 
@@ -30,7 +30,7 @@ Whether the camera is shared
 
 > `optional` **accountId**: `string`
 
-Defined in: src/types/camera.ts:58
+Defined in: [src/types/camera.ts:58](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L58)
 
 Account ID of the sharing account
 
@@ -40,7 +40,7 @@ Account ID of the sharing account
 
 > `optional` **firstResponder**: `boolean`
 
-Defined in: src/types/camera.ts:60
+Defined in: [src/types/camera.ts:60](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L60)
 
 Whether shared for first responder access
 
@@ -50,6 +50,6 @@ Whether shared for first responder access
 
 > `optional` **permissions**: `string`[]
 
-Defined in: src/types/camera.ts:62
+Defined in: [src/types/camera.ts:62](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L62)
 
 Permissions granted to the share recipient

--- a/docs/api/interfaces/CameraShareDetails.md
+++ b/docs/api/interfaces/CameraShareDetails.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStreamUrls.md
+++ b/docs/api/interfaces/CameraStreamUrls.md
@@ -1,0 +1,55 @@
+[**EEN API Toolkit v0.0.13**](../README.md)
+
+***
+
+[EEN API Toolkit](../README.md) / CameraStreamUrls
+
+# Interface: CameraStreamUrls
+
+Defined in: src/types/camera.ts:73
+
+Stream URLs for camera media.
+
+## Remarks
+
+Contains URLs for accessing various camera stream formats.
+
+## Properties
+
+### hls?
+
+> `optional` **hls**: `string`
+
+Defined in: src/types/camera.ts:75
+
+HLS stream URL
+
+***
+
+### rtsp?
+
+> `optional` **rtsp**: `string`
+
+Defined in: src/types/camera.ts:77
+
+RTSP stream URL
+
+***
+
+### webrtc?
+
+> `optional` **webrtc**: `string`
+
+Defined in: src/types/camera.ts:79
+
+WebRTC stream URL
+
+***
+
+### jpeg?
+
+> `optional` **jpeg**: `string`
+
+Defined in: src/types/camera.ts:81
+
+JPEG snapshot URL

--- a/docs/api/interfaces/CameraStreamUrls.md
+++ b/docs/api/interfaces/CameraStreamUrls.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: CameraStreamUrls
 
-Defined in: src/types/camera.ts:73
+Defined in: [src/types/camera.ts:73](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L73)
 
 Stream URLs for camera media.
 
@@ -20,7 +20,7 @@ Contains URLs for accessing various camera stream formats.
 
 > `optional` **hls**: `string`
 
-Defined in: src/types/camera.ts:75
+Defined in: [src/types/camera.ts:75](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L75)
 
 HLS stream URL
 
@@ -30,7 +30,7 @@ HLS stream URL
 
 > `optional` **rtsp**: `string`
 
-Defined in: src/types/camera.ts:77
+Defined in: [src/types/camera.ts:77](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L77)
 
 RTSP stream URL
 
@@ -40,7 +40,7 @@ RTSP stream URL
 
 > `optional` **webrtc**: `string`
 
-Defined in: src/types/camera.ts:79
+Defined in: [src/types/camera.ts:79](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L79)
 
 WebRTC stream URL
 
@@ -50,6 +50,6 @@ WebRTC stream URL
 
 > `optional` **jpeg**: `string`
 
-Defined in: src/types/camera.ts:81
+Defined in: [src/types/camera.ts:81](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L81)
 
 JPEG snapshot URL

--- a/docs/api/interfaces/CameraStreamUrls.md
+++ b/docs/api/interfaces/CameraStreamUrls.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenError.md
+++ b/docs/api/interfaces/EenError.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenError.md
+++ b/docs/api/interfaces/EenError.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenToolkitConfig.md
+++ b/docs/api/interfaces/EenToolkitConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenToolkitConfig.md
+++ b/docs/api/interfaces/EenToolkitConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetCameraParams.md
+++ b/docs/api/interfaces/GetCameraParams.md
@@ -1,0 +1,43 @@
+[**EEN API Toolkit v0.0.13**](../README.md)
+
+***
+
+[EEN API Toolkit](../README.md) / GetCameraParams
+
+# Interface: GetCameraParams
+
+Defined in: src/types/camera.ts:359
+
+Parameters for getting a single camera.
+
+## Remarks
+
+Valid include values: bridge, account, status, locationSummary, deviceAddress,
+timeZone, notes, tags, devicePosition, networkInfo, deviceInfo, effectivePermissions,
+firmware, shareDetails, visibleByBridges, capabilities, analog, packages,
+dewarpConfig, adminCredentials, publicSafetySharing, enabledAnalytics
+
+## Example
+
+```typescript
+import { getCamera } from 'een-api-toolkit'
+
+const { data } = await getCamera('camera-123', {
+  include: ['deviceInfo', 'status', 'shareDetails']
+})
+```
+
+## Properties
+
+### include?
+
+> `optional` **include**: `string`[]
+
+Defined in: src/types/camera.ts:368
+
+Additional fields to include in the response.
+Valid values: bridge, account, status, locationSummary, deviceAddress,
+timeZone, notes, tags, devicePosition, networkInfo, deviceInfo,
+effectivePermissions, firmware, shareDetails, visibleByBridges,
+capabilities, analog, packages, dewarpConfig, adminCredentials,
+publicSafetySharing, enabledAnalytics

--- a/docs/api/interfaces/GetCameraParams.md
+++ b/docs/api/interfaces/GetCameraParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: GetCameraParams
 
-Defined in: src/types/camera.ts:359
+Defined in: [src/types/camera.ts:359](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L359)
 
 Parameters for getting a single camera.
 
@@ -33,7 +33,7 @@ const { data } = await getCamera('camera-123', {
 
 > `optional` **include**: `string`[]
 
-Defined in: src/types/camera.ts:368
+Defined in: [src/types/camera.ts:368](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L368)
 
 Additional fields to include in the response.
 Valid values: bridge, account, status, locationSummary, deviceAddress,

--- a/docs/api/interfaces/GetCameraParams.md
+++ b/docs/api/interfaces/GetCameraParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetUserParams.md
+++ b/docs/api/interfaces/GetUserParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetUserParams.md
+++ b/docs/api/interfaces/GetUserParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListCamerasParams.md
+++ b/docs/api/interfaces/ListCamerasParams.md
@@ -1,0 +1,334 @@
+[**EEN API Toolkit v0.0.13**](../README.md)
+
+***
+
+[EEN API Toolkit](../README.md) / ListCamerasParams
+
+# Interface: ListCamerasParams
+
+Defined in: src/types/camera.ts:251
+
+Parameters for listing cameras.
+
+## Remarks
+
+Supports extensive filtering options matching the EEN API v3.0.
+All array parameters are sent as comma-separated values.
+
+For more details, see the
+[EEN API Documentation](https://developer.eagleeyenetworks.com/reference/listcameras).
+
+## Example
+
+```typescript
+import { getCameras } from 'een-api-toolkit'
+
+// Get online cameras with pagination
+const { data } = await getCameras({
+  pageSize: 50,
+  status__in: ['online', 'streaming'],
+  include: ['deviceInfo', 'streamUrls']
+})
+
+// Search cameras by name
+const { data: searchResults } = await getCameras({
+  q: 'front door',
+  qRelevance__gte: 0.5
+})
+
+// Filter by location and tags
+const { data: filtered } = await getCameras({
+  locationId__in: ['loc-123'],
+  tags__contains: ['security', 'entrance']
+})
+```
+
+## Properties
+
+### pageSize?
+
+> `optional` **pageSize**: `number`
+
+Defined in: src/types/camera.ts:254
+
+Number of results per page (default: 100, max: 1000)
+
+***
+
+### pageToken?
+
+> `optional` **pageToken**: `string`
+
+Defined in: src/types/camera.ts:256
+
+Token for fetching a specific page
+
+***
+
+### include?
+
+> `optional` **include**: `string`[]
+
+Defined in: src/types/camera.ts:260
+
+Additional fields to include in the response
+
+***
+
+### sort?
+
+> `optional` **sort**: `string`[]
+
+Defined in: src/types/camera.ts:262
+
+Fields to sort by (prefix with - for descending)
+
+***
+
+### locationId\_\_in?
+
+> `optional` **locationId\_\_in**: `string`[]
+
+Defined in: src/types/camera.ts:266
+
+Filter by location IDs
+
+***
+
+### bridgeId\_\_in?
+
+> `optional` **bridgeId\_\_in**: `string`[]
+
+Defined in: src/types/camera.ts:268
+
+Filter by bridge IDs
+
+***
+
+### multiCameraId?
+
+> `optional` **multiCameraId**: `string`
+
+Defined in: src/types/camera.ts:272
+
+Filter by exact multi-camera ID
+
+***
+
+### multiCameraId\_\_ne?
+
+> `optional` **multiCameraId\_\_ne**: `string`
+
+Defined in: src/types/camera.ts:274
+
+Filter by multi-camera ID not equal to
+
+***
+
+### multiCameraId\_\_in?
+
+> `optional` **multiCameraId\_\_in**: `string`[]
+
+Defined in: src/types/camera.ts:276
+
+Filter by multi-camera IDs (any match)
+
+***
+
+### tags\_\_contains?
+
+> `optional` **tags\_\_contains**: `string`[]
+
+Defined in: src/types/camera.ts:280
+
+Filter by tags (all tags must be present)
+
+***
+
+### tags\_\_any?
+
+> `optional` **tags\_\_any**: `string`[]
+
+Defined in: src/types/camera.ts:282
+
+Filter by tags (any tag must be present)
+
+***
+
+### packages\_\_contains?
+
+> `optional` **packages\_\_contains**: `string`[]
+
+Defined in: src/types/camera.ts:284
+
+Filter by packages (all must be present)
+
+***
+
+### name?
+
+> `optional` **name**: `string`
+
+Defined in: src/types/camera.ts:288
+
+Filter by exact name
+
+***
+
+### name\_\_contains?
+
+> `optional` **name\_\_contains**: `string`
+
+Defined in: src/types/camera.ts:290
+
+Filter by name containing substring (case-insensitive)
+
+***
+
+### name\_\_in?
+
+> `optional` **name\_\_in**: `string`[]
+
+Defined in: src/types/camera.ts:292
+
+Filter by exact names (any match)
+
+***
+
+### id\_\_in?
+
+> `optional` **id\_\_in**: `string`[]
+
+Defined in: src/types/camera.ts:296
+
+Filter by camera IDs
+
+***
+
+### id\_\_notIn?
+
+> `optional` **id\_\_notIn**: `string`[]
+
+Defined in: src/types/camera.ts:298
+
+Exclude camera IDs
+
+***
+
+### id\_\_contains?
+
+> `optional` **id\_\_contains**: `string`
+
+Defined in: src/types/camera.ts:300
+
+Filter by ID containing substring
+
+***
+
+### layoutId?
+
+> `optional` **layoutId**: `string`
+
+Defined in: src/types/camera.ts:304
+
+Filter by layout ID
+
+***
+
+### shared?
+
+> `optional` **shared**: `boolean`
+
+Defined in: src/types/camera.ts:308
+
+Filter by shared status
+
+***
+
+### sharedCameraAccount?
+
+> `optional` **sharedCameraAccount**: `string`
+
+Defined in: src/types/camera.ts:310
+
+Filter by sharing account ID
+
+***
+
+### firstResponder?
+
+> `optional` **firstResponder**: `boolean`
+
+Defined in: src/types/camera.ts:312
+
+Filter by first responder sharing
+
+***
+
+### directToCloud?
+
+> `optional` **directToCloud**: `boolean`
+
+Defined in: src/types/camera.ts:316
+
+Filter by direct-to-cloud connection
+
+***
+
+### speakerId\_\_in?
+
+> `optional` **speakerId\_\_in**: `string`[]
+
+Defined in: src/types/camera.ts:320
+
+Filter by speaker IDs
+
+***
+
+### q?
+
+> `optional` **q**: `string`
+
+Defined in: src/types/camera.ts:324
+
+Full-text search query
+
+***
+
+### qRelevance\_\_gte?
+
+> `optional` **qRelevance\_\_gte**: `number`
+
+Defined in: src/types/camera.ts:326
+
+Minimum search relevance score
+
+***
+
+### enabledAnalytics\_\_contains?
+
+> `optional` **enabledAnalytics\_\_contains**: `string`[]
+
+Defined in: src/types/camera.ts:330
+
+Filter by enabled analytics (all must be present)
+
+***
+
+### status\_\_in?
+
+> `optional` **status\_\_in**: [`CameraStatus`](../type-aliases/CameraStatus.md)[]
+
+Defined in: src/types/camera.ts:334
+
+Filter by status values (any match)
+
+***
+
+### status\_\_ne?
+
+> `optional` **status\_\_ne**: [`CameraStatus`](../type-aliases/CameraStatus.md)
+
+Defined in: src/types/camera.ts:336
+
+Filter by status not equal to

--- a/docs/api/interfaces/ListCamerasParams.md
+++ b/docs/api/interfaces/ListCamerasParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: ListCamerasParams
 
-Defined in: src/types/camera.ts:251
+Defined in: [src/types/camera.ts:251](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L251)
 
 Parameters for listing cameras.
 
@@ -49,7 +49,7 @@ const { data: filtered } = await getCameras({
 
 > `optional` **pageSize**: `number`
 
-Defined in: src/types/camera.ts:254
+Defined in: [src/types/camera.ts:254](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L254)
 
 Number of results per page (default: 100, max: 1000)
 
@@ -59,7 +59,7 @@ Number of results per page (default: 100, max: 1000)
 
 > `optional` **pageToken**: `string`
 
-Defined in: src/types/camera.ts:256
+Defined in: [src/types/camera.ts:256](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L256)
 
 Token for fetching a specific page
 
@@ -69,7 +69,7 @@ Token for fetching a specific page
 
 > `optional` **include**: `string`[]
 
-Defined in: src/types/camera.ts:260
+Defined in: [src/types/camera.ts:260](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L260)
 
 Additional fields to include in the response
 
@@ -79,7 +79,7 @@ Additional fields to include in the response
 
 > `optional` **sort**: `string`[]
 
-Defined in: src/types/camera.ts:262
+Defined in: [src/types/camera.ts:262](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L262)
 
 Fields to sort by (prefix with - for descending)
 
@@ -89,7 +89,7 @@ Fields to sort by (prefix with - for descending)
 
 > `optional` **locationId\_\_in**: `string`[]
 
-Defined in: src/types/camera.ts:266
+Defined in: [src/types/camera.ts:266](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L266)
 
 Filter by location IDs
 
@@ -99,7 +99,7 @@ Filter by location IDs
 
 > `optional` **bridgeId\_\_in**: `string`[]
 
-Defined in: src/types/camera.ts:268
+Defined in: [src/types/camera.ts:268](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L268)
 
 Filter by bridge IDs
 
@@ -109,7 +109,7 @@ Filter by bridge IDs
 
 > `optional` **multiCameraId**: `string`
 
-Defined in: src/types/camera.ts:272
+Defined in: [src/types/camera.ts:272](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L272)
 
 Filter by exact multi-camera ID
 
@@ -119,7 +119,7 @@ Filter by exact multi-camera ID
 
 > `optional` **multiCameraId\_\_ne**: `string`
 
-Defined in: src/types/camera.ts:274
+Defined in: [src/types/camera.ts:274](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L274)
 
 Filter by multi-camera ID not equal to
 
@@ -129,7 +129,7 @@ Filter by multi-camera ID not equal to
 
 > `optional` **multiCameraId\_\_in**: `string`[]
 
-Defined in: src/types/camera.ts:276
+Defined in: [src/types/camera.ts:276](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L276)
 
 Filter by multi-camera IDs (any match)
 
@@ -139,7 +139,7 @@ Filter by multi-camera IDs (any match)
 
 > `optional` **tags\_\_contains**: `string`[]
 
-Defined in: src/types/camera.ts:280
+Defined in: [src/types/camera.ts:280](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L280)
 
 Filter by tags (all tags must be present)
 
@@ -149,7 +149,7 @@ Filter by tags (all tags must be present)
 
 > `optional` **tags\_\_any**: `string`[]
 
-Defined in: src/types/camera.ts:282
+Defined in: [src/types/camera.ts:282](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L282)
 
 Filter by tags (any tag must be present)
 
@@ -159,7 +159,7 @@ Filter by tags (any tag must be present)
 
 > `optional` **packages\_\_contains**: `string`[]
 
-Defined in: src/types/camera.ts:284
+Defined in: [src/types/camera.ts:284](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L284)
 
 Filter by packages (all must be present)
 
@@ -169,7 +169,7 @@ Filter by packages (all must be present)
 
 > `optional` **name**: `string`
 
-Defined in: src/types/camera.ts:288
+Defined in: [src/types/camera.ts:288](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L288)
 
 Filter by exact name
 
@@ -179,7 +179,7 @@ Filter by exact name
 
 > `optional` **name\_\_contains**: `string`
 
-Defined in: src/types/camera.ts:290
+Defined in: [src/types/camera.ts:290](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L290)
 
 Filter by name containing substring (case-insensitive)
 
@@ -189,7 +189,7 @@ Filter by name containing substring (case-insensitive)
 
 > `optional` **name\_\_in**: `string`[]
 
-Defined in: src/types/camera.ts:292
+Defined in: [src/types/camera.ts:292](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L292)
 
 Filter by exact names (any match)
 
@@ -199,7 +199,7 @@ Filter by exact names (any match)
 
 > `optional` **id\_\_in**: `string`[]
 
-Defined in: src/types/camera.ts:296
+Defined in: [src/types/camera.ts:296](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L296)
 
 Filter by camera IDs
 
@@ -209,7 +209,7 @@ Filter by camera IDs
 
 > `optional` **id\_\_notIn**: `string`[]
 
-Defined in: src/types/camera.ts:298
+Defined in: [src/types/camera.ts:298](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L298)
 
 Exclude camera IDs
 
@@ -219,7 +219,7 @@ Exclude camera IDs
 
 > `optional` **id\_\_contains**: `string`
 
-Defined in: src/types/camera.ts:300
+Defined in: [src/types/camera.ts:300](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L300)
 
 Filter by ID containing substring
 
@@ -229,7 +229,7 @@ Filter by ID containing substring
 
 > `optional` **layoutId**: `string`
 
-Defined in: src/types/camera.ts:304
+Defined in: [src/types/camera.ts:304](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L304)
 
 Filter by layout ID
 
@@ -239,9 +239,9 @@ Filter by layout ID
 
 > `optional` **shared**: `boolean`
 
-Defined in: src/types/camera.ts:308
+Defined in: [src/types/camera.ts:308](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L308)
 
-Filter by shared status
+Filter by shared status. Maps to `shareDetails.shared` in the API query.
 
 ***
 
@@ -249,9 +249,9 @@ Filter by shared status
 
 > `optional` **sharedCameraAccount**: `string`
 
-Defined in: src/types/camera.ts:310
+Defined in: [src/types/camera.ts:310](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L310)
 
-Filter by sharing account ID
+Filter by sharing account ID. Maps to `shareDetails.accountId` in the API query.
 
 ***
 
@@ -259,9 +259,9 @@ Filter by sharing account ID
 
 > `optional` **firstResponder**: `boolean`
 
-Defined in: src/types/camera.ts:312
+Defined in: [src/types/camera.ts:312](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L312)
 
-Filter by first responder sharing
+Filter by first responder sharing. Maps to `shareDetails.firstResponder` in the API query.
 
 ***
 
@@ -269,9 +269,9 @@ Filter by first responder sharing
 
 > `optional` **directToCloud**: `boolean`
 
-Defined in: src/types/camera.ts:316
+Defined in: [src/types/camera.ts:316](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L316)
 
-Filter by direct-to-cloud connection
+Filter by direct-to-cloud connection. Maps to `deviceInfo.directToCloud` in the API query.
 
 ***
 
@@ -279,7 +279,7 @@ Filter by direct-to-cloud connection
 
 > `optional` **speakerId\_\_in**: `string`[]
 
-Defined in: src/types/camera.ts:320
+Defined in: [src/types/camera.ts:320](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L320)
 
 Filter by speaker IDs
 
@@ -289,7 +289,7 @@ Filter by speaker IDs
 
 > `optional` **q**: `string`
 
-Defined in: src/types/camera.ts:324
+Defined in: [src/types/camera.ts:324](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L324)
 
 Full-text search query
 
@@ -299,7 +299,7 @@ Full-text search query
 
 > `optional` **qRelevance\_\_gte**: `number`
 
-Defined in: src/types/camera.ts:326
+Defined in: [src/types/camera.ts:326](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L326)
 
 Minimum search relevance score
 
@@ -309,7 +309,7 @@ Minimum search relevance score
 
 > `optional` **enabledAnalytics\_\_contains**: `string`[]
 
-Defined in: src/types/camera.ts:330
+Defined in: [src/types/camera.ts:330](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L330)
 
 Filter by enabled analytics (all must be present)
 
@@ -319,7 +319,7 @@ Filter by enabled analytics (all must be present)
 
 > `optional` **status\_\_in**: [`CameraStatus`](../type-aliases/CameraStatus.md)[]
 
-Defined in: src/types/camera.ts:334
+Defined in: [src/types/camera.ts:334](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L334)
 
 Filter by status values (any match)
 
@@ -329,6 +329,6 @@ Filter by status values (any match)
 
 > `optional` **status\_\_ne**: [`CameraStatus`](../type-aliases/CameraStatus.md)
 
-Defined in: src/types/camera.ts:336
+Defined in: [src/types/camera.ts:336](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L336)
 
 Filter by status not equal to

--- a/docs/api/interfaces/ListCamerasParams.md
+++ b/docs/api/interfaces/ListCamerasParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListUsersParams.md
+++ b/docs/api/interfaces/ListUsersParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListUsersParams.md
+++ b/docs/api/interfaces/ListUsersParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginatedResult.md
+++ b/docs/api/interfaces/PaginatedResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginatedResult.md
+++ b/docs/api/interfaces/PaginatedResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginationParams.md
+++ b/docs/api/interfaces/PaginationParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginationParams.md
+++ b/docs/api/interfaces/PaginationParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/TokenResponse.md
+++ b/docs/api/interfaces/TokenResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/TokenResponse.md
+++ b/docs/api/interfaces/TokenResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UseCameraOptions.md
+++ b/docs/api/interfaces/UseCameraOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: UseCameraOptions
 
-Defined in: src/cameras/composables.ts:166
+Defined in: [src/cameras/composables.ts:166](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/cameras/composables.ts#L166)
 
 Options for the useCamera composable.
 
@@ -16,7 +16,7 @@ Options for the useCamera composable.
 
 > `optional` **immediate**: `boolean`
 
-Defined in: src/cameras/composables.ts:171
+Defined in: [src/cameras/composables.ts:171](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/cameras/composables.ts#L171)
 
 Whether to fetch the camera immediately on mount.
 
@@ -32,6 +32,6 @@ true
 
 > `optional` **include**: `string`[]
 
-Defined in: src/cameras/composables.ts:175
+Defined in: [src/cameras/composables.ts:175](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/cameras/composables.ts#L175)
 
 Additional fields to include in the response.

--- a/docs/api/interfaces/UseCameraOptions.md
+++ b/docs/api/interfaces/UseCameraOptions.md
@@ -1,0 +1,37 @@
+[**EEN API Toolkit v0.0.13**](../README.md)
+
+***
+
+[EEN API Toolkit](../README.md) / UseCameraOptions
+
+# Interface: UseCameraOptions
+
+Defined in: src/cameras/composables.ts:166
+
+Options for the useCamera composable.
+
+## Properties
+
+### immediate?
+
+> `optional` **immediate**: `boolean`
+
+Defined in: src/cameras/composables.ts:171
+
+Whether to fetch the camera immediately on mount.
+
+#### Default Value
+
+```ts
+true
+```
+
+***
+
+### include?
+
+> `optional` **include**: `string`[]
+
+Defined in: src/cameras/composables.ts:175
+
+Additional fields to include in the response.

--- a/docs/api/interfaces/UseCameraOptions.md
+++ b/docs/api/interfaces/UseCameraOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UseCamerasOptions.md
+++ b/docs/api/interfaces/UseCamerasOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: UseCamerasOptions
 
-Defined in: src/cameras/composables.ts:10
+Defined in: [src/cameras/composables.ts:10](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/cameras/composables.ts#L10)
 
 Options for the useCameras composable.
 
@@ -16,7 +16,7 @@ Options for the useCameras composable.
 
 > `optional` **immediate**: `boolean`
 
-Defined in: src/cameras/composables.ts:15
+Defined in: [src/cameras/composables.ts:15](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/cameras/composables.ts#L15)
 
 Whether to fetch cameras immediately on mount.
 

--- a/docs/api/interfaces/UseCamerasOptions.md
+++ b/docs/api/interfaces/UseCamerasOptions.md
@@ -1,0 +1,27 @@
+[**EEN API Toolkit v0.0.13**](../README.md)
+
+***
+
+[EEN API Toolkit](../README.md) / UseCamerasOptions
+
+# Interface: UseCamerasOptions
+
+Defined in: src/cameras/composables.ts:10
+
+Options for the useCameras composable.
+
+## Properties
+
+### immediate?
+
+> `optional` **immediate**: `boolean`
+
+Defined in: src/cameras/composables.ts:15
+
+Whether to fetch cameras immediately on mount.
+
+#### Default Value
+
+```ts
+true
+```

--- a/docs/api/interfaces/UseCamerasOptions.md
+++ b/docs/api/interfaces/UseCamerasOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UseCurrentUserOptions.md
+++ b/docs/api/interfaces/UseCurrentUserOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UseCurrentUserOptions.md
+++ b/docs/api/interfaces/UseCurrentUserOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UseUserOptions.md
+++ b/docs/api/interfaces/UseUserOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UseUserOptions.md
+++ b/docs/api/interfaces/UseUserOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UseUsersOptions.md
+++ b/docs/api/interfaces/UseUsersOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UseUsersOptions.md
+++ b/docs/api/interfaces/UseUsersOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/User.md
+++ b/docs/api/interfaces/User.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/User.md
+++ b/docs/api/interfaces/User.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UserProfile.md
+++ b/docs/api/interfaces/UserProfile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UserProfile.md
+++ b/docs/api/interfaces/UserProfile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraStatus.md
+++ b/docs/api/type-aliases/CameraStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **CameraStatus** = `"online"` \| `"offline"` \| `"deviceOffline"` \| `"bridgeOffline"` \| `"invalidCredentials"` \| `"error"` \| `"streaming"` \| `"registered"` \| `"attaching"` \| `"initializing"`
 
-Defined in: src/types/camera.ts:9
+Defined in: [src/types/camera.ts:9](https://github.com/klaushofrichter/een-api-toolkit/blob/develop/src/types/camera.ts#L9)
 
 Camera status values from EEN API v3.0.
 

--- a/docs/api/type-aliases/CameraStatus.md
+++ b/docs/api/type-aliases/CameraStatus.md
@@ -1,0 +1,17 @@
+[**EEN API Toolkit v0.0.13**](../README.md)
+
+***
+
+[EEN API Toolkit](../README.md) / CameraStatus
+
+# Type Alias: CameraStatus
+
+> **CameraStatus** = `"online"` \| `"offline"` \| `"deviceOffline"` \| `"bridgeOffline"` \| `"invalidCredentials"` \| `"error"` \| `"streaming"` \| `"registered"` \| `"attaching"` \| `"initializing"`
+
+Defined in: src/types/camera.ts:9
+
+Camera status values from EEN API v3.0.
+
+## Remarks
+
+Indicates the current operational state of a camera.

--- a/docs/api/type-aliases/CameraStatus.md
+++ b/docs/api/type-aliases/CameraStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ErrorCode.md
+++ b/docs/api/type-aliases/ErrorCode.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ErrorCode.md
+++ b/docs/api/type-aliases/ErrorCode.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/Result.md
+++ b/docs/api/type-aliases/Result.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/Result.md
+++ b/docs/api/type-aliases/Result.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/docs/api/variables/useAuthStore.md
+++ b/docs/api/variables/useAuthStore.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.13**](../README.md)
+[**EEN API Toolkit v0.0.14**](../README.md)
 
 ***
 

--- a/docs/api/variables/useAuthStore.md
+++ b/docs/api/variables/useAuthStore.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.14**](../README.md)
+[**EEN API Toolkit v0.0.15**](../README.md)
 
 ***
 

--- a/e2e/cameras.spec.ts
+++ b/e2e/cameras.spec.ts
@@ -1,0 +1,200 @@
+import { test, expect } from '@playwright/test'
+import { getAuthToken, AuthState } from './auth-helper'
+import { apiGet } from './api-helper'
+
+test.describe('Cameras API', () => {
+  let auth: AuthState
+
+  test.beforeAll(async () => {
+    // Get auth token (from cache or fresh login)
+    auth = await getAuthToken()
+  })
+
+  test('GET /api/v3.0/cameras returns camera list', async ({ request }) => {
+    const response = await apiGet(request, auth, '/api/v3.0/cameras', { pageSize: '10' })
+
+    expect(response.ok()).toBe(true)
+
+    const data = await response.json()
+    console.log('Cameras returned:', data.results?.length || 0)
+
+    // Verify response structure
+    expect(data).toHaveProperty('results')
+    expect(Array.isArray(data.results)).toBe(true)
+
+    // Check camera structure if results exist
+    if (data.results.length > 0) {
+      const firstCamera = data.results[0]
+      expect(firstCamera).toHaveProperty('id')
+      expect(firstCamera).toHaveProperty('name')
+      expect(firstCamera).toHaveProperty('accountId')
+      console.log('First camera:', firstCamera.name, '- Status:', firstCamera.status || 'N/A')
+    }
+  })
+
+  test('GET /api/v3.0/cameras with pagination', async ({ request }) => {
+    // First request with small page size
+    const response1 = await apiGet(request, auth, '/api/v3.0/cameras', { pageSize: '2' })
+
+    expect(response1.ok()).toBe(true)
+    const data1 = await response1.json()
+
+    expect(data1).toHaveProperty('results')
+    expect(data1.results.length).toBeLessThanOrEqual(2)
+
+    // If there's a next page, fetch it
+    if (data1.nextPageToken) {
+      console.log('Fetching next page...')
+      const response2 = await apiGet(request, auth, '/api/v3.0/cameras', {
+        pageSize: '2',
+        pageToken: data1.nextPageToken
+      })
+
+      expect(response2.ok()).toBe(true)
+      const data2 = await response2.json()
+      expect(data2).toHaveProperty('results')
+      console.log('Second page cameras:', data2.results?.length || 0)
+    } else {
+      console.log('No additional pages available (account may have <= 2 cameras)')
+    }
+  })
+
+  test('GET /api/v3.0/cameras with include parameter', async ({ request }) => {
+    const response = await apiGet(request, auth, '/api/v3.0/cameras', {
+      pageSize: '5',
+      include: 'deviceInfo,status'
+    })
+
+    expect(response.ok()).toBe(true)
+
+    const data = await response.json()
+    console.log('Cameras with deviceInfo:', data.results?.length || 0)
+
+    // Check that cameras are returned
+    expect(data).toHaveProperty('results')
+
+    if (data.results.length > 0) {
+      const camera = data.results[0]
+      console.log('Camera:', camera.name)
+      if (camera.deviceInfo) {
+        console.log('  Device:', camera.deviceInfo.make || 'Unknown', camera.deviceInfo.model || '')
+      }
+    }
+  })
+
+  test('GET /api/v3.0/cameras with status filter', async ({ request }) => {
+    // Try to get online cameras with status included in response
+    const response = await apiGet(request, auth, '/api/v3.0/cameras', {
+      pageSize: '10',
+      include: 'status',
+      'status__in': 'online,streaming'
+    })
+
+    expect(response.ok()).toBe(true)
+
+    const data = await response.json()
+    console.log('Online/streaming cameras:', data.results?.length || 0)
+
+    // All returned cameras should be online or streaming (if any exist)
+    for (const camera of data.results || []) {
+      // Status can be a string or object with connectionStatus
+      const status =
+        typeof camera.status === 'string'
+          ? camera.status
+          : camera.status?.connectionStatus
+      if (status) {
+        expect(['online', 'streaming']).toContain(status)
+      }
+    }
+  })
+
+  test('GET /api/v3.0/cameras with search query', async ({ request }) => {
+    // Search for cameras (may or may not return results depending on camera names)
+    const response = await apiGet(request, auth, '/api/v3.0/cameras', {
+      pageSize: '10',
+      q: 'camera'
+    })
+
+    expect(response.ok()).toBe(true)
+
+    const data = await response.json()
+    console.log('Search results for "camera":', data.results?.length || 0)
+
+    // Verify response structure
+    expect(data).toHaveProperty('results')
+    expect(Array.isArray(data.results)).toBe(true)
+  })
+
+  test('GET /api/v3.0/cameras/{id} returns specific camera', async ({ request }) => {
+    // First get a camera from the list
+    const listResponse = await apiGet(request, auth, '/api/v3.0/cameras', { pageSize: '1' })
+
+    expect(listResponse.ok()).toBe(true)
+    const listData = await listResponse.json()
+
+    if (listData.results?.length > 0) {
+      const cameraId = listData.results[0].id
+      const cameraName = listData.results[0].name
+
+      // Now fetch that camera by ID
+      const response = await apiGet(request, auth, `/api/v3.0/cameras/${cameraId}`)
+
+      expect(response.ok()).toBe(true)
+
+      const camera = await response.json()
+      expect(camera.id).toBe(cameraId)
+      expect(camera).toHaveProperty('name')
+      expect(camera).toHaveProperty('accountId')
+      console.log('Fetched camera by ID:', cameraName)
+    } else {
+      console.log('No cameras available to test single camera fetch')
+    }
+  })
+
+  test('GET /api/v3.0/cameras/{id} with include parameter', async ({ request }) => {
+    // First get a camera from the list
+    const listResponse = await apiGet(request, auth, '/api/v3.0/cameras', { pageSize: '1' })
+
+    expect(listResponse.ok()).toBe(true)
+    const listData = await listResponse.json()
+
+    if (listData.results?.length > 0) {
+      const cameraId = listData.results[0].id
+
+      // Fetch with deviceInfo included (streamUrls may require additional permissions)
+      const response = await apiGet(request, auth, `/api/v3.0/cameras/${cameraId}`, {
+        include: 'deviceInfo'
+      })
+
+      // If the include parameter fails, just skip the detailed check
+      if (!response.ok()) {
+        console.log('Include parameter not supported for this camera, status:', response.status())
+        // Still verify we can get the camera without include
+        const basicResponse = await apiGet(request, auth, `/api/v3.0/cameras/${cameraId}`)
+        expect(basicResponse.ok()).toBe(true)
+        return
+      }
+
+      const camera = await response.json()
+      expect(camera.id).toBe(cameraId)
+      console.log('Camera with details:', camera.name)
+
+      if (camera.deviceInfo) {
+        console.log('  Make:', camera.deviceInfo.make || 'N/A')
+        console.log('  Model:', camera.deviceInfo.model || 'N/A')
+      }
+    } else {
+      console.log('No cameras available to test detailed fetch')
+    }
+  })
+
+  test('GET /api/v3.0/cameras/{id} returns 404 for non-existent camera', async ({ request }) => {
+    // Use a clearly invalid ID format
+    const response = await apiGet(request, auth, '/api/v3.0/cameras/non-existent-camera-id-12345')
+
+    // Should return 404 Not Found
+    expect(response.ok()).toBe(false)
+    expect(response.status()).toBe(404)
+    console.log('Correctly returned 404 for non-existent camera')
+  })
+})

--- a/examples/vue-cameras/.env.example
+++ b/examples/vue-cameras/.env.example
@@ -1,0 +1,13 @@
+# Copy this file to .env and fill in your values
+
+# OAuth Proxy URL (from een-oauth-proxy project)
+VITE_PROXY_URL=http://localhost:8787
+
+# EEN OAuth Client ID (from EEN Developer Portal)
+VITE_EEN_CLIENT_ID=your-client-id
+
+# Optional: Override redirect URI (default: http://127.0.0.1:3333)
+# VITE_REDIRECT_URI=http://127.0.0.1:3333
+
+# Optional: Enable debug logging
+VITE_DEBUG=true

--- a/examples/vue-cameras/e2e/app.spec.ts
+++ b/examples/vue-cameras/e2e/app.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Cameras Example App', () => {
+  test('should display the home page', async ({ page }) => {
+    await page.goto('/')
+
+    // Check title
+    await expect(page).toHaveTitle('EEN Cameras Example')
+
+    // Check header
+    await expect(page.locator('h1')).toContainText('EEN Cameras Example')
+
+    // Check navigation links
+    await expect(page.locator('nav')).toContainText('Home')
+    await expect(page.locator('nav')).toContainText('Login')
+  })
+
+  test('should show welcome message on home page', async ({ page }) => {
+    await page.goto('/')
+
+    await expect(page.locator('h2')).toContainText('Welcome to the EEN Cameras Example')
+  })
+
+  test('should display login prompt when not authenticated', async ({ page }) => {
+    await page.goto('/')
+
+    // Should show login prompt
+    await expect(page.locator('.login-prompt')).toBeVisible()
+    await expect(page.locator('.login-prompt')).toContainText('Please log in to view your cameras')
+  })
+
+  test('should navigate to login page', async ({ page }) => {
+    await page.goto('/')
+
+    // Click login in nav
+    await page.locator('nav a:has-text("Login")').click()
+
+    // Should be on login page
+    await expect(page.locator('h2')).toContainText('Login')
+    await expect(page.locator('button')).toContainText('Login with Eagle Eye Networks')
+  })
+
+  test('should redirect to login when accessing cameras without auth', async ({ page }) => {
+    // Try to access cameras directly
+    await page.goto('/cameras')
+
+    // Should be redirected to login
+    await expect(page.locator('h2')).toContainText('Login')
+  })
+
+  test('should show about section on home page', async ({ page }) => {
+    await page.goto('/')
+
+    // Check the about section
+    await expect(page.locator('.description h3')).toContainText('About This Example')
+    await expect(page.locator('.description')).toContainText('useCameras')
+    await expect(page.locator('.description')).toContainText('useCamera')
+  })
+
+  test('should have correct navigation structure', async ({ page }) => {
+    await page.goto('/')
+
+    // Check all expected nav links for unauthenticated state
+    const navLinks = page.locator('nav a')
+    await expect(navLinks).toHaveCount(2) // Home, Login
+
+    // Verify Home link
+    await expect(navLinks.nth(0)).toHaveAttribute('href', '/')
+
+    // Verify Login link
+    await expect(navLinks.nth(1)).toHaveAttribute('href', '/login')
+  })
+})

--- a/examples/vue-cameras/index.html
+++ b/examples/vue-cameras/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EEN Cameras Example</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/vue-cameras/package-lock.json
+++ b/examples/vue-cameras/package-lock.json
@@ -1,0 +1,1583 @@
+{
+  "name": "een-api-toolkit-cameras-example",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "een-api-toolkit-cameras-example",
+      "version": "0.0.1",
+      "dependencies": {
+        "een-api-toolkit": "file:../..",
+        "pinia": "^2.1.7",
+        "vue": "^3.4.0",
+        "vue-router": "^4.2.0"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.57.0",
+        "@vitejs/plugin-vue": "^6.0.0",
+        "dotenv": "^17.2.3",
+        "typescript": "~5.8.0",
+        "vite": "^7.3.0",
+        "vue-tsc": "^3.2.1"
+      }
+    },
+    "../..": {
+      "version": "0.0.13",
+      "license": "MIT",
+      "devDependencies": {
+        "@playwright/test": "^1.57.0",
+        "@types/node": "^22.0.0",
+        "@typescript-eslint/eslint-plugin": "^6.21.0",
+        "@typescript-eslint/parser": "^6.21.0",
+        "@vitejs/plugin-vue": "^6.0.0",
+        "@vue/tsconfig": "^0.5.0",
+        "dotenv": "^17.2.3",
+        "eslint": "^8.56.0",
+        "eslint-plugin-vue": "^9.20.0",
+        "husky": "^9.1.7",
+        "jsdom": "^27.4.0",
+        "pinia": "^2.1.7",
+        "tsx": "^4.21.0",
+        "typedoc": "^0.28.15",
+        "typedoc-plugin-markdown": "^4.9.0",
+        "typescript": "~5.8.0",
+        "vite": "^7.3.0",
+        "vite-plugin-dts": "^4.5.4",
+        "vitest": "^4.0.16",
+        "vue": "^3.4.0",
+        "vue-tsc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "pinia": "^2.0.0 || ^3.0.0",
+        "vue": "^3.3.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
+      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.5"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
+      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
+      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
+      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
+      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
+      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
+      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
+      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
+      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
+      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
+      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
+      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
+      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
+      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
+      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
+      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
+      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
+      "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
+      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
+      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
+      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
+      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
+      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
+      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.53.tgz",
+      "integrity": "sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.54.0.tgz",
+      "integrity": "sha512-OywsdRHrFvCdvsewAInDKCNyR3laPA2mc9bRYJ6LBp5IyvF3fvXbbNR0bSzHlZVFtn6E0xw2oZlyjg4rKCVcng==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.54.0.tgz",
+      "integrity": "sha512-Skx39Uv+u7H224Af+bDgNinitlmHyQX1K/atIA32JP3JQw6hVODX5tkbi2zof/E69M1qH2UoN3Xdxgs90mmNYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.54.0.tgz",
+      "integrity": "sha512-k43D4qta/+6Fq+nCDhhv9yP2HdeKeP56QrUUTW7E6PhZP1US6NDqpJj4MY0jBHlJivVJD5P8NxrjuobZBJTCRw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.54.0.tgz",
+      "integrity": "sha512-cOo7biqwkpawslEfox5Vs8/qj83M/aZCSSNIWpVzfU2CYHa2G3P1UN5WF01RdTHSgCkri7XOlTdtk17BezlV3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.54.0.tgz",
+      "integrity": "sha512-miSvuFkmvFbgJ1BevMa4CPCFt5MPGw094knM64W9I0giUIMMmRYcGW/JWZDriaw/k1kOBtsWh1z6nIFV1vPNtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.54.0.tgz",
+      "integrity": "sha512-KGXIs55+b/ZfZsq9aR026tmr/+7tq6VG6MsnrvF4H8VhwflTIuYh+LFUlIsRdQSgrgmtM3fVATzEAj4hBQlaqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.54.0.tgz",
+      "integrity": "sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.54.0.tgz",
+      "integrity": "sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.54.0.tgz",
+      "integrity": "sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.54.0.tgz",
+      "integrity": "sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.54.0.tgz",
+      "integrity": "sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.54.0.tgz",
+      "integrity": "sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.54.0.tgz",
+      "integrity": "sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.54.0.tgz",
+      "integrity": "sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.54.0.tgz",
+      "integrity": "sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.54.0.tgz",
+      "integrity": "sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.54.0.tgz",
+      "integrity": "sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.54.0.tgz",
+      "integrity": "sha512-huT3fd0iC7jigGh7n3q/+lfPcXxBi+om/Rs3yiFxjvSxbSB6aohDFXbWvlspaqjeOh+hx7DDHS+5Es5qRkWkZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.54.0.tgz",
+      "integrity": "sha512-c2V0W1bsKIKfbLMBu/WGBz6Yci8nJ/ZJdheE0EwB73N3MvHYKiKGs3mVilX4Gs70eGeDaMqEob25Tw2Gb9Nqyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.54.0.tgz",
+      "integrity": "sha512-woEHgqQqDCkAzrDhvDipnSirm5vxUXtSKDYTVpZG3nUdW/VVB5VdCYA2iReSj/u3yCZzXID4kuKG7OynPnB3WQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.54.0.tgz",
+      "integrity": "sha512-dzAc53LOuFvHwbCEOS0rPbXp6SIhAf2txMP5p6mGyOXXw5mWY8NGGbPMPrs4P1WItkfApDathBj/NzMLUZ9rtQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.54.0.tgz",
+      "integrity": "sha512-hYT5d3YNdSh3mbCU1gwQyPgQd3T2ne0A3KG8KSBdav5TiBg6eInVmV+TeR5uHufiIgSFg0XsOWGW5/RhNcSvPg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.3.tgz",
+      "integrity": "sha512-TlGPkLFLVOY3T7fZrwdvKpjprR3s4fxRln0ORDo1VQ7HHyxJwTlrjKU3kpVWTlaAjIEuCTokmjkZnr8Tpc925w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "1.0.0-beta.53"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@volar/language-core": {
+      "version": "2.4.27",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.27.tgz",
+      "integrity": "sha512-DjmjBWZ4tJKxfNC1F6HyYERNHPYS7L7OPFyCrestykNdUZMFYzI9WTyvwPcaNaHlrEUwESHYsfEw3isInncZxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.27"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "2.4.27",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.27.tgz",
+      "integrity": "sha512-ynlcBReMgOZj2i6po+qVswtDUeeBRCTgDurjMGShbm8WYZgJ0PA4RmtebBJ0BCYol1qPv3GQF6jK7C9qoVc7lg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@volar/typescript": {
+      "version": "2.4.27",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.27.tgz",
+      "integrity": "sha512-eWaYCcl/uAPInSK2Lze6IqVWaBu/itVqR5InXcHXFyles4zO++Mglt3oxdgj75BDcv1Knr9Y93nowS8U3wqhxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.27",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.26.tgz",
+      "integrity": "sha512-vXyI5GMfuoBCnv5ucIT7jhHKl55Y477yxP6fc4eUswjP8FG3FFVFd41eNDArR+Uk3QKn2Z85NavjaxLxOC19/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.5",
+        "@vue/shared": "3.5.26",
+        "entities": "^7.0.0",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.26.tgz",
+      "integrity": "sha512-y1Tcd3eXs834QjswshSilCBnKGeQjQXB6PqFn/1nxcQw4pmG42G8lwz+FZPAZAby6gZeHSt/8LMPfZ4Rb+Bd/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.26",
+        "@vue/shared": "3.5.26"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.26.tgz",
+      "integrity": "sha512-egp69qDTSEZcf4bGOSsprUr4xI73wfrY5oRs6GSgXFTiHrWj4Y3X5Ydtip9QMqiCMCPVwLglB9GBxXtTadJ3mA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.5",
+        "@vue/compiler-core": "3.5.26",
+        "@vue/compiler-dom": "3.5.26",
+        "@vue/compiler-ssr": "3.5.26",
+        "@vue/shared": "3.5.26",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.6",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.26.tgz",
+      "integrity": "sha512-lZT9/Y0nSIRUPVvapFJEVDbEXruZh2IYHMk2zTtEgJSlP5gVOqeWXH54xDKAaFS4rTnDeDBQUYDtxKyoW9FwDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.26",
+        "@vue/shared": "3.5.26"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/language-core": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.2.1.tgz",
+      "integrity": "sha512-g6oSenpnGMtpxHGAwKuu7HJJkNZpemK/zg3vZzZbJ6cnnXq1ssxuNrXSsAHYM3NvH8p4IkTw+NLmuxyeYz4r8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.27",
+        "@vue/compiler-dom": "^3.5.0",
+        "@vue/shared": "^3.5.0",
+        "alien-signals": "^3.0.0",
+        "muggle-string": "^0.4.1",
+        "path-browserify": "^1.0.1",
+        "picomatch": "^4.0.2"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.26.tgz",
+      "integrity": "sha512-9EnYB1/DIiUYYnzlnUBgwU32NNvLp/nhxLXeWRhHUEeWNTn1ECxX8aGO7RTXeX6PPcxe3LLuNBFoJbV4QZ+CFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.26"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.26.tgz",
+      "integrity": "sha512-xJWM9KH1kd201w5DvMDOwDHYhrdPTrAatn56oB/LRG4plEQeZRQLw0Bpwih9KYoqmzaxF0OKSn6swzYi84e1/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.26",
+        "@vue/shared": "3.5.26"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.26.tgz",
+      "integrity": "sha512-XLLd/+4sPC2ZkN/6+V4O4gjJu6kSDbHAChvsyWgm1oGbdSO3efvGYnm25yCjtFm/K7rrSDvSfPDgN1pHgS4VNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.26",
+        "@vue/runtime-core": "3.5.26",
+        "@vue/shared": "3.5.26",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.26.tgz",
+      "integrity": "sha512-TYKLXmrwWKSodyVuO1WAubucd+1XlLg4set0YoV+Hu8Lo79mp/YMwWV5mC5FgtsDxX3qo1ONrxFaTP1OQgy1uA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.26",
+        "@vue/shared": "3.5.26"
+      },
+      "peerDependencies": {
+        "vue": "3.5.26"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.26.tgz",
+      "integrity": "sha512-7Z6/y3uFI5PRoKeorTOSXKcDj0MSasfNNltcslbFrPpcw6aXRUALq4IfJlaTRspiWIUOEZbrpM+iQGmCOiWe4A==",
+      "license": "MIT"
+    },
+    "node_modules/alien-signals": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.1.2.tgz",
+      "integrity": "sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/een-api-toolkit": {
+      "resolved": "../..",
+      "link": true
+    },
+    "node_modules/entities": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.0.tgz",
+      "integrity": "sha512-FDWG5cmEYf2Z00IkYRhbFrwIwvdFKH07uV8dvNy0omp/Qb1xcyCWp2UDtcwJF4QZZvk0sLudP6/hAu42TaqVhQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
+      "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.2",
+        "@esbuild/android-arm": "0.27.2",
+        "@esbuild/android-arm64": "0.27.2",
+        "@esbuild/android-x64": "0.27.2",
+        "@esbuild/darwin-arm64": "0.27.2",
+        "@esbuild/darwin-x64": "0.27.2",
+        "@esbuild/freebsd-arm64": "0.27.2",
+        "@esbuild/freebsd-x64": "0.27.2",
+        "@esbuild/linux-arm": "0.27.2",
+        "@esbuild/linux-arm64": "0.27.2",
+        "@esbuild/linux-ia32": "0.27.2",
+        "@esbuild/linux-loong64": "0.27.2",
+        "@esbuild/linux-mips64el": "0.27.2",
+        "@esbuild/linux-ppc64": "0.27.2",
+        "@esbuild/linux-riscv64": "0.27.2",
+        "@esbuild/linux-s390x": "0.27.2",
+        "@esbuild/linux-x64": "0.27.2",
+        "@esbuild/netbsd-arm64": "0.27.2",
+        "@esbuild/netbsd-x64": "0.27.2",
+        "@esbuild/openbsd-arm64": "0.27.2",
+        "@esbuild/openbsd-x64": "0.27.2",
+        "@esbuild/openharmony-arm64": "0.27.2",
+        "@esbuild/sunos-x64": "0.27.2",
+        "@esbuild/win32-arm64": "0.27.2",
+        "@esbuild/win32-ia32": "0.27.2",
+        "@esbuild/win32-x64": "0.27.2"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/muggle-string": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pinia": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.3.1.tgz",
+      "integrity": "sha512-khUlZSwt9xXCaTbbxFYBKDc/bWAGWJjOgvxETwkTN7KRm66EeT1ZdZj6i2ceh9sP2Pzqsbc704r2yngBrxBVug==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.3",
+        "vue-demi": "^0.14.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.4.4",
+        "vue": "^2.7.0 || ^3.5.11"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
+      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
+      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.54.0.tgz",
+      "integrity": "sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.54.0",
+        "@rollup/rollup-android-arm64": "4.54.0",
+        "@rollup/rollup-darwin-arm64": "4.54.0",
+        "@rollup/rollup-darwin-x64": "4.54.0",
+        "@rollup/rollup-freebsd-arm64": "4.54.0",
+        "@rollup/rollup-freebsd-x64": "4.54.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.54.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.54.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.54.0",
+        "@rollup/rollup-linux-arm64-musl": "4.54.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.54.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.54.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.54.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.54.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.54.0",
+        "@rollup/rollup-linux-x64-gnu": "4.54.0",
+        "@rollup/rollup-linux-x64-musl": "4.54.0",
+        "@rollup/rollup-openharmony-arm64": "4.54.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.54.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.54.0",
+        "@rollup/rollup-win32-x64-gnu": "4.54.0",
+        "@rollup/rollup-win32-x64-msvc": "4.54.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
+      "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vue": {
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.26.tgz",
+      "integrity": "sha512-SJ/NTccVyAoNUJmkM9KUqPcYlY+u8OVL1X5EW9RIs3ch5H2uERxyyIUI4MRxVCSOiEcupX9xNGde1tL9ZKpimA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.26",
+        "@vue/compiler-sfc": "3.5.26",
+        "@vue/runtime-dom": "3.5.26",
+        "@vue/server-renderer": "3.5.26",
+        "@vue/shared": "3.5.26"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-router": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
+      "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/vue-tsc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.2.1.tgz",
+      "integrity": "sha512-I23Rk8dkQfmcSbxDO0dmg9ioMLjKA1pjlU3Lz6Jfk2pMGu3Uryu9810XkcZH24IzPbhzPCnkKo2rEMRX0skSrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/typescript": "2.4.27",
+        "@vue/language-core": "3.2.1"
+      },
+      "bin": {
+        "vue-tsc": "bin/vue-tsc.js"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      }
+    }
+  }
+}

--- a/examples/vue-cameras/package.json
+++ b/examples/vue-cameras/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "een-api-toolkit-cameras-example",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "stop": "npx kill-port 3333",
+    "dev": "npm run stop && vite",
+    "build": "vue-tsc && vite build",
+    "preview": "vite preview",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
+  },
+  "dependencies": {
+    "een-api-toolkit": "file:../..",
+    "pinia": "^2.1.7",
+    "vue": "^3.4.0",
+    "vue-router": "^4.2.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.57.0",
+    "@vitejs/plugin-vue": "^6.0.0",
+    "dotenv": "^17.2.3",
+    "typescript": "~5.8.0",
+    "vite": "^7.3.0",
+    "vue-tsc": "^3.2.1"
+  }
+}

--- a/examples/vue-cameras/playwright.config.ts
+++ b/examples/vue-cameras/playwright.config.ts
@@ -1,0 +1,46 @@
+import { defineConfig, devices } from '@playwright/test'
+import dotenv from 'dotenv'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+// Load .env files: parent first, then local with override to replace any conflicts
+dotenv.config({ path: path.resolve(__dirname, '../../.env') })
+dotenv.config({ path: path.resolve(__dirname, '.env'), override: true })
+
+const redirectUri = process.env.VITE_REDIRECT_URI || 'http://127.0.0.1:3333'
+if (!redirectUri.startsWith('http://127.0.0.1:') && !redirectUri.startsWith('http://localhost:')) {
+  throw new Error('VITE_REDIRECT_URI must use localhost or 127.0.0.1 for security')
+}
+const baseURL = redirectUri
+
+export default defineConfig({
+  testDir: './e2e',
+  testMatch: '**/*.spec.ts',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  maxFailures: 1,
+  workers: 1,
+  reporter: [['html', { open: 'never' }]],
+  timeout: 30000,
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    video: 'retain-on-failure'
+  },
+  outputDir: './e2e-results/',
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] }
+    }
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 30000
+  }
+})

--- a/examples/vue-cameras/src/App.vue
+++ b/examples/vue-cameras/src/App.vue
@@ -1,0 +1,108 @@
+<script setup lang="ts">
+import { useAuthStore } from 'een-api-toolkit'
+import { computed } from 'vue'
+
+const authStore = useAuthStore()
+const isAuthenticated = computed(() => authStore.isAuthenticated)
+</script>
+
+<template>
+  <div class="app">
+    <header>
+      <h1>EEN Cameras Example</h1>
+      <nav>
+        <router-link to="/">Home</router-link>
+        <router-link v-if="isAuthenticated" to="/cameras">Cameras</router-link>
+        <router-link v-if="!isAuthenticated" to="/login">Login</router-link>
+        <router-link v-if="isAuthenticated" to="/logout">Logout</router-link>
+      </nav>
+    </header>
+    <main>
+      <router-view />
+    </main>
+  </div>
+</template>
+
+<style>
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
+    Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  line-height: 1.6;
+  color: #333;
+}
+
+.app {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 30px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid #eee;
+}
+
+header h1 {
+  font-size: 1.5rem;
+}
+
+nav {
+  display: flex;
+  gap: 20px;
+}
+
+nav a {
+  color: #42b883;
+  text-decoration: none;
+}
+
+nav a:hover {
+  text-decoration: underline;
+}
+
+nav a.router-link-active {
+  font-weight: bold;
+}
+
+button {
+  background: #42b883;
+  color: white;
+  border: none;
+  padding: 10px 20px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+button:hover {
+  background: #3aa876;
+}
+
+button:disabled {
+  background: #ccc;
+  cursor: not-allowed;
+}
+
+.error {
+  color: #e74c3c;
+  padding: 10px;
+  background: #fdf2f2;
+  border-radius: 4px;
+  margin: 10px 0;
+}
+
+.loading {
+  color: #666;
+  font-style: italic;
+}
+</style>

--- a/examples/vue-cameras/src/main.ts
+++ b/examples/vue-cameras/src/main.ts
@@ -1,0 +1,23 @@
+import { createApp } from 'vue'
+import { createPinia } from 'pinia'
+import { initEenToolkit } from 'een-api-toolkit'
+import App from './App.vue'
+import router from './router'
+
+const app = createApp(App)
+
+// Install Pinia (required before initEenToolkit)
+app.use(createPinia())
+
+// Initialize EEN API Toolkit
+initEenToolkit({
+  proxyUrl: import.meta.env.VITE_PROXY_URL,
+  clientId: import.meta.env.VITE_EEN_CLIENT_ID,
+  redirectUri: import.meta.env.VITE_REDIRECT_URI,
+  debug: import.meta.env.VITE_DEBUG === 'true'
+})
+
+// Install router
+app.use(router)
+
+app.mount('#app')

--- a/examples/vue-cameras/src/router/index.ts
+++ b/examples/vue-cameras/src/router/index.ts
@@ -1,0 +1,68 @@
+import { createRouter, createWebHistory } from 'vue-router'
+import { useAuthStore } from 'een-api-toolkit'
+import Home from '../views/Home.vue'
+import Login from '../views/Login.vue'
+import Callback from '../views/Callback.vue'
+import Cameras from '../views/Cameras.vue'
+import CameraDetail from '../views/CameraDetail.vue'
+import Logout from '../views/Logout.vue'
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [
+    {
+      path: '/',
+      name: 'home',
+      component: Home,
+      // Handle OAuth callback on root path (EEN IDP redirects to http://127.0.0.1:3333)
+      beforeEnter: (to, _from, next) => {
+        // If URL has code and state params, it's an OAuth callback
+        if (to.query.code && to.query.state) {
+          next({ name: 'callback', query: to.query })
+        } else {
+          next()
+        }
+      }
+    },
+    {
+      path: '/login',
+      name: 'login',
+      component: Login
+    },
+    {
+      path: '/callback',
+      name: 'callback',
+      component: Callback
+    },
+    {
+      path: '/cameras',
+      name: 'cameras',
+      component: Cameras,
+      meta: { requiresAuth: true }
+    },
+    {
+      path: '/cameras/:id',
+      name: 'camera-detail',
+      component: CameraDetail,
+      meta: { requiresAuth: true }
+    },
+    {
+      path: '/logout',
+      name: 'logout',
+      component: Logout
+    }
+  ]
+})
+
+// Navigation guard for protected routes
+router.beforeEach((to, _from, next) => {
+  const authStore = useAuthStore()
+
+  if (to.meta.requiresAuth && !authStore.isAuthenticated) {
+    next({ name: 'login' })
+  } else {
+    next()
+  }
+})
+
+export default router

--- a/examples/vue-cameras/src/views/Callback.vue
+++ b/examples/vue-cameras/src/views/Callback.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { handleAuthCallback } from 'een-api-toolkit'
+
+const router = useRouter()
+const error = ref<string | null>(null)
+const processing = ref(true)
+
+onMounted(async () => {
+  const url = new URL(window.location.href)
+  const code = url.searchParams.get('code')
+  const state = url.searchParams.get('state')
+  const errorParam = url.searchParams.get('error')
+
+  if (errorParam) {
+    error.value = `OAuth error: ${errorParam}`
+    processing.value = false
+    return
+  }
+
+  if (!code || !state) {
+    error.value = 'Missing authorization code or state parameter'
+    processing.value = false
+    return
+  }
+
+  const result = await handleAuthCallback(code, state)
+
+  if (result.error) {
+    error.value = result.error.message
+    processing.value = false
+    return
+  }
+
+  // Success - redirect to cameras
+  router.push('/cameras')
+})
+</script>
+
+<template>
+  <div class="callback">
+    <div v-if="processing" class="loading">
+      <h2>Authenticating...</h2>
+      <p>Please wait while we complete the login process.</p>
+    </div>
+
+    <div v-else-if="error" class="error-state">
+      <h2>Authentication Failed</h2>
+      <p class="error">{{ error }}</p>
+      <router-link to="/login">
+        <button>Try Again</button>
+      </router-link>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.callback {
+  text-align: center;
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+h2 {
+  margin-bottom: 20px;
+}
+
+.loading p {
+  color: #666;
+}
+
+.error-state .error {
+  margin-bottom: 20px;
+}
+</style>

--- a/examples/vue-cameras/src/views/CameraDetail.vue
+++ b/examples/vue-cameras/src/views/CameraDetail.vue
@@ -1,0 +1,315 @@
+<script setup lang="ts">
+import { useRoute } from 'vue-router'
+import { useCamera, type CameraStatus } from 'een-api-toolkit'
+
+const route = useRoute()
+
+// Fetch camera with all details
+const { camera, loading, error, refresh } = useCamera(
+  () => route.params.id as string,
+  {
+    include: ['deviceInfo', 'status', 'shareDetails', 'devicePosition', 'networkInfo', 'tags']
+  }
+)
+
+// Get status badge class
+function getStatusClass(status?: CameraStatus): string {
+  switch (status) {
+    case 'online':
+    case 'streaming':
+      return 'status-online'
+    case 'offline':
+    case 'deviceOffline':
+    case 'bridgeOffline':
+      return 'status-offline'
+    case 'error':
+    case 'invalidCredentials':
+      return 'status-error'
+    default:
+      return 'status-unknown'
+  }
+}
+</script>
+
+<template>
+  <div class="camera-detail">
+    <div class="nav-back">
+      <router-link to="/cameras">&larr; Back to Cameras</router-link>
+    </div>
+
+    <div v-if="loading" class="loading">
+      Loading camera details...
+    </div>
+
+    <div v-else-if="error" class="error">
+      Error: {{ error.message }}
+    </div>
+
+    <div v-else-if="camera" class="camera-info">
+      <div class="header">
+        <div>
+          <h2>{{ camera.name }}</h2>
+          <p class="camera-id">ID: {{ camera.id }}</p>
+        </div>
+        <div class="header-actions">
+          <span :class="['status-badge', getStatusClass(camera.status)]">
+            {{ camera.status || 'Unknown' }}
+          </span>
+          <button @click="refresh">Refresh</button>
+        </div>
+      </div>
+
+      <div class="sections">
+        <!-- Basic Info -->
+        <section class="info-section">
+          <h3>Basic Information</h3>
+          <dl>
+            <dt>Account ID</dt>
+            <dd>{{ camera.accountId }}</dd>
+
+            <dt>Bridge ID</dt>
+            <dd>{{ camera.bridgeId || 'Direct to Cloud' }}</dd>
+
+            <dt>Location ID</dt>
+            <dd>{{ camera.locationId || 'Not assigned' }}</dd>
+
+            <dt v-if="camera.timezone">Timezone</dt>
+            <dd v-if="camera.timezone">{{ camera.timezone }}</dd>
+
+            <dt v-if="camera.tags && camera.tags.length > 0">Tags</dt>
+            <dd v-if="camera.tags && camera.tags.length > 0">
+              <span v-for="tag in camera.tags" :key="tag" class="tag">{{ tag }}</span>
+            </dd>
+          </dl>
+        </section>
+
+        <!-- Device Info -->
+        <section v-if="camera.deviceInfo" class="info-section">
+          <h3>Device Information</h3>
+          <dl>
+            <dt v-if="camera.deviceInfo.make">Manufacturer</dt>
+            <dd v-if="camera.deviceInfo.make">{{ camera.deviceInfo.make }}</dd>
+
+            <dt v-if="camera.deviceInfo.model">Model</dt>
+            <dd v-if="camera.deviceInfo.model">{{ camera.deviceInfo.model }}</dd>
+
+            <dt v-if="camera.deviceInfo.firmwareVersion">Firmware</dt>
+            <dd v-if="camera.deviceInfo.firmwareVersion">{{ camera.deviceInfo.firmwareVersion }}</dd>
+
+            <dt v-if="camera.deviceInfo.serialNumber">Serial Number</dt>
+            <dd v-if="camera.deviceInfo.serialNumber">{{ camera.deviceInfo.serialNumber }}</dd>
+
+            <dt v-if="camera.deviceInfo.resolution">Resolution</dt>
+            <dd v-if="camera.deviceInfo.resolution">{{ camera.deviceInfo.resolution }}</dd>
+
+            <dt>Direct to Cloud</dt>
+            <dd>{{ camera.deviceInfo.directToCloud ? 'Yes' : 'No' }}</dd>
+          </dl>
+        </section>
+
+        <!-- Network Info -->
+        <section v-if="camera.ipAddress || camera.macAddress" class="info-section">
+          <h3>Network Information</h3>
+          <dl>
+            <dt v-if="camera.ipAddress">IP Address</dt>
+            <dd v-if="camera.ipAddress">{{ camera.ipAddress }}</dd>
+
+            <dt v-if="camera.macAddress">MAC Address</dt>
+            <dd v-if="camera.macAddress">{{ camera.macAddress }}</dd>
+
+            <dt v-if="camera.guid">GUID</dt>
+            <dd v-if="camera.guid">{{ camera.guid }}</dd>
+          </dl>
+        </section>
+
+        <!-- Share Details -->
+        <section v-if="camera.shareDetails" class="info-section">
+          <h3>Sharing</h3>
+          <dl>
+            <dt>Shared</dt>
+            <dd>{{ camera.shareDetails.shared ? 'Yes' : 'No' }}</dd>
+
+            <dt v-if="camera.shareDetails.accountId">Shared with Account</dt>
+            <dd v-if="camera.shareDetails.accountId">{{ camera.shareDetails.accountId }}</dd>
+
+            <dt v-if="camera.shareDetails.firstResponder !== undefined">First Responder</dt>
+            <dd v-if="camera.shareDetails.firstResponder !== undefined">
+              {{ camera.shareDetails.firstResponder ? 'Yes' : 'No' }}
+            </dd>
+          </dl>
+        </section>
+
+        <!-- Position -->
+        <section v-if="camera.devicePosition" class="info-section">
+          <h3>Location</h3>
+          <dl>
+            <dt v-if="camera.devicePosition.latitude !== undefined">Coordinates</dt>
+            <dd v-if="camera.devicePosition.latitude !== undefined">
+              {{ camera.devicePosition.latitude }}, {{ camera.devicePosition.longitude }}
+            </dd>
+
+            <dt v-if="camera.devicePosition.floor !== undefined">Floor</dt>
+            <dd v-if="camera.devicePosition.floor !== undefined">{{ camera.devicePosition.floor }}</dd>
+
+            <dt v-if="camera.devicePosition.azimuth !== undefined">Azimuth</dt>
+            <dd v-if="camera.devicePosition.azimuth !== undefined">{{ camera.devicePosition.azimuth }}deg</dd>
+          </dl>
+        </section>
+
+        <!-- Analytics -->
+        <section v-if="camera.enabledAnalytics && camera.enabledAnalytics.length > 0" class="info-section">
+          <h3>Analytics</h3>
+          <div class="analytics-list">
+            <span v-for="analytic in camera.enabledAnalytics" :key="analytic" class="analytic-badge">
+              {{ analytic }}
+            </span>
+          </div>
+        </section>
+
+        <!-- Timestamps -->
+        <section class="info-section">
+          <h3>Timestamps</h3>
+          <dl>
+            <dt v-if="camera.createdAt">Created</dt>
+            <dd v-if="camera.createdAt">{{ new Date(camera.createdAt).toLocaleString() }}</dd>
+
+            <dt v-if="camera.updatedAt">Updated</dt>
+            <dd v-if="camera.updatedAt">{{ new Date(camera.updatedAt).toLocaleString() }}</dd>
+          </dl>
+        </section>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.camera-detail {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.nav-back {
+  margin-bottom: 20px;
+}
+
+.nav-back a {
+  color: #42b883;
+  text-decoration: none;
+}
+
+.nav-back a:hover {
+  text-decoration: underline;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 30px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid #eee;
+}
+
+.header h2 {
+  margin: 0 0 5px 0;
+}
+
+.camera-id {
+  color: #666;
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.header-actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.status-badge {
+  padding: 6px 12px;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.status-online {
+  background: #d4edda;
+  color: #155724;
+}
+
+.status-offline {
+  background: #f8d7da;
+  color: #721c24;
+}
+
+.status-error {
+  background: #fff3cd;
+  color: #856404;
+}
+
+.status-unknown {
+  background: #e2e3e5;
+  color: #383d41;
+}
+
+.sections {
+  display: grid;
+  gap: 25px;
+}
+
+.info-section {
+  background: #f9f9f9;
+  padding: 20px;
+  border-radius: 8px;
+}
+
+.info-section h3 {
+  margin: 0 0 15px 0;
+  font-size: 1rem;
+  color: #333;
+  border-bottom: 1px solid #ddd;
+  padding-bottom: 10px;
+}
+
+dl {
+  display: grid;
+  grid-template-columns: 150px 1fr;
+  gap: 10px 15px;
+  margin: 0;
+}
+
+dt {
+  font-weight: 600;
+  color: #555;
+}
+
+dd {
+  margin: 0;
+  color: #333;
+}
+
+.tag {
+  display: inline-block;
+  background: #e0e0e0;
+  padding: 2px 8px;
+  border-radius: 3px;
+  margin-right: 5px;
+  font-size: 0.85rem;
+}
+
+.analytics-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.analytic-badge {
+  background: #42b883;
+  color: white;
+  padding: 4px 10px;
+  border-radius: 4px;
+  font-size: 0.85rem;
+}
+</style>

--- a/examples/vue-cameras/src/views/Cameras.vue
+++ b/examples/vue-cameras/src/views/Cameras.vue
@@ -1,0 +1,249 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { useCameras, type CameraStatus } from 'een-api-toolkit'
+
+// Status filter
+const statusFilter = ref<CameraStatus | ''>('')
+
+// Initial fetch with common includes
+const {
+  cameras,
+  loading,
+  error,
+  hasNextPage,
+  totalSize,
+  fetchNextPage,
+  refresh,
+  setParams,
+  fetch
+} = useCameras({
+  pageSize: 20,
+  include: ['deviceInfo', 'status']
+})
+
+// Watch for status filter changes
+watch(statusFilter, async (newStatus) => {
+  if (newStatus) {
+    setParams({
+      pageSize: 20,
+      include: ['deviceInfo', 'status'],
+      status__in: [newStatus]
+    })
+  } else {
+    setParams({
+      pageSize: 20,
+      include: ['deviceInfo', 'status']
+    })
+  }
+  await fetch()
+})
+
+// Get status badge class
+function getStatusClass(status?: CameraStatus): string {
+  switch (status) {
+    case 'online':
+    case 'streaming':
+      return 'status-online'
+    case 'offline':
+    case 'deviceOffline':
+    case 'bridgeOffline':
+      return 'status-offline'
+    case 'error':
+    case 'invalidCredentials':
+      return 'status-error'
+    default:
+      return 'status-unknown'
+  }
+}
+</script>
+
+<template>
+  <div class="cameras">
+    <div class="header">
+      <h2>Cameras</h2>
+      <div class="controls">
+        <select v-model="statusFilter" class="status-filter">
+          <option value="">All Statuses</option>
+          <option value="online">Online</option>
+          <option value="streaming">Streaming</option>
+          <option value="offline">Offline</option>
+          <option value="deviceOffline">Device Offline</option>
+          <option value="bridgeOffline">Bridge Offline</option>
+          <option value="error">Error</option>
+        </select>
+        <button @click="refresh" :disabled="loading">
+          {{ loading ? 'Loading...' : 'Refresh' }}
+        </button>
+      </div>
+    </div>
+
+    <div v-if="totalSize !== undefined" class="total-count">
+      Total: {{ totalSize }} camera{{ totalSize !== 1 ? 's' : '' }}
+    </div>
+
+    <div v-if="loading && cameras.length === 0" class="loading">
+      Loading cameras...
+    </div>
+
+    <div v-else-if="error" class="error">
+      Error: {{ error.message }}
+    </div>
+
+    <div v-else>
+      <div v-if="cameras.length > 0" class="camera-grid">
+        <router-link
+          v-for="camera in cameras"
+          :key="camera.id"
+          :to="`/cameras/${camera.id}`"
+          class="camera-card"
+        >
+          <div class="camera-header">
+            <h3>{{ camera.name }}</h3>
+            <span :class="['status-badge', getStatusClass(camera.status)]">
+              {{ camera.status || 'Unknown' }}
+            </span>
+          </div>
+          <div class="camera-details">
+            <p v-if="camera.deviceInfo?.make || camera.deviceInfo?.model">
+              <strong>Device:</strong>
+              {{ camera.deviceInfo?.make || '' }} {{ camera.deviceInfo?.model || '' }}
+            </p>
+            <p v-if="camera.locationId">
+              <strong>Location:</strong> {{ camera.locationId }}
+            </p>
+            <p v-if="camera.tags && camera.tags.length > 0">
+              <strong>Tags:</strong> {{ camera.tags.join(', ') }}
+            </p>
+          </div>
+        </router-link>
+      </div>
+
+      <p v-else class="no-cameras">
+        No cameras found{{ statusFilter ? ' with selected filter' : '' }}.
+      </p>
+
+      <div v-if="hasNextPage" class="pagination">
+        <button @click="fetchNextPage" :disabled="loading">
+          {{ loading ? 'Loading...' : 'Load More' }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.cameras {
+  max-width: 1000px;
+  margin: 0 auto;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.controls {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.status-filter {
+  padding: 10px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 1rem;
+}
+
+.total-count {
+  color: #666;
+  margin-bottom: 20px;
+}
+
+.camera-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 20px;
+}
+
+.camera-card {
+  background: #fff;
+  border: 1px solid #eee;
+  border-radius: 8px;
+  padding: 20px;
+  text-decoration: none;
+  color: inherit;
+  transition: box-shadow 0.2s, border-color 0.2s;
+}
+
+.camera-card:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  border-color: #42b883;
+}
+
+.camera-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 15px;
+}
+
+.camera-header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  flex: 1;
+  margin-right: 10px;
+}
+
+.status-badge {
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.status-online {
+  background: #d4edda;
+  color: #155724;
+}
+
+.status-offline {
+  background: #f8d7da;
+  color: #721c24;
+}
+
+.status-error {
+  background: #fff3cd;
+  color: #856404;
+}
+
+.status-unknown {
+  background: #e2e3e5;
+  color: #383d41;
+}
+
+.camera-details p {
+  margin: 5px 0;
+  font-size: 0.9rem;
+  color: #666;
+}
+
+.camera-details strong {
+  color: #333;
+}
+
+.no-cameras {
+  text-align: center;
+  color: #666;
+  padding: 40px;
+}
+
+.pagination {
+  margin-top: 30px;
+  text-align: center;
+}
+</style>

--- a/examples/vue-cameras/src/views/Home.vue
+++ b/examples/vue-cameras/src/views/Home.vue
@@ -1,0 +1,125 @@
+<script setup lang="ts">
+import { useAuthStore, useCurrentUser } from 'een-api-toolkit'
+import { computed } from 'vue'
+
+const authStore = useAuthStore()
+const isAuthenticated = computed(() => authStore.isAuthenticated)
+
+// Fetch current user if authenticated
+const { user, loading, error } = useCurrentUser({ immediate: true })
+</script>
+
+<template>
+  <div class="home">
+    <h2>Welcome to the EEN Cameras Example</h2>
+
+    <div v-if="isAuthenticated">
+      <div v-if="loading" class="loading">Loading user info...</div>
+      <div v-else-if="error" class="error">{{ error.message }}</div>
+      <div v-else-if="user" class="user-info">
+        <p>Logged in as: <strong>{{ user.firstName }} {{ user.lastName }}</strong></p>
+        <p>Email: {{ user.email }}</p>
+      </div>
+
+      <div class="actions">
+        <router-link to="/cameras">
+          <button>View Cameras</button>
+        </router-link>
+      </div>
+    </div>
+
+    <div v-else class="login-prompt">
+      <p>Please log in to view your cameras.</p>
+      <router-link to="/login">
+        <button>Login</button>
+      </router-link>
+    </div>
+
+    <div class="description">
+      <h3>About This Example</h3>
+      <p>
+        This example demonstrates how to use the <code>useCameras</code> and
+        <code>useCamera</code> composables from the EEN API Toolkit to display
+        and manage cameras from the Eagle Eye Networks platform.
+      </p>
+      <h4>Features</h4>
+      <ul>
+        <li>List cameras with pagination</li>
+        <li>Filter cameras by status</li>
+        <li>View camera details</li>
+        <li>Display device information</li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.home {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+h2 {
+  margin-bottom: 20px;
+}
+
+.user-info {
+  background: #f5f5f5;
+  padding: 15px;
+  border-radius: 4px;
+  margin-bottom: 20px;
+}
+
+.user-info p {
+  margin: 5px 0;
+}
+
+.actions {
+  margin: 20px 0;
+}
+
+.login-prompt {
+  text-align: center;
+  padding: 20px;
+  background: #f5f5f5;
+  border-radius: 4px;
+  margin-bottom: 20px;
+}
+
+.login-prompt p {
+  margin-bottom: 15px;
+}
+
+.description {
+  margin-top: 40px;
+  padding-top: 20px;
+  border-top: 1px solid #eee;
+}
+
+.description h3 {
+  margin-bottom: 10px;
+}
+
+.description h4 {
+  margin-top: 15px;
+  margin-bottom: 10px;
+}
+
+.description p {
+  color: #666;
+  margin-bottom: 15px;
+}
+
+.description ul {
+  list-style: disc;
+  padding-left: 20px;
+  color: #666;
+}
+
+.description code {
+  background: #f0f0f0;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 0.9em;
+}
+</style>

--- a/examples/vue-cameras/src/views/Login.vue
+++ b/examples/vue-cameras/src/views/Login.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { getAuthUrl } from 'een-api-toolkit'
+
+function login() {
+  // Redirect to EEN OAuth login
+  window.location.href = getAuthUrl()
+}
+</script>
+
+<template>
+  <div class="login">
+    <h2>Login</h2>
+    <p>Click the button below to login with your Eagle Eye Networks account.</p>
+    <button @click="login">Login with Eagle Eye Networks</button>
+  </div>
+</template>
+
+<style scoped>
+.login {
+  text-align: center;
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+h2 {
+  margin-bottom: 20px;
+}
+
+p {
+  margin-bottom: 20px;
+  color: #666;
+}
+</style>

--- a/examples/vue-cameras/src/views/Logout.vue
+++ b/examples/vue-cameras/src/views/Logout.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { revokeToken, useAuthStore } from 'een-api-toolkit'
+
+const router = useRouter()
+const authStore = useAuthStore()
+const error = ref<string | null>(null)
+const processing = ref(true)
+
+onMounted(async () => {
+  if (!authStore.isAuthenticated) {
+    // Already logged out
+    router.push('/')
+    return
+  }
+
+  const result = await revokeToken()
+
+  if (result.error) {
+    error.value = result.error.message
+    processing.value = false
+    return
+  }
+
+  // Success - redirect to home
+  router.push('/')
+})
+</script>
+
+<template>
+  <div class="logout">
+    <div v-if="processing" class="loading">
+      <h2>Logging out...</h2>
+      <p>Please wait while we complete the logout process.</p>
+    </div>
+
+    <div v-else-if="error" class="error-state">
+      <h2>Logout Failed</h2>
+      <p class="error">{{ error }}</p>
+      <router-link to="/">
+        <button>Return Home</button>
+      </router-link>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.logout {
+  text-align: center;
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+h2 {
+  margin-bottom: 20px;
+}
+
+.loading p {
+  color: #666;
+}
+
+.error-state .error {
+  margin-bottom: 20px;
+}
+</style>

--- a/examples/vue-cameras/src/vite-env.d.ts
+++ b/examples/vue-cameras/src/vite-env.d.ts
@@ -1,0 +1,12 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_PROXY_URL: string
+  readonly VITE_EEN_CLIENT_ID: string
+  readonly VITE_REDIRECT_URI?: string
+  readonly VITE_DEBUG?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/examples/vue-cameras/tsconfig.json
+++ b/examples/vue-cameras/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "preserve",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/examples/vue-cameras/tsconfig.node.json
+++ b/examples/vue-cameras/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/examples/vue-cameras/vite.config.ts
+++ b/examples/vue-cameras/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+  server: {
+    // IMPORTANT: Must use 127.0.0.1:3333 for EEN OAuth callback
+    // The EEN Identity Provider only permits this specific redirect URI
+    host: '127.0.0.1',
+    port: 3333
+  }
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit",
-      "version": "0.0.14",
+      "version": "0.0.15",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.57.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.57.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "EEN Video platform API v3.0 library for Vue 3",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "EEN Video platform API v3.0 library for Vue 3",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/scripts/generate-ai-context.ts
+++ b/scripts/generate-ai-context.ts
@@ -64,6 +64,13 @@ function generateQuickReference(): string {
 | \`getUsers(params?)\` | List all users (paginated) | \`Result<PaginatedResult<User>>\` |
 | \`getUser(userId, params?)\` | Get a specific user | \`Result<User>\` |
 
+### Camera Functions
+
+| Function | Purpose | Returns |
+|----------|---------|---------|
+| \`getCameras(params?)\` | List all cameras (paginated) | \`Result<PaginatedResult<Camera>>\` |
+| \`getCamera(cameraId, params?)\` | Get a specific camera | \`Result<Camera>\` |
+
 ### Vue 3 Composables
 
 | Composable | Purpose | Returns |
@@ -71,6 +78,8 @@ function generateQuickReference(): string {
 | \`useCurrentUser(options?)\` | Reactive current user | \`{ user, loading, error, refresh }\` |
 | \`useUsers(params?, options?)\` | Reactive user list with pagination | \`{ users, loading, hasNextPage, fetchNextPage, ... }\` |
 | \`useUser(userId, options?)\` | Reactive single user | \`{ user, loading, error, refresh }\` |
+| \`useCameras(params?, options?)\` | Reactive camera list with pagination | \`{ cameras, loading, hasNextPage, fetchNextPage, ... }\` |
+| \`useCamera(cameraId, options?)\` | Reactive single camera | \`{ camera, loading, error, refresh }\` |
 
 ---
 
@@ -245,7 +254,65 @@ interface UserProfile {
 }
 \`\`\`
 
-### Parameter Types
+### Camera
+
+\`\`\`typescript
+type CameraStatus =
+  | 'online' | 'offline' | 'deviceOffline' | 'bridgeOffline'
+  | 'invalidCredentials' | 'error' | 'streaming' | 'registered'
+  | 'attaching' | 'initializing'
+
+interface Camera {
+  id: string
+  name: string
+  accountId: string
+  bridgeId?: string | null
+  locationId?: string | null
+  status?: CameraStatus
+  timezone?: string
+  guid?: string
+  ipAddress?: string
+  macAddress?: string
+  tags?: string[]
+  notes?: string
+  multiCameraId?: string
+  recordingModes?: CameraRecordingModes
+  deviceInfo?: CameraDeviceInfo
+  shareDetails?: CameraShareDetails
+  devicePosition?: CameraDevicePosition
+  enabledAnalytics?: string[]
+  packages?: string[]
+  createdAt?: string
+  updatedAt?: string
+}
+
+interface CameraDeviceInfo {
+  make?: string           // Manufacturer (e.g., "Axis", "Hikvision")
+  model?: string          // Model name
+  firmwareVersion?: string
+  directToCloud?: boolean // Direct-to-cloud camera (no bridge)
+  serialNumber?: string
+  resolution?: string
+  type?: string           // Camera type (e.g., "IP", "Analog")
+}
+
+interface CameraShareDetails {
+  shared?: boolean
+  accountId?: string      // Sharing account ID
+  firstResponder?: boolean
+  permissions?: string[]
+}
+
+interface CameraDevicePosition {
+  latitude?: number
+  longitude?: number
+  altitude?: number
+  floor?: number
+  azimuth?: number
+}
+\`\`\`
+
+### User Parameter Types
 
 \`\`\`typescript
 interface ListUsersParams {
@@ -256,6 +323,41 @@ interface ListUsersParams {
 
 interface GetUserParams {
   include?: string[]   // Additional fields to include
+}
+\`\`\`
+
+### Camera Parameter Types
+
+\`\`\`typescript
+interface ListCamerasParams {
+  pageSize?: number           // Results per page
+  pageToken?: string          // Pagination token
+  include?: string[]          // Additional fields to include
+  sort?: string[]             // Sort order
+  status__in?: CameraStatus[] // Filter by status
+  status__ne?: CameraStatus   // Exclude by status
+  tags__contains?: string[]   // Filter by tags (all must match)
+  tags__any?: string[]        // Filter by tags (any match)
+  name?: string               // Exact name match
+  name__contains?: string     // Partial name match
+  name__in?: string[]         // Name in list
+  id__in?: string[]           // ID in list
+  id__notIn?: string[]        // ID not in list
+  bridgeId__in?: string[]     // Bridge ID filter
+  locationId__in?: string[]   // Location ID filter
+  shared?: boolean            // Shared camera filter
+  directToCloud?: boolean     // Direct-to-cloud filter
+  q?: string                  // Full-text search
+  // ... and more filter parameters
+}
+
+interface GetCameraParams {
+  include?: string[]  // Valid values: bridge, account, status, locationSummary,
+                      // deviceAddress, timeZone, notes, tags, devicePosition,
+                      // networkInfo, deviceInfo, effectivePermissions, firmware,
+                      // shareDetails, visibleByBridges, capabilities, analog,
+                      // packages, dewarpConfig, adminCredentials,
+                      // publicSafetySharing, enabledAnalytics
 }
 \`\`\`
 
@@ -385,6 +487,54 @@ const { data: userWithPerms } = await getUser('user-id-123', {
 })
 \`\`\`
 
+### getCameras
+
+List cameras with optional pagination and filtering.
+
+\`\`\`typescript
+import { getCameras } from 'een-api-toolkit'
+
+// Basic usage
+const { data, error } = await getCameras()
+
+// With pagination
+const { data } = await getCameras({ pageSize: 50 })
+
+// With status filter
+const { data } = await getCameras({
+  pageSize: 20,
+  status__in: ['online', 'streaming']
+})
+
+// With search
+const { data } = await getCameras({
+  q: 'front door',
+  include: ['deviceInfo', 'status']
+})
+\`\`\`
+
+### getCamera
+
+Get a specific camera by ID.
+
+\`\`\`typescript
+import { getCamera } from 'een-api-toolkit'
+
+const { data, error } = await getCamera('camera-id-123')
+
+if (error) {
+  if (error.code === 'NOT_FOUND') {
+    console.log('Camera not found')
+  }
+  return
+}
+
+// With additional fields
+const { data: cameraWithDetails } = await getCamera('camera-id-123', {
+  include: ['deviceInfo', 'status', 'shareDetails']
+})
+\`\`\`
+
 ---
 
 `
@@ -496,6 +646,87 @@ const { user: userWithPerms } = useUser('user-123', {
 - \`error: Ref<EenError | null>\` - Last error
 - \`fetch(params?): Promise<Result<User>>\` - Fetch user
 - \`refresh(): Promise<Result<User>>\` - Refresh user
+
+### useCameras
+
+Reactive composable for listing cameras with pagination and filtering.
+
+\`\`\`vue
+<script setup>
+import { useCameras } from 'een-api-toolkit'
+
+const {
+  cameras,
+  loading,
+  error,
+  hasNextPage,
+  fetchNextPage,
+  refresh,
+  setParams
+} = useCameras({ pageSize: 20 })
+
+// Filter by status
+function showOnlineCameras() {
+  setParams({ status__in: ['online', 'streaming'] })
+  refresh()
+}
+</script>
+
+<template>
+  <ul>
+    <li v-for="camera in cameras" :key="camera.id">
+      {{ camera.name }} - {{ camera.status || 'Unknown' }}
+    </li>
+  </ul>
+  <button v-if="hasNextPage" @click="fetchNextPage">Load More</button>
+</template>
+\`\`\`
+
+**Returns:**
+- \`cameras: Ref<Camera[]>\` - Array of cameras
+- \`loading: Ref<boolean>\` - Fetch in progress
+- \`error: Ref<EenError | null>\` - Last error
+- \`hasNextPage: ComputedRef<boolean>\` - More pages available
+- \`hasPrevPage: ComputedRef<boolean>\` - Previous page available
+- \`nextPageToken: Ref<string | undefined>\` - Next page token
+- \`totalSize: Ref<number | undefined>\` - Total count
+- \`params: Ref<ListCamerasParams>\` - Current params
+- \`fetch(params?): Promise<Result>\` - Fetch with params
+- \`refresh(): Promise<Result>\` - Refresh current page
+- \`fetchNextPage(): Promise<Result | undefined>\` - Fetch next page
+- \`fetchPrevPage(): Promise<Result | undefined>\` - Fetch previous page
+- \`setParams(params): void\` - Update default params
+
+### useCamera
+
+Reactive composable for a single camera by ID.
+
+\`\`\`vue
+<script setup>
+import { useCamera } from 'een-api-toolkit'
+import { useRoute } from 'vue-router'
+
+const route = useRoute()
+
+// Static ID
+const { camera, loading, error } = useCamera('camera-123')
+
+// Reactive ID from route
+const { camera: routeCamera } = useCamera(() => route.params.id as string)
+
+// With additional fields
+const { camera: cameraWithDetails } = useCamera('camera-123', {
+  include: ['deviceInfo', 'status', 'shareDetails']
+})
+</script>
+\`\`\`
+
+**Returns:**
+- \`camera: Ref<Camera | null>\` - The camera
+- \`loading: Ref<boolean>\` - Fetch in progress
+- \`error: Ref<EenError | null>\` - Last error
+- \`fetch(params?): Promise<Result<Camera>>\` - Fetch camera
+- \`refresh(): Promise<Result<Camera>>\` - Refresh camera
 
 ---
 

--- a/scripts/generate-ai-context.ts
+++ b/scripts/generate-ai-context.ts
@@ -691,10 +691,10 @@ function showOnlineCameras() {
 - \`nextPageToken: Ref<string | undefined>\` - Next page token
 - \`totalSize: Ref<number | undefined>\` - Total count
 - \`params: Ref<ListCamerasParams>\` - Current params
-- \`fetch(params?): Promise<Result>\` - Fetch with params
-- \`refresh(): Promise<Result>\` - Refresh current page
-- \`fetchNextPage(): Promise<Result | undefined>\` - Fetch next page
-- \`fetchPrevPage(): Promise<Result | undefined>\` - Fetch previous page
+- \`fetch(params?): Promise<Result<PaginatedResult<Camera>>>\` - Fetch with params
+- \`refresh(): Promise<Result<PaginatedResult<Camera>>>\` - Refresh current page
+- \`fetchNextPage(): Promise<Result<PaginatedResult<Camera>> | undefined>\` - Fetch next page
+- \`fetchPrevPage(): Promise<Result<PaginatedResult<Camera>> | undefined>\` - Fetch previous page
 - \`setParams(params): void\` - Update default params
 
 ### useCamera

--- a/src/__tests__/cameras.test.ts
+++ b/src/__tests__/cameras.test.ts
@@ -1,0 +1,387 @@
+import { describe, it, expect } from 'vitest'
+import type {
+  Camera,
+  CameraStatus,
+  CameraDeviceInfo,
+  CameraShareDetails,
+  CameraStreamUrls,
+  CameraRtspConnectionSettings,
+  CameraDevicePosition,
+  CameraRecordingModes,
+  ListCamerasParams,
+  GetCameraParams
+} from '../types'
+
+describe('Camera types', () => {
+  describe('Camera interface', () => {
+    it('should accept a minimal camera object', () => {
+      const camera: Camera = {
+        id: 'cam-123',
+        name: 'Front Door',
+        accountId: 'acc-456'
+      }
+
+      expect(camera.id).toBe('cam-123')
+      expect(camera.name).toBe('Front Door')
+      expect(camera.accountId).toBe('acc-456')
+    })
+
+    it('should accept a full camera object with all optional fields', () => {
+      const camera: Camera = {
+        id: 'cam-123',
+        name: 'Front Door',
+        accountId: 'acc-456',
+        bridgeId: 'bridge-789',
+        locationId: 'loc-001',
+        guid: 'guid-xyz',
+        macAddress: '00:11:22:33:44:55',
+        ipAddress: '192.168.1.100',
+        timezone: 'America/Los_Angeles',
+        status: 'online',
+        tags: ['entrance', 'security'],
+        packages: ['analytics'],
+        multiCameraId: null,
+        speakerId: null,
+        deviceInfo: {
+          make: 'Axis',
+          model: 'P1375',
+          firmwareVersion: '10.12.0',
+          directToCloud: false,
+          serialNumber: 'SN123456',
+          resolution: '1080p',
+          type: 'IP'
+        },
+        shareDetails: {
+          shared: false,
+          accountId: 'acc-share',
+          firstResponder: false,
+          permissions: ['view', 'ptz']
+        },
+        streamUrls: {
+          hls: 'https://example.com/hls',
+          rtsp: 'rtsp://example.com/stream',
+          webrtc: 'https://example.com/webrtc',
+          jpeg: 'https://example.com/snapshot.jpg'
+        },
+        rtspConnectionSettings: {
+          url: 'rtsp://camera.local/stream',
+          username: 'admin',
+          transport: 'tcp'
+        },
+        devicePosition: {
+          latitude: 37.7749,
+          longitude: -122.4194,
+          altitude: 10,
+          floor: 1,
+          azimuth: 180
+        },
+        enabledAnalytics: ['motion', 'lineCrossing'],
+        recordingModes: {
+          continuous: true,
+          motion: true,
+          scheduled: false
+        },
+        createdAt: '2024-01-15T10:30:00Z',
+        updatedAt: '2024-06-20T14:45:00Z'
+      }
+
+      expect(camera.id).toBe('cam-123')
+      expect(camera.deviceInfo?.make).toBe('Axis')
+      expect(camera.status).toBe('online')
+      expect(camera.tags).toContain('entrance')
+      expect(camera.streamUrls?.hls).toBe('https://example.com/hls')
+      expect(camera.devicePosition?.latitude).toBe(37.7749)
+      expect(camera.recordingModes?.continuous).toBe(true)
+    })
+
+    it('should accept null for bridgeId and locationId', () => {
+      const camera: Camera = {
+        id: 'cam-direct',
+        name: 'Direct Cloud Camera',
+        accountId: 'acc-456',
+        bridgeId: null,
+        locationId: null
+      }
+
+      expect(camera.bridgeId).toBeNull()
+      expect(camera.locationId).toBeNull()
+    })
+  })
+
+  describe('CameraStatus type', () => {
+    it('should accept all valid status values', () => {
+      const statuses: CameraStatus[] = [
+        'online',
+        'offline',
+        'deviceOffline',
+        'bridgeOffline',
+        'invalidCredentials',
+        'error',
+        'streaming',
+        'registered',
+        'attaching',
+        'initializing'
+      ]
+
+      expect(statuses).toHaveLength(10)
+      expect(statuses).toContain('online')
+      expect(statuses).toContain('offline')
+      expect(statuses).toContain('streaming')
+    })
+  })
+
+  describe('CameraDeviceInfo interface', () => {
+    it('should accept device info with all fields', () => {
+      const deviceInfo: CameraDeviceInfo = {
+        make: 'Hikvision',
+        model: 'DS-2CD2143G2-I',
+        firmwareVersion: '5.7.1',
+        directToCloud: true,
+        serialNumber: 'HV123456789',
+        resolution: '4MP',
+        type: 'IP'
+      }
+
+      expect(deviceInfo.make).toBe('Hikvision')
+      expect(deviceInfo.directToCloud).toBe(true)
+    })
+  })
+
+  describe('CameraShareDetails interface', () => {
+    it('should accept share details', () => {
+      const shareDetails: CameraShareDetails = {
+        shared: true,
+        accountId: 'acc-shared',
+        firstResponder: true,
+        permissions: ['view', 'ptz', 'audio']
+      }
+
+      expect(shareDetails.shared).toBe(true)
+      expect(shareDetails.permissions).toContain('ptz')
+    })
+  })
+
+  describe('CameraStreamUrls interface', () => {
+    it('should accept stream URLs', () => {
+      const streamUrls: CameraStreamUrls = {
+        hls: 'https://stream.example.com/cam/hls',
+        rtsp: 'rtsp://stream.example.com/cam',
+        webrtc: 'https://webrtc.example.com/cam',
+        jpeg: 'https://stream.example.com/cam/snapshot.jpg'
+      }
+
+      expect(streamUrls.hls).toContain('hls')
+      expect(streamUrls.rtsp).toContain('rtsp://')
+    })
+  })
+
+  describe('CameraRtspConnectionSettings interface', () => {
+    it('should accept RTSP settings', () => {
+      const rtspSettings: CameraRtspConnectionSettings = {
+        url: 'rtsp://192.168.1.100:554/stream1',
+        username: 'admin',
+        transport: 'tcp'
+      }
+
+      expect(rtspSettings.url).toContain('rtsp://')
+      expect(rtspSettings.transport).toBe('tcp')
+    })
+
+    it('should accept udp transport', () => {
+      const rtspSettings: CameraRtspConnectionSettings = {
+        url: 'rtsp://camera/stream',
+        transport: 'udp'
+      }
+
+      expect(rtspSettings.transport).toBe('udp')
+    })
+  })
+
+  describe('CameraDevicePosition interface', () => {
+    it('should accept position data', () => {
+      const position: CameraDevicePosition = {
+        latitude: 40.7128,
+        longitude: -74.0060,
+        altitude: 50,
+        floor: 3,
+        azimuth: 270
+      }
+
+      expect(position.latitude).toBe(40.7128)
+      expect(position.floor).toBe(3)
+    })
+  })
+
+  describe('CameraRecordingModes interface', () => {
+    it('should accept recording modes', () => {
+      const modes: CameraRecordingModes = {
+        continuous: true,
+        motion: true,
+        scheduled: false
+      }
+
+      expect(modes.continuous).toBe(true)
+      expect(modes.scheduled).toBe(false)
+    })
+  })
+
+  describe('ListCamerasParams interface', () => {
+    it('should accept pagination parameters', () => {
+      const params: ListCamerasParams = {
+        pageSize: 50,
+        pageToken: 'abc123'
+      }
+
+      expect(params.pageSize).toBe(50)
+      expect(params.pageToken).toBe('abc123')
+    })
+
+    it('should accept include and sort parameters', () => {
+      const params: ListCamerasParams = {
+        include: ['deviceInfo', 'streamUrls', 'shareDetails'],
+        sort: ['-createdAt', 'name']
+      }
+
+      expect(params.include).toContain('deviceInfo')
+      expect(params.sort).toContain('-createdAt')
+    })
+
+    it('should accept location and bridge filters', () => {
+      const params: ListCamerasParams = {
+        locationId__in: ['loc-1', 'loc-2'],
+        bridgeId__in: ['bridge-1', 'bridge-2']
+      }
+
+      expect(params.locationId__in).toHaveLength(2)
+      expect(params.bridgeId__in).toContain('bridge-1')
+    })
+
+    it('should accept multi-camera filters', () => {
+      const params: ListCamerasParams = {
+        multiCameraId: 'multi-123',
+        multiCameraId__ne: 'multi-456',
+        multiCameraId__in: ['multi-1', 'multi-2']
+      }
+
+      expect(params.multiCameraId).toBe('multi-123')
+      expect(params.multiCameraId__ne).toBe('multi-456')
+    })
+
+    it('should accept tag and package filters', () => {
+      const params: ListCamerasParams = {
+        tags__contains: ['security', 'entrance'],
+        tags__any: ['outdoor', 'indoor'],
+        packages__contains: ['analytics']
+      }
+
+      expect(params.tags__contains).toContain('security')
+      expect(params.tags__any).toContain('outdoor')
+    })
+
+    it('should accept name filters', () => {
+      const params: ListCamerasParams = {
+        name: 'Front Door',
+        name__contains: 'door',
+        name__in: ['Front Door', 'Back Door']
+      }
+
+      expect(params.name).toBe('Front Door')
+      expect(params.name__contains).toBe('door')
+    })
+
+    it('should accept ID filters', () => {
+      const params: ListCamerasParams = {
+        id__in: ['cam-1', 'cam-2'],
+        id__notIn: ['cam-3'],
+        id__contains: 'cam-'
+      }
+
+      expect(params.id__in).toHaveLength(2)
+      expect(params.id__notIn).toContain('cam-3')
+    })
+
+    it('should accept share detail filters', () => {
+      const params: ListCamerasParams = {
+        shared: true,
+        sharedCameraAccount: 'acc-123',
+        firstResponder: false
+      }
+
+      expect(params.shared).toBe(true)
+      expect(params.firstResponder).toBe(false)
+    })
+
+    it('should accept device filters', () => {
+      const params: ListCamerasParams = {
+        directToCloud: true
+      }
+
+      expect(params.directToCloud).toBe(true)
+    })
+
+    it('should accept search parameters', () => {
+      const params: ListCamerasParams = {
+        q: 'front door camera',
+        qRelevance__gte: 0.5
+      }
+
+      expect(params.q).toBe('front door camera')
+      expect(params.qRelevance__gte).toBe(0.5)
+    })
+
+    it('should accept analytics filter', () => {
+      const params: ListCamerasParams = {
+        enabledAnalytics__contains: ['motion', 'lineCrossing']
+      }
+
+      expect(params.enabledAnalytics__contains).toContain('motion')
+    })
+
+    it('should accept status filters', () => {
+      const params: ListCamerasParams = {
+        status__in: ['online', 'streaming'],
+        status__ne: 'offline'
+      }
+
+      expect(params.status__in).toContain('online')
+      expect(params.status__ne).toBe('offline')
+    })
+
+    it('should accept all filter parameters together', () => {
+      const params: ListCamerasParams = {
+        pageSize: 100,
+        pageToken: 'token123',
+        include: ['deviceInfo'],
+        sort: ['name'],
+        locationId__in: ['loc-1'],
+        bridgeId__in: ['bridge-1'],
+        status__in: ['online'],
+        tags__contains: ['security'],
+        q: 'search term',
+        directToCloud: false,
+        shared: false
+      }
+
+      expect(params.pageSize).toBe(100)
+      expect(params.status__in).toContain('online')
+      expect(params.directToCloud).toBe(false)
+    })
+  })
+
+  describe('GetCameraParams interface', () => {
+    it('should accept include parameter', () => {
+      const params: GetCameraParams = {
+        include: ['deviceInfo', 'streamUrls', 'shareDetails']
+      }
+
+      expect(params.include).toContain('deviceInfo')
+      expect(params.include).toHaveLength(3)
+    })
+
+    it('should accept empty params', () => {
+      const params: GetCameraParams = {}
+
+      expect(params.include).toBeUndefined()
+    })
+  })
+})

--- a/src/cameras/composables.ts
+++ b/src/cameras/composables.ts
@@ -1,4 +1,4 @@
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { getCameras, getCamera } from './service'
 import type { Camera, EenError, ListCamerasParams, GetCameraParams } from '../types'
 
@@ -215,7 +215,7 @@ export interface UseCameraOptions {
  * ```typescript
  * // With additional fields
  * const { camera } = useCamera('camera-123', {
- *   include: ['deviceInfo', 'streamUrls']
+ *   include: ['deviceInfo', 'status', 'shareDetails']
  * })
  *
  * // Access device info when loaded
@@ -274,6 +274,15 @@ export function useCamera(cameraId: string | (() => string), options?: UseCamera
   // Fetch immediately by default if cameraId is provided
   if (options?.immediate !== false && resolveCameraId()) {
     onMounted(fetch)
+  }
+
+  // Watch for camera ID changes when using a getter function
+  if (typeof cameraId === 'function') {
+    watch(cameraId, (newId, oldId) => {
+      if (newId && newId !== oldId) {
+        fetch()
+      }
+    })
   }
 
   return {

--- a/src/cameras/composables.ts
+++ b/src/cameras/composables.ts
@@ -1,0 +1,286 @@
+import { ref, computed, onMounted } from 'vue'
+import { getCameras, getCamera } from './service'
+import type { Camera, EenError, ListCamerasParams, GetCameraParams } from '../types'
+
+/**
+ * Options for the useCameras composable.
+ *
+ * @category Cameras
+ */
+export interface UseCamerasOptions {
+  /**
+   * Whether to fetch cameras immediately on mount.
+   * @defaultValue true
+   */
+  immediate?: boolean
+}
+
+/**
+ * Vue 3 composable for listing cameras with pagination.
+ *
+ * @remarks
+ * Provides reactive access to a paginated list of cameras with built-in
+ * pagination controls. Automatically fetches on mount unless disabled.
+ *
+ * @param initialParams - Initial pagination/filter parameters
+ * @param options - Configuration options
+ * @returns Reactive cameras state and pagination controls
+ *
+ * @example
+ * ```vue
+ * <script setup>
+ * import { useCameras } from 'een-api-toolkit'
+ *
+ * const {
+ *   cameras,
+ *   loading,
+ *   error,
+ *   hasNextPage,
+ *   fetchNextPage,
+ *   refresh
+ * } = useCameras({ pageSize: 20, status__in: ['online'] })
+ * </script>
+ *
+ * <template>
+ *   <div v-if="loading">Loading...</div>
+ *   <div v-else-if="error">Error: {{ error.message }}</div>
+ *   <div v-else>
+ *     <ul>
+ *       <li v-for="camera in cameras" :key="camera.id">
+ *         {{ camera.name }} ({{ camera.status }})
+ *       </li>
+ *     </ul>
+ *     <button v-if="hasNextPage" @click="fetchNextPage">Load More</button>
+ *     <button @click="refresh">Refresh</button>
+ *   </div>
+ * </template>
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // Change parameters dynamically
+ * const { cameras, setParams, fetch } = useCameras()
+ *
+ * async function filterByStatus(status: string) {
+ *   setParams({ pageSize: 50, status__in: [status] })
+ *   await fetch()
+ * }
+ * ```
+ *
+ * @category Cameras
+ */
+export function useCameras(initialParams?: ListCamerasParams, options?: UseCamerasOptions) {
+  /** Array of cameras for the current page */
+  const cameras = ref<Camera[]>([])
+  /** Whether a fetch is in progress */
+  const loading = ref(false)
+  /** The last error that occurred, or null if successful */
+  const error = ref<EenError | null>(null)
+  /** Token for fetching the next page */
+  const nextPageToken = ref<string | undefined>(undefined)
+  /** Token for fetching the previous page */
+  const prevPageToken = ref<string | undefined>(undefined)
+  /** Total number of cameras (if provided by API) */
+  const totalSize = ref<number | undefined>(undefined)
+
+  /** Whether there is a next page available */
+  const hasNextPage = computed(() => !!nextPageToken.value)
+  /** Whether there is a previous page available */
+  const hasPrevPage = computed(() => !!prevPageToken.value)
+
+  /** Current pagination/filter parameters */
+  const params = ref<ListCamerasParams>(initialParams ?? {})
+
+  const fetch = async (fetchParams?: ListCamerasParams) => {
+    loading.value = true
+    error.value = null
+
+    const mergedParams = { ...params.value, ...fetchParams }
+    const result = await getCameras(mergedParams)
+
+    if (result.error) {
+      error.value = result.error
+      cameras.value = []
+      nextPageToken.value = undefined
+      prevPageToken.value = undefined
+      totalSize.value = undefined
+    } else {
+      cameras.value = result.data.results
+      nextPageToken.value = result.data.nextPageToken
+      prevPageToken.value = result.data.prevPageToken
+      totalSize.value = result.data.totalSize
+    }
+
+    loading.value = false
+    return result
+  }
+
+  /** Refresh the current page */
+  const refresh = () => fetch()
+
+  /** Fetch the next page of results */
+  const fetchNextPage = async () => {
+    if (!nextPageToken.value) return
+    return fetch({ ...params.value, pageToken: nextPageToken.value })
+  }
+
+  /** Fetch the previous page of results */
+  const fetchPrevPage = async () => {
+    if (!prevPageToken.value) return
+    return fetch({ ...params.value, pageToken: prevPageToken.value })
+  }
+
+  /** Update the pagination/filter parameters */
+  const setParams = (newParams: ListCamerasParams) => {
+    params.value = newParams
+  }
+
+  // Fetch immediately by default
+  if (options?.immediate !== false) {
+    onMounted(fetch)
+  }
+
+  return {
+    cameras,
+    loading,
+    error,
+    nextPageToken,
+    prevPageToken,
+    totalSize,
+    hasNextPage,
+    hasPrevPage,
+    params,
+    fetch,
+    refresh,
+    fetchNextPage,
+    fetchPrevPage,
+    setParams
+  }
+}
+
+/**
+ * Options for the useCamera composable.
+ *
+ * @category Cameras
+ */
+export interface UseCameraOptions {
+  /**
+   * Whether to fetch the camera immediately on mount.
+   * @defaultValue true
+   */
+  immediate?: boolean
+  /**
+   * Additional fields to include in the response.
+   */
+  include?: string[]
+}
+
+/**
+ * Vue 3 composable for getting a single camera by ID.
+ *
+ * @remarks
+ * Provides reactive access to a specific camera. The camera ID can be provided
+ * as a string or a getter function (useful for reactive route params).
+ *
+ * @param cameraId - The camera ID (string or getter function)
+ * @param options - Configuration options
+ * @returns Reactive camera state and control functions
+ *
+ * @example
+ * ```vue
+ * <script setup>
+ * import { useCamera } from 'een-api-toolkit'
+ * import { useRoute } from 'vue-router'
+ *
+ * const route = useRoute()
+ *
+ * // Static ID
+ * const { camera, loading, error } = useCamera('camera-123')
+ *
+ * // Or reactive ID from route
+ * const { camera: routeCamera } = useCamera(() => route.params.id as string)
+ * </script>
+ *
+ * <template>
+ *   <div v-if="loading">Loading...</div>
+ *   <div v-else-if="error">Error: {{ error.message }}</div>
+ *   <div v-else-if="camera">
+ *     <h1>{{ camera.name }}</h1>
+ *     <p>Status: {{ camera.status }}</p>
+ *   </div>
+ * </template>
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // With additional fields
+ * const { camera } = useCamera('camera-123', {
+ *   include: ['deviceInfo', 'streamUrls']
+ * })
+ *
+ * // Access device info when loaded
+ * watchEffect(() => {
+ *   if (camera.value?.deviceInfo) {
+ *     console.log('Camera make:', camera.value.deviceInfo.make)
+ *   }
+ * })
+ * ```
+ *
+ * @category Cameras
+ */
+export function useCamera(cameraId: string | (() => string), options?: UseCameraOptions) {
+  /** The camera, or null if not loaded */
+  const camera = ref<Camera | null>(null)
+  /** Whether a fetch is in progress */
+  const loading = ref(false)
+  /** The last error that occurred, or null if successful */
+  const error = ref<EenError | null>(null)
+
+  const resolveCameraId = () => {
+    return typeof cameraId === 'function' ? cameraId() : cameraId
+  }
+
+  const fetch = async (params?: GetCameraParams) => {
+    const id = resolveCameraId()
+    if (!id) {
+      error.value = { code: 'VALIDATION_ERROR', message: 'Camera ID is required' }
+      return { data: null, error: error.value }
+    }
+
+    loading.value = true
+    error.value = null
+
+    const mergedParams: GetCameraParams = {
+      include: options?.include,
+      ...params
+    }
+
+    const result = await getCamera(id, mergedParams)
+
+    if (result.error) {
+      error.value = result.error
+      camera.value = null
+    } else {
+      camera.value = result.data
+    }
+
+    loading.value = false
+    return result
+  }
+
+  /** Refresh the camera data */
+  const refresh = () => fetch()
+
+  // Fetch immediately by default if cameraId is provided
+  if (options?.immediate !== false && resolveCameraId()) {
+    onMounted(fetch)
+  }
+
+  return {
+    camera,
+    loading,
+    error,
+    fetch,
+    refresh
+  }
+}

--- a/src/cameras/index.ts
+++ b/src/cameras/index.ts
@@ -1,0 +1,11 @@
+// Plain functions
+export { getCameras, getCamera } from './service'
+
+// Composables
+export { useCameras, useCamera } from './composables'
+
+// Composable option types
+export type {
+  UseCamerasOptions,
+  UseCameraOptions
+} from './composables'

--- a/src/cameras/service.ts
+++ b/src/cameras/service.ts
@@ -295,7 +295,8 @@ async function handleErrorResponse<T>(response: Response): Promise<Result<T>> {
   try {
     const errorData = await response.json()
     message = errorData.message ?? errorData.error ?? response.statusText
-  } catch {
+  } catch (parseError) {
+    debug('Failed to parse error response JSON:', parseError)
     message = response.statusText || 'Unknown error'
   }
 

--- a/src/cameras/service.ts
+++ b/src/cameras/service.ts
@@ -1,0 +1,314 @@
+import { useAuthStore } from '../auth/store'
+import { success, failure } from '../types'
+import type { Result, PaginatedResult, Camera, ListCamerasParams, GetCameraParams } from '../types'
+import { debug } from '../utils/debug'
+
+/**
+ * List cameras with optional pagination and filtering.
+ *
+ * @remarks
+ * Fetches a paginated list of cameras from `/api/v3.0/cameras`. Supports
+ * extensive filtering options for location, status, tags, and more.
+ *
+ * For more details, see the
+ * [EEN API Documentation](https://developer.eagleeyenetworks.com/reference/listcameras).
+ *
+ * @param params - Optional pagination and filtering parameters
+ * @returns A Result containing a paginated list of cameras or an error
+ *
+ * @example
+ * ```typescript
+ * import { getCameras } from 'een-api-toolkit'
+ *
+ * // Basic usage
+ * const { data, error } = await getCameras()
+ * if (data) {
+ *   console.log(`Found ${data.results.length} cameras`)
+ * }
+ *
+ * // With filters
+ * const { data } = await getCameras({
+ *   pageSize: 50,
+ *   status__in: ['online'],
+ *   include: ['deviceInfo', 'streamUrls']
+ * })
+ *
+ * // Fetch all cameras
+ * let allCameras: Camera[] = []
+ * let pageToken: string | undefined
+ * do {
+ *   const { data, error } = await getCameras({ pageSize: 100, pageToken })
+ *   if (error) break
+ *   allCameras.push(...data.results)
+ *   pageToken = data.nextPageToken
+ * } while (pageToken)
+ * ```
+ *
+ * @category Cameras
+ */
+export async function getCameras(params?: ListCamerasParams): Promise<Result<PaginatedResult<Camera>>> {
+  const authStore = useAuthStore()
+
+  if (!authStore.isAuthenticated) {
+    return failure('AUTH_REQUIRED', 'Authentication required')
+  }
+
+  if (!authStore.baseUrl) {
+    return failure('AUTH_REQUIRED', 'Base URL not configured')
+  }
+
+  const queryParams = new URLSearchParams()
+
+  // Pagination
+  if (params?.pageSize) {
+    queryParams.append('pageSize', String(params.pageSize))
+  }
+  if (params?.pageToken) {
+    queryParams.append('pageToken', params.pageToken)
+  }
+
+  // Include/Sort
+  if (params?.include && params.include.length > 0) {
+    queryParams.append('include', params.include.join(','))
+  }
+  if (params?.sort && params.sort.length > 0) {
+    queryParams.append('sort', params.sort.join(','))
+  }
+
+  // Location/Bridge filters
+  if (params?.locationId__in && params.locationId__in.length > 0) {
+    queryParams.append('locationId__in', params.locationId__in.join(','))
+  }
+  if (params?.bridgeId__in && params.bridgeId__in.length > 0) {
+    queryParams.append('bridgeId__in', params.bridgeId__in.join(','))
+  }
+
+  // Multi-camera filters
+  if (params?.multiCameraId) {
+    queryParams.append('multiCameraId', params.multiCameraId)
+  }
+  if (params?.multiCameraId__ne) {
+    queryParams.append('multiCameraId__ne', params.multiCameraId__ne)
+  }
+  if (params?.multiCameraId__in && params.multiCameraId__in.length > 0) {
+    queryParams.append('multiCameraId__in', params.multiCameraId__in.join(','))
+  }
+
+  // Tag/Package filters
+  if (params?.tags__contains && params.tags__contains.length > 0) {
+    queryParams.append('tags__contains', params.tags__contains.join(','))
+  }
+  if (params?.tags__any && params.tags__any.length > 0) {
+    queryParams.append('tags__any', params.tags__any.join(','))
+  }
+  if (params?.packages__contains && params.packages__contains.length > 0) {
+    queryParams.append('packages__contains', params.packages__contains.join(','))
+  }
+
+  // Name filters
+  if (params?.name) {
+    queryParams.append('name', params.name)
+  }
+  if (params?.name__contains) {
+    queryParams.append('name__contains', params.name__contains)
+  }
+  if (params?.name__in && params.name__in.length > 0) {
+    queryParams.append('name__in', params.name__in.join(','))
+  }
+
+  // ID filters
+  if (params?.id__in && params.id__in.length > 0) {
+    queryParams.append('id__in', params.id__in.join(','))
+  }
+  if (params?.id__notIn && params.id__notIn.length > 0) {
+    queryParams.append('id__notIn', params.id__notIn.join(','))
+  }
+  if (params?.id__contains) {
+    queryParams.append('id__contains', params.id__contains)
+  }
+
+  // Layout filter
+  if (params?.layoutId) {
+    queryParams.append('layoutId', params.layoutId)
+  }
+
+  // Share filters (use API nested field syntax)
+  if (typeof params?.shared === 'boolean') {
+    queryParams.append('shareDetails.shared', String(params.shared))
+  }
+  if (params?.sharedCameraAccount) {
+    queryParams.append('shareDetails.accountId', params.sharedCameraAccount)
+  }
+  if (typeof params?.firstResponder === 'boolean') {
+    queryParams.append('shareDetails.firstResponder', String(params.firstResponder))
+  }
+
+  // Device filters
+  if (typeof params?.directToCloud === 'boolean') {
+    queryParams.append('deviceInfo.directToCloud', String(params.directToCloud))
+  }
+
+  // Speaker filter
+  if (params?.speakerId__in && params.speakerId__in.length > 0) {
+    queryParams.append('speakerId__in', params.speakerId__in.join(','))
+  }
+
+  // Search
+  if (params?.q) {
+    queryParams.append('q', params.q)
+  }
+  if (typeof params?.qRelevance__gte === 'number') {
+    queryParams.append('qRelevance__gte', String(params.qRelevance__gte))
+  }
+
+  // Analytics filter
+  if (params?.enabledAnalytics__contains && params.enabledAnalytics__contains.length > 0) {
+    queryParams.append('enabledAnalytics__contains', params.enabledAnalytics__contains.join(','))
+  }
+
+  // Status filters
+  if (params?.status__in && params.status__in.length > 0) {
+    queryParams.append('status__in', params.status__in.join(','))
+  }
+  if (params?.status__ne) {
+    queryParams.append('status__ne', params.status__ne)
+  }
+
+  const queryString = queryParams.toString()
+  const url = `${authStore.baseUrl}/api/v3.0/cameras${queryString ? `?${queryString}` : ''}`
+  debug('Fetching cameras:', url)
+
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'Accept': 'application/json',
+        'Authorization': `Bearer ${authStore.token}`
+      }
+    })
+
+    if (!response.ok) {
+      return handleErrorResponse(response)
+    }
+
+    const data = await response.json() as PaginatedResult<Camera>
+    debug('Cameras fetched:', data.results?.length ?? 0, 'cameras')
+
+    return success(data)
+  } catch (err) {
+    return failure('NETWORK_ERROR', `Failed to fetch cameras: ${String(err)}`)
+  }
+}
+
+/**
+ * Get a specific camera by ID.
+ *
+ * @remarks
+ * Fetches a single camera from `/api/v3.0/cameras/{cameraId}`. Use the `include`
+ * parameter to request additional fields.
+ *
+ * For more details, see the
+ * [EEN API Documentation](https://developer.eagleeyenetworks.com/reference/getcamera).
+ *
+ * @param cameraId - The unique identifier of the camera to fetch
+ * @param params - Optional parameters (e.g., include additional fields)
+ * @returns A Result containing the camera or an error
+ *
+ * @example
+ * ```typescript
+ * import { getCamera } from 'een-api-toolkit'
+ *
+ * const { data, error } = await getCamera('camera-123')
+ *
+ * if (error) {
+ *   if (error.code === 'NOT_FOUND') {
+ *     console.log('Camera not found')
+ *   }
+ *   return
+ * }
+ *
+ * console.log(`Camera: ${data.name} (${data.status})`)
+ *
+ * // With additional fields
+ * const { data: cameraWithDetails } = await getCamera('camera-123', {
+ *   include: ['deviceInfo', 'streamUrls', 'shareDetails']
+ * })
+ * ```
+ *
+ * @category Cameras
+ */
+export async function getCamera(cameraId: string, params?: GetCameraParams): Promise<Result<Camera>> {
+  const authStore = useAuthStore()
+
+  if (!authStore.isAuthenticated) {
+    return failure('AUTH_REQUIRED', 'Authentication required')
+  }
+
+  if (!authStore.baseUrl) {
+    return failure('AUTH_REQUIRED', 'Base URL not configured')
+  }
+
+  if (!cameraId) {
+    return failure('VALIDATION_ERROR', 'Camera ID is required')
+  }
+
+  const queryParams = new URLSearchParams()
+
+  if (params?.include && params.include.length > 0) {
+    queryParams.append('include', params.include.join(','))
+  }
+
+  const queryString = queryParams.toString()
+  const url = `${authStore.baseUrl}/api/v3.0/cameras/${encodeURIComponent(cameraId)}${queryString ? `?${queryString}` : ''}`
+  debug('Fetching camera:', url)
+
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'Accept': 'application/json',
+        'Authorization': `Bearer ${authStore.token}`
+      }
+    })
+
+    if (!response.ok) {
+      return handleErrorResponse(response)
+    }
+
+    const data = await response.json() as Camera
+    debug('Camera fetched:', data.name)
+
+    return success(data)
+  } catch (err) {
+    return failure('NETWORK_ERROR', `Failed to fetch camera: ${String(err)}`)
+  }
+}
+
+/**
+ * Handle error responses from the API.
+ * @internal
+ */
+async function handleErrorResponse<T>(response: Response): Promise<Result<T>> {
+  const status = response.status
+
+  let message: string
+  try {
+    const errorData = await response.json()
+    message = errorData.message ?? errorData.error ?? response.statusText
+  } catch {
+    message = response.statusText || 'Unknown error'
+  }
+
+  switch (status) {
+    case 401:
+      return failure('AUTH_REQUIRED', `Authentication failed: ${message}`, status)
+    case 403:
+      return failure('FORBIDDEN', `Access denied: ${message}`, status)
+    case 404:
+      return failure('NOT_FOUND', `Not found: ${message}`, status)
+    case 429:
+      return failure('RATE_LIMITED', `Rate limited: ${message}`, status)
+    default:
+      return failure('API_ERROR', `API error: ${message}`, status)
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,17 @@ export type {
   User,
   UserProfile,
   ListUsersParams,
-  GetUserParams
+  GetUserParams,
+  Camera,
+  CameraStatus,
+  CameraDeviceInfo,
+  CameraShareDetails,
+  CameraStreamUrls,
+  CameraRtspConnectionSettings,
+  CameraDevicePosition,
+  CameraRecordingModes,
+  ListCamerasParams,
+  GetCameraParams
 } from './types'
 
 // Type helpers
@@ -51,3 +61,21 @@ export type {
   UseUsersOptions,
   UseUserOptions
 } from './users'
+
+// Cameras - Plain functions
+export {
+  getCameras,
+  getCamera
+} from './cameras'
+
+// Cameras - Composables
+export {
+  useCameras,
+  useCamera
+} from './cameras'
+
+// Cameras - Composable option types
+export type {
+  UseCamerasOptions,
+  UseCameraOptions
+} from './cameras'

--- a/src/types/camera.ts
+++ b/src/types/camera.ts
@@ -1,0 +1,369 @@
+/**
+ * Camera status values from EEN API v3.0.
+ *
+ * @remarks
+ * Indicates the current operational state of a camera.
+ *
+ * @category Cameras
+ */
+export type CameraStatus =
+  | 'online'
+  | 'offline'
+  | 'deviceOffline'
+  | 'bridgeOffline'
+  | 'invalidCredentials'
+  | 'error'
+  | 'streaming'
+  | 'registered'
+  | 'attaching'
+  | 'initializing'
+
+/**
+ * Device information for a camera.
+ *
+ * @remarks
+ * Contains hardware and firmware details about the physical camera device.
+ *
+ * @category Cameras
+ */
+export interface CameraDeviceInfo {
+  /** Camera manufacturer (e.g., "Axis", "Hikvision") */
+  make?: string
+  /** Camera model */
+  model?: string
+  /** Firmware version */
+  firmwareVersion?: string
+  /** Whether camera connects directly to cloud (no bridge) */
+  directToCloud?: boolean
+  /** Serial number */
+  serialNumber?: string
+  /** Resolution capabilities */
+  resolution?: string
+  /** Camera type (e.g., "IP", "Analog") */
+  type?: string
+}
+
+/**
+ * Share details for shared cameras.
+ *
+ * @remarks
+ * Contains information about camera sharing between accounts.
+ *
+ * @category Cameras
+ */
+export interface CameraShareDetails {
+  /** Whether the camera is shared */
+  shared?: boolean
+  /** Account ID of the sharing account */
+  accountId?: string
+  /** Whether shared for first responder access */
+  firstResponder?: boolean
+  /** Permissions granted to the share recipient */
+  permissions?: string[]
+}
+
+/**
+ * Stream URLs for camera media.
+ *
+ * @remarks
+ * Contains URLs for accessing various camera stream formats.
+ *
+ * @category Cameras
+ */
+export interface CameraStreamUrls {
+  /** HLS stream URL */
+  hls?: string
+  /** RTSP stream URL */
+  rtsp?: string
+  /** WebRTC stream URL */
+  webrtc?: string
+  /** JPEG snapshot URL */
+  jpeg?: string
+}
+
+/**
+ * RTSP connection settings for RTSP-based cameras.
+ *
+ * @remarks
+ * Configuration for cameras that connect via RTSP protocol.
+ *
+ * @category Cameras
+ */
+export interface CameraRtspConnectionSettings {
+  /** RTSP URL for the camera stream */
+  url?: string
+  /** Username for RTSP authentication */
+  username?: string
+  /** Password for RTSP authentication (write-only, not returned in responses) */
+  password?: string
+  /** Transport protocol (tcp, udp) */
+  transport?: 'tcp' | 'udp'
+}
+
+/**
+ * Camera position/location data.
+ *
+ * @remarks
+ * Physical location and orientation of the camera.
+ *
+ * @category Cameras
+ */
+export interface CameraDevicePosition {
+  /** Latitude coordinate */
+  latitude?: number
+  /** Longitude coordinate */
+  longitude?: number
+  /** Altitude in meters */
+  altitude?: number
+  /** Floor level */
+  floor?: number
+  /** Direction camera is facing (0-360 degrees) */
+  azimuth?: number
+}
+
+/**
+ * Recording modes for a camera.
+ *
+ * @remarks
+ * Indicates which recording modes are enabled for the camera.
+ *
+ * @category Cameras
+ */
+export interface CameraRecordingModes {
+  /** Whether continuous recording is enabled */
+  continuous?: boolean
+  /** Whether motion-triggered recording is enabled */
+  motion?: boolean
+  /** Whether scheduled recording is enabled */
+  scheduled?: boolean
+}
+
+/**
+ * Camera entity from EEN API v3.0.
+ *
+ * @remarks
+ * Represents a camera in the Eagle Eye Networks platform. Cameras can be
+ * connected via bridges or directly to the cloud. They have various
+ * properties including status, device info, and stream URLs.
+ *
+ * For more details on camera management, see the
+ * [EEN API Documentation](https://developer.eagleeyenetworks.com/reference/listcameras).
+ *
+ * @example
+ * ```typescript
+ * import { getCameras, type Camera } from 'een-api-toolkit'
+ *
+ * const { data, error } = await getCameras({ status__in: ['online'] })
+ * if (data) {
+ *   data.results.forEach((camera: Camera) => {
+ *     console.log(`${camera.name}: ${camera.status}`)
+ *   })
+ * }
+ * ```
+ *
+ * @category Cameras
+ */
+export interface Camera {
+  /** Unique identifier for the camera */
+  id: string
+  /** Display name of the camera */
+  name: string
+  /** ID of the account this camera belongs to */
+  accountId: string
+  /** ID of the bridge this camera is connected to (null for direct-to-cloud) */
+  bridgeId?: string | null
+  /** ID of the location where the camera is installed */
+  locationId?: string | null
+  /** Globally unique identifier */
+  guid?: string
+  /** MAC address of the camera */
+  macAddress?: string
+  /** IP address of the camera on the local network */
+  ipAddress?: string
+  /** Timezone of the camera location (IANA timezone name) */
+  timezone?: string
+  /** Current status of the camera */
+  status?: CameraStatus
+  /** Tags assigned to this camera for organization */
+  tags?: string[]
+  /** Feature packages enabled for this camera */
+  packages?: string[]
+  /** ID of multi-camera group if part of one */
+  multiCameraId?: string | null
+  /** ID of associated speaker device */
+  speakerId?: string | null
+  /** Device information (make, model, firmware) */
+  deviceInfo?: CameraDeviceInfo
+  /** Share details if camera is shared */
+  shareDetails?: CameraShareDetails
+  /** Stream URLs for accessing camera media */
+  streamUrls?: CameraStreamUrls
+  /** RTSP connection settings */
+  rtspConnectionSettings?: CameraRtspConnectionSettings
+  /** Physical position of the camera */
+  devicePosition?: CameraDevicePosition
+  /** List of enabled analytics on this camera */
+  enabledAnalytics?: string[]
+  /** Recording mode settings */
+  recordingModes?: CameraRecordingModes
+  /** ISO 8601 timestamp when the camera was created */
+  createdAt?: string
+  /** ISO 8601 timestamp when the camera was last updated */
+  updatedAt?: string
+}
+
+/**
+ * Parameters for listing cameras.
+ *
+ * @remarks
+ * Supports extensive filtering options matching the EEN API v3.0.
+ * All array parameters are sent as comma-separated values.
+ *
+ * For more details, see the
+ * [EEN API Documentation](https://developer.eagleeyenetworks.com/reference/listcameras).
+ *
+ * @example
+ * ```typescript
+ * import { getCameras } from 'een-api-toolkit'
+ *
+ * // Get online cameras with pagination
+ * const { data } = await getCameras({
+ *   pageSize: 50,
+ *   status__in: ['online', 'streaming'],
+ *   include: ['deviceInfo', 'streamUrls']
+ * })
+ *
+ * // Search cameras by name
+ * const { data: searchResults } = await getCameras({
+ *   q: 'front door',
+ *   qRelevance__gte: 0.5
+ * })
+ *
+ * // Filter by location and tags
+ * const { data: filtered } = await getCameras({
+ *   locationId__in: ['loc-123'],
+ *   tags__contains: ['security', 'entrance']
+ * })
+ * ```
+ *
+ * @category Cameras
+ */
+export interface ListCamerasParams {
+  // Pagination
+  /** Number of results per page (default: 100, max: 1000) */
+  pageSize?: number
+  /** Token for fetching a specific page */
+  pageToken?: string
+
+  // Include/Sort
+  /** Additional fields to include in the response */
+  include?: string[]
+  /** Fields to sort by (prefix with - for descending) */
+  sort?: string[]
+
+  // Location/Bridge filters
+  /** Filter by location IDs */
+  locationId__in?: string[]
+  /** Filter by bridge IDs */
+  bridgeId__in?: string[]
+
+  // Multi-camera filters
+  /** Filter by exact multi-camera ID */
+  multiCameraId?: string
+  /** Filter by multi-camera ID not equal to */
+  multiCameraId__ne?: string
+  /** Filter by multi-camera IDs (any match) */
+  multiCameraId__in?: string[]
+
+  // Tag/Package filters
+  /** Filter by tags (all tags must be present) */
+  tags__contains?: string[]
+  /** Filter by tags (any tag must be present) */
+  tags__any?: string[]
+  /** Filter by packages (all must be present) */
+  packages__contains?: string[]
+
+  // Name filters
+  /** Filter by exact name */
+  name?: string
+  /** Filter by name containing substring (case-insensitive) */
+  name__contains?: string
+  /** Filter by exact names (any match) */
+  name__in?: string[]
+
+  // ID filters
+  /** Filter by camera IDs */
+  id__in?: string[]
+  /** Exclude camera IDs */
+  id__notIn?: string[]
+  /** Filter by ID containing substring */
+  id__contains?: string
+
+  // Layout filter
+  /** Filter by layout ID */
+  layoutId?: string
+
+  // Share filters (nested field syntax in API: shareDetails.*)
+  /** Filter by shared status */
+  shared?: boolean
+  /** Filter by sharing account ID */
+  sharedCameraAccount?: string
+  /** Filter by first responder sharing */
+  firstResponder?: boolean
+
+  // Device filters (nested field syntax in API: deviceInfo.*)
+  /** Filter by direct-to-cloud connection */
+  directToCloud?: boolean
+
+  // Speaker filter
+  /** Filter by speaker IDs */
+  speakerId__in?: string[]
+
+  // Search
+  /** Full-text search query */
+  q?: string
+  /** Minimum search relevance score */
+  qRelevance__gte?: number
+
+  // Analytics filter
+  /** Filter by enabled analytics (all must be present) */
+  enabledAnalytics__contains?: string[]
+
+  // Status filters
+  /** Filter by status values (any match) */
+  status__in?: CameraStatus[]
+  /** Filter by status not equal to */
+  status__ne?: CameraStatus
+}
+
+/**
+ * Parameters for getting a single camera.
+ *
+ * @remarks
+ * Valid include values: bridge, account, status, locationSummary, deviceAddress,
+ * timeZone, notes, tags, devicePosition, networkInfo, deviceInfo, effectivePermissions,
+ * firmware, shareDetails, visibleByBridges, capabilities, analog, packages,
+ * dewarpConfig, adminCredentials, publicSafetySharing, enabledAnalytics
+ *
+ * @example
+ * ```typescript
+ * import { getCamera } from 'een-api-toolkit'
+ *
+ * const { data } = await getCamera('camera-123', {
+ *   include: ['deviceInfo', 'status', 'shareDetails']
+ * })
+ * ```
+ *
+ * @category Cameras
+ */
+export interface GetCameraParams {
+  /**
+   * Additional fields to include in the response.
+   * Valid values: bridge, account, status, locationSummary, deviceAddress,
+   * timeZone, notes, tags, devicePosition, networkInfo, deviceInfo,
+   * effectivePermissions, firmware, shareDetails, visibleByBridges,
+   * capabilities, analog, packages, dewarpConfig, adminCredentials,
+   * publicSafetySharing, enabledAnalytics
+   */
+  include?: string[]
+}

--- a/src/types/camera.ts
+++ b/src/types/camera.ts
@@ -182,8 +182,8 @@ export interface Camera {
   ipAddress?: string
   /** Timezone of the camera location (IANA timezone name) */
   timezone?: string
-  /** Current status of the camera */
-  status?: CameraStatus
+  /** Current status of the camera (string or object with connectionStatus) */
+  status?: CameraStatus | { connectionStatus?: CameraStatus }
   /** Tags assigned to this camera for organization */
   tags?: string[]
   /** Feature packages enabled for this camera */
@@ -304,15 +304,15 @@ export interface ListCamerasParams {
   layoutId?: string
 
   // Share filters (nested field syntax in API: shareDetails.*)
-  /** Filter by shared status */
+  /** Filter by shared status. Maps to `shareDetails.shared` in the API query. */
   shared?: boolean
-  /** Filter by sharing account ID */
+  /** Filter by sharing account ID. Maps to `shareDetails.accountId` in the API query. */
   sharedCameraAccount?: string
-  /** Filter by first responder sharing */
+  /** Filter by first responder sharing. Maps to `shareDetails.firstResponder` in the API query. */
   firstResponder?: boolean
 
   // Device filters (nested field syntax in API: deviceInfo.*)
-  /** Filter by direct-to-cloud connection */
+  /** Filter by direct-to-cloud connection. Maps to `deviceInfo.directToCloud` in the API query. */
   directToCloud?: boolean
 
   // Speaker filter

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from './common'
 export * from './user'
+export * from './camera'


### PR DESCRIPTION
## Summary

Add comprehensive Camera API support to een-api-toolkit following the same patterns as the Users API.

### New Features
- **Camera Types**: `Camera`, `CameraStatus`, `CameraDeviceInfo`, `CameraShareDetails`, `CameraDevicePosition`, `CameraStreamUrls`, `CameraRtspConnectionSettings`, `CameraRecordingModes`
- **Service Functions**: `getCameras()`, `getCamera()` with all 25+ filter parameters
- **Vue 3 Composables**: `useCameras()`, `useCamera()` with pagination and filtering support
- **Example App**: `examples/vue-cameras/` - Complete Vue 3 app demonstrating camera APIs

### Changes
- `04cb829` feat: Add Camera API support with getCameras, getCamera, useCameras, useCamera
- `9765ed0` Merge pull request #25 from klaushofrichter/develop
- `aa8b0e9` docs: Regenerate API documentation for v0.0.13

## Test Results
- ✅ Lint: Pass (0 errors, 1 expected warning)
- ✅ Unit tests: 33 passed (26 cameras + 7 types)
- ✅ E2E tests: 14 passed
- ✅ vue-cameras Playwright tests: 7 passed
- ✅ Build: Success

## Version
`0.0.14`

🤖 Generated with [Claude Code](https://claude.com/claude-code)