### PR TITLE
Fix: Regenerate ALL docs after version bump

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -22,10 +22,10 @@ if git diff --cached --name-only | grep -qE "^(src|e2e)/|^README\.md$"; then
         git add package-lock.json
     fi
 
-    # Regenerate AI-CONTEXT.md with the new version
-    echo "Regenerating AI-CONTEXT.md with new version..."
-    npm run docs:ai-context --silent || exit 1
-    git add docs/AI-CONTEXT.md
+    # Regenerate all documentation with the new version
+    echo "Regenerating documentation with new version..."
+    npm run docs --silent || exit 1
+    git add docs/
 
     echo "Main package version incremented successfully"
 fi

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,8 +1,8 @@
-**EEN API Toolkit v0.0.16**
+**EEN API Toolkit v0.0.17**
 
 ***
 
-# EEN API Toolkit v0.0.16
+# EEN API Toolkit v0.0.17
 
 ## Interfaces
 

--- a/docs/api/functions/getAccessToken.md
+++ b/docs/api/functions/getAccessToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAuthUrl.md
+++ b/docs/api/functions/getAuthUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCamera.md
+++ b/docs/api/functions/getCamera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameras.md
+++ b/docs/api/functions/getCameras.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/functions/getClientId.md
+++ b/docs/api/functions/getClientId.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/functions/getConfig.md
+++ b/docs/api/functions/getConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCurrentUser.md
+++ b/docs/api/functions/getCurrentUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/functions/getProxyUrl.md
+++ b/docs/api/functions/getProxyUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRedirectUri.md
+++ b/docs/api/functions/getRedirectUri.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUser.md
+++ b/docs/api/functions/getUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUsers.md
+++ b/docs/api/functions/getUsers.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/functions/handleAuthCallback.md
+++ b/docs/api/functions/handleAuthCallback.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/functions/initEenToolkit.md
+++ b/docs/api/functions/initEenToolkit.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/functions/refreshToken.md
+++ b/docs/api/functions/refreshToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/functions/revokeToken.md
+++ b/docs/api/functions/revokeToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/functions/useCamera.md
+++ b/docs/api/functions/useCamera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/functions/useCameras.md
+++ b/docs/api/functions/useCameras.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/functions/useCurrentUser.md
+++ b/docs/api/functions/useCurrentUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/functions/useUser.md
+++ b/docs/api/functions/useUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/functions/useUsers.md
+++ b/docs/api/functions/useUsers.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Camera.md
+++ b/docs/api/interfaces/Camera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDeviceInfo.md
+++ b/docs/api/interfaces/CameraDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDevicePosition.md
+++ b/docs/api/interfaces/CameraDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRecordingModes.md
+++ b/docs/api/interfaces/CameraRecordingModes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRtspConnectionSettings.md
+++ b/docs/api/interfaces/CameraRtspConnectionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraShareDetails.md
+++ b/docs/api/interfaces/CameraShareDetails.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStreamUrls.md
+++ b/docs/api/interfaces/CameraStreamUrls.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenError.md
+++ b/docs/api/interfaces/EenError.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenToolkitConfig.md
+++ b/docs/api/interfaces/EenToolkitConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetCameraParams.md
+++ b/docs/api/interfaces/GetCameraParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetUserParams.md
+++ b/docs/api/interfaces/GetUserParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListCamerasParams.md
+++ b/docs/api/interfaces/ListCamerasParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListUsersParams.md
+++ b/docs/api/interfaces/ListUsersParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginatedResult.md
+++ b/docs/api/interfaces/PaginatedResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginationParams.md
+++ b/docs/api/interfaces/PaginationParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/TokenResponse.md
+++ b/docs/api/interfaces/TokenResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UseCameraOptions.md
+++ b/docs/api/interfaces/UseCameraOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UseCamerasOptions.md
+++ b/docs/api/interfaces/UseCamerasOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UseCurrentUserOptions.md
+++ b/docs/api/interfaces/UseCurrentUserOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UseUserOptions.md
+++ b/docs/api/interfaces/UseUserOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UseUsersOptions.md
+++ b/docs/api/interfaces/UseUsersOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/User.md
+++ b/docs/api/interfaces/User.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UserProfile.md
+++ b/docs/api/interfaces/UserProfile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraStatus.md
+++ b/docs/api/type-aliases/CameraStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ErrorCode.md
+++ b/docs/api/type-aliases/ErrorCode.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/Result.md
+++ b/docs/api/type-aliases/Result.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 

--- a/docs/api/variables/useAuthStore.md
+++ b/docs/api/variables/useAuthStore.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.0.16**](../README.md)
+[**EEN API Toolkit v0.0.17**](../README.md)
 
 ***
 


### PR DESCRIPTION
## Summary

Fixes CI failure in test-release workflow caused by version mismatch in docs/api files.

### Problem

The previous fix only regenerated `AI-CONTEXT.md` after version bump, but the `docs/api/*.md` files also contain version numbers (e.g., `[**EEN API Toolkit v0.0.16**]`). This caused CI to fail because it detected a mismatch when regenerating docs.

### Solution

Updated pre-commit hook to regenerate ALL docs (`npm run docs`) instead of just AI-CONTEXT.md after version bump.

### Changes

- `.husky/pre-commit`: Run `npm run docs` instead of `npm run docs:ai-context`
- `docs/api/*`: Regenerated with v0.0.17

### Test Results

- ✅ Lint: Passed
- ✅ Unit tests: 33 passed
- ✅ Build: Success

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)