### PR TITLE
feat: Add RecordedImage page with shared camera selection

### DIFF
--- a/examples/vue-media/e2e/app.spec.ts
+++ b/examples/vue-media/e2e/app.spec.ts
@@ -36,8 +36,8 @@ test.describe('vue-media example app', () => {
     // Check navigation is present
     await expect(page.getByRole('navigation')).toBeVisible()
 
-    // Navigate to login via nav link
-    await page.getByRole('link', { name: 'Login' }).click()
+    // Navigate to login via nav link (use testid to be specific)
+    await page.getByTestId('nav-login').click()
     await expect(page).toHaveURL('/login')
 
     // Navigate back home
@@ -51,5 +51,13 @@ test.describe('vue-media example app', () => {
     // Check for the function descriptions
     await expect(page.getByText('getCameras()')).toBeVisible()
     await expect(page.getByText('getLiveImage()')).toBeVisible()
+    await expect(page.getByText('getRecordedImage()')).toBeVisible()
+  })
+
+  test('recorded route redirects to login when not authenticated', async ({ page }) => {
+    await page.goto('/recorded')
+
+    // Should redirect to login page (auth guard)
+    await expect(page).toHaveURL('/login')
   })
 })

--- a/examples/vue-media/e2e/auth.spec.ts
+++ b/examples/vue-media/e2e/auth.spec.ts
@@ -199,18 +199,16 @@ test.describe('vue-media authenticated tests', () => {
     }
   })
 
-  test('authenticated user sees cameras on live page', async ({ page }) => {
-    // Set up localStorage with auth state before navigating
-    await page.goto('/')
-
-    // Inject auth state into individual localStorage keys (matches auth store)
+  /**
+   * Helper function to inject auth state into localStorage
+   */
+  async function injectAuthState(page: import('@playwright/test').Page) {
     await page.evaluate(
       ({ token, baseUrl, sessionId, tokenExpiration }) => {
         localStorage.setItem('een_token', token)
         localStorage.setItem('een_tokenExpiration', String(tokenExpiration))
         localStorage.setItem('een_refreshTokenMarker', 'present')
         localStorage.setItem('een_sessionId', sessionId)
-        // Parse baseUrl to extract hostname
         const url = new URL(baseUrl)
         localStorage.setItem('een_hostname', url.hostname)
         if (url.port) {
@@ -219,8 +217,16 @@ test.describe('vue-media authenticated tests', () => {
       },
       authState
     )
+  }
 
-    // Navigate to live page
+  test.beforeEach(async ({ page }) => {
+    // Navigate to home and inject auth state before each test
+    await page.goto('/')
+    await injectAuthState(page)
+  })
+
+  test('authenticated user sees cameras on live page', async ({ page }) => {
+    // Navigate to live page (auth already injected by beforeEach)
     await page.goto('/live')
 
     // Should show the live camera view
@@ -269,23 +275,7 @@ test.describe('vue-media authenticated tests', () => {
   })
 
   test('authenticated home page shows view live button', async ({ page }) => {
-    await page.goto('/')
-
-    // Inject auth state into individual localStorage keys
-    await page.evaluate(
-      ({ token, baseUrl, sessionId, tokenExpiration }) => {
-        localStorage.setItem('een_token', token)
-        localStorage.setItem('een_tokenExpiration', String(tokenExpiration))
-        localStorage.setItem('een_refreshTokenMarker', 'present')
-        localStorage.setItem('een_sessionId', sessionId)
-        const url = new URL(baseUrl)
-        localStorage.setItem('een_hostname', url.hostname)
-        if (url.port) localStorage.setItem('een_port', url.port)
-      },
-      authState
-    )
-
-    // Reload to apply auth state
+    // Reload to apply auth state (already injected by beforeEach)
     await page.reload()
 
     // Should show authenticated state
@@ -295,22 +285,7 @@ test.describe('vue-media authenticated tests', () => {
   })
 
   test('refresh button fetches new image', async ({ page }) => {
-    await page.goto('/')
-
-    // Inject auth state into individual localStorage keys
-    await page.evaluate(
-      ({ token, baseUrl, sessionId, tokenExpiration }) => {
-        localStorage.setItem('een_token', token)
-        localStorage.setItem('een_tokenExpiration', String(tokenExpiration))
-        localStorage.setItem('een_refreshTokenMarker', 'present')
-        localStorage.setItem('een_sessionId', sessionId)
-        const url = new URL(baseUrl)
-        localStorage.setItem('een_hostname', url.hostname)
-        if (url.port) localStorage.setItem('een_port', url.port)
-      },
-      authState
-    )
-
+    // Navigate to live page (auth already injected by beforeEach)
     await page.goto('/live')
 
     // Wait for initial load
@@ -340,23 +315,7 @@ test.describe('vue-media authenticated tests', () => {
   })
 
   test('authenticated home page shows view recorded button', async ({ page }) => {
-    await page.goto('/')
-
-    // Inject auth state into individual localStorage keys
-    await page.evaluate(
-      ({ token, baseUrl, sessionId, tokenExpiration }) => {
-        localStorage.setItem('een_token', token)
-        localStorage.setItem('een_tokenExpiration', String(tokenExpiration))
-        localStorage.setItem('een_refreshTokenMarker', 'present')
-        localStorage.setItem('een_sessionId', sessionId)
-        const url = new URL(baseUrl)
-        localStorage.setItem('een_hostname', url.hostname)
-        if (url.port) localStorage.setItem('een_port', url.port)
-      },
-      authState
-    )
-
-    // Reload to apply auth state
+    // Reload to apply auth state (already injected by beforeEach)
     await page.reload()
 
     // Should show authenticated state with both buttons
@@ -366,22 +325,7 @@ test.describe('vue-media authenticated tests', () => {
   })
 
   test('recorded image page shows camera selector and time picker', async ({ page }) => {
-    await page.goto('/')
-
-    // Inject auth state into individual localStorage keys
-    await page.evaluate(
-      ({ token, baseUrl, sessionId, tokenExpiration }) => {
-        localStorage.setItem('een_token', token)
-        localStorage.setItem('een_tokenExpiration', String(tokenExpiration))
-        localStorage.setItem('een_refreshTokenMarker', 'present')
-        localStorage.setItem('een_sessionId', sessionId)
-        const url = new URL(baseUrl)
-        localStorage.setItem('een_hostname', url.hostname)
-        if (url.port) localStorage.setItem('een_port', url.port)
-      },
-      authState
-    )
-
+    // Navigate to recorded page (auth already injected by beforeEach)
     await page.goto('/recorded')
 
     // Should show the recorded image page
@@ -413,22 +357,7 @@ test.describe('vue-media authenticated tests', () => {
   })
 
   test('recorded image page auto-loads image on mount', async ({ page }) => {
-    await page.goto('/')
-
-    // Inject auth state into individual localStorage keys
-    await page.evaluate(
-      ({ token, baseUrl, sessionId, tokenExpiration }) => {
-        localStorage.setItem('een_token', token)
-        localStorage.setItem('een_tokenExpiration', String(tokenExpiration))
-        localStorage.setItem('een_refreshTokenMarker', 'present')
-        localStorage.setItem('een_sessionId', sessionId)
-        const url = new URL(baseUrl)
-        localStorage.setItem('een_hostname', url.hostname)
-        if (url.port) localStorage.setItem('een_port', url.port)
-      },
-      authState
-    )
-
+    // Navigate to recorded page (auth already injected by beforeEach)
     await page.goto('/recorded')
 
     // Wait for cameras to load
@@ -467,22 +396,7 @@ test.describe('vue-media authenticated tests', () => {
   })
 
   test('recorded image navigation buttons work', async ({ page }) => {
-    await page.goto('/')
-
-    // Inject auth state into individual localStorage keys
-    await page.evaluate(
-      ({ token, baseUrl, sessionId, tokenExpiration }) => {
-        localStorage.setItem('een_token', token)
-        localStorage.setItem('een_tokenExpiration', String(tokenExpiration))
-        localStorage.setItem('een_refreshTokenMarker', 'present')
-        localStorage.setItem('een_sessionId', sessionId)
-        const url = new URL(baseUrl)
-        localStorage.setItem('een_hostname', url.hostname)
-        if (url.port) localStorage.setItem('een_port', url.port)
-      },
-      authState
-    )
-
+    // Navigate to recorded page (auth already injected by beforeEach)
     await page.goto('/recorded')
 
     // Wait for cameras to load
@@ -541,22 +455,7 @@ test.describe('vue-media authenticated tests', () => {
   })
 
   test('recorded image page loads with past date via Go button', async ({ page }) => {
-    await page.goto('/')
-
-    // Inject auth state into individual localStorage keys
-    await page.evaluate(
-      ({ token, baseUrl, sessionId, tokenExpiration }) => {
-        localStorage.setItem('een_token', token)
-        localStorage.setItem('een_tokenExpiration', String(tokenExpiration))
-        localStorage.setItem('een_refreshTokenMarker', 'present')
-        localStorage.setItem('een_sessionId', sessionId)
-        const url = new URL(baseUrl)
-        localStorage.setItem('een_hostname', url.hostname)
-        if (url.port) localStorage.setItem('een_port', url.port)
-      },
-      authState
-    )
-
+    // Navigate to recorded page (auth already injected by beforeEach)
     await page.goto('/recorded')
 
     // Wait for cameras to load
@@ -610,22 +509,7 @@ test.describe('vue-media authenticated tests', () => {
   })
 
   test('camera selection persists between live and recorded pages', async ({ page }) => {
-    await page.goto('/')
-
-    // Inject auth state into individual localStorage keys
-    await page.evaluate(
-      ({ token, baseUrl, sessionId, tokenExpiration }) => {
-        localStorage.setItem('een_token', token)
-        localStorage.setItem('een_tokenExpiration', String(tokenExpiration))
-        localStorage.setItem('een_refreshTokenMarker', 'present')
-        localStorage.setItem('een_sessionId', sessionId)
-        const url = new URL(baseUrl)
-        localStorage.setItem('een_hostname', url.hostname)
-        if (url.port) localStorage.setItem('een_port', url.port)
-      },
-      authState
-    )
-
+    // Navigate to live page (auth already injected by beforeEach)
     await page.goto('/live')
 
     // Wait for cameras to load

--- a/examples/vue-media/e2e/auth.spec.ts
+++ b/examples/vue-media/e2e/auth.spec.ts
@@ -203,18 +203,19 @@ test.describe('vue-media authenticated tests', () => {
     // Set up localStorage with auth state before navigating
     await page.goto('/')
 
-    // Inject auth state into the app's Pinia store via localStorage
+    // Inject auth state into individual localStorage keys (matches auth store)
     await page.evaluate(
       ({ token, baseUrl, sessionId, tokenExpiration }) => {
-        const authData = {
-          isAuthenticated: true,
-          token,
-          tokenExpiration,
-          refreshTokenMarker: 'present',
-          baseUrl,
-          sessionId
+        localStorage.setItem('een_token', token)
+        localStorage.setItem('een_tokenExpiration', String(tokenExpiration))
+        localStorage.setItem('een_refreshTokenMarker', 'present')
+        localStorage.setItem('een_sessionId', sessionId)
+        // Parse baseUrl to extract hostname
+        const url = new URL(baseUrl)
+        localStorage.setItem('een_hostname', url.hostname)
+        if (url.port) {
+          localStorage.setItem('een_port', url.port)
         }
-        localStorage.setItem('een-auth', JSON.stringify(authData))
       },
       authState
     )
@@ -270,18 +271,16 @@ test.describe('vue-media authenticated tests', () => {
   test('authenticated home page shows view live button', async ({ page }) => {
     await page.goto('/')
 
-    // Inject auth state
+    // Inject auth state into individual localStorage keys
     await page.evaluate(
       ({ token, baseUrl, sessionId, tokenExpiration }) => {
-        const authData = {
-          isAuthenticated: true,
-          token,
-          tokenExpiration,
-          refreshTokenMarker: 'present',
-          baseUrl,
-          sessionId
-        }
-        localStorage.setItem('een-auth', JSON.stringify(authData))
+        localStorage.setItem('een_token', token)
+        localStorage.setItem('een_tokenExpiration', String(tokenExpiration))
+        localStorage.setItem('een_refreshTokenMarker', 'present')
+        localStorage.setItem('een_sessionId', sessionId)
+        const url = new URL(baseUrl)
+        localStorage.setItem('een_hostname', url.hostname)
+        if (url.port) localStorage.setItem('een_port', url.port)
       },
       authState
     )
@@ -298,18 +297,16 @@ test.describe('vue-media authenticated tests', () => {
   test('refresh button fetches new image', async ({ page }) => {
     await page.goto('/')
 
-    // Inject auth state
+    // Inject auth state into individual localStorage keys
     await page.evaluate(
       ({ token, baseUrl, sessionId, tokenExpiration }) => {
-        const authData = {
-          isAuthenticated: true,
-          token,
-          tokenExpiration,
-          refreshTokenMarker: 'present',
-          baseUrl,
-          sessionId
-        }
-        localStorage.setItem('een-auth', JSON.stringify(authData))
+        localStorage.setItem('een_token', token)
+        localStorage.setItem('een_tokenExpiration', String(tokenExpiration))
+        localStorage.setItem('een_refreshTokenMarker', 'present')
+        localStorage.setItem('een_sessionId', sessionId)
+        const url = new URL(baseUrl)
+        localStorage.setItem('een_hostname', url.hostname)
+        if (url.port) localStorage.setItem('een_port', url.port)
       },
       authState
     )
@@ -339,6 +336,355 @@ test.describe('vue-media authenticated tests', () => {
       console.log('Refresh button clicked successfully')
     } else {
       console.log('No cameras to test refresh with')
+    }
+  })
+
+  test('authenticated home page shows view recorded button', async ({ page }) => {
+    await page.goto('/')
+
+    // Inject auth state into individual localStorage keys
+    await page.evaluate(
+      ({ token, baseUrl, sessionId, tokenExpiration }) => {
+        localStorage.setItem('een_token', token)
+        localStorage.setItem('een_tokenExpiration', String(tokenExpiration))
+        localStorage.setItem('een_refreshTokenMarker', 'present')
+        localStorage.setItem('een_sessionId', sessionId)
+        const url = new URL(baseUrl)
+        localStorage.setItem('een_hostname', url.hostname)
+        if (url.port) localStorage.setItem('een_port', url.port)
+      },
+      authState
+    )
+
+    // Reload to apply auth state
+    await page.reload()
+
+    // Should show authenticated state with both buttons
+    await expect(page.getByTestId('authenticated')).toBeVisible()
+    await expect(page.getByTestId('view-live-button')).toBeVisible()
+    await expect(page.getByTestId('view-recorded-button')).toBeVisible()
+  })
+
+  test('recorded image page shows camera selector and time picker', async ({ page }) => {
+    await page.goto('/')
+
+    // Inject auth state into individual localStorage keys
+    await page.evaluate(
+      ({ token, baseUrl, sessionId, tokenExpiration }) => {
+        localStorage.setItem('een_token', token)
+        localStorage.setItem('een_tokenExpiration', String(tokenExpiration))
+        localStorage.setItem('een_refreshTokenMarker', 'present')
+        localStorage.setItem('een_sessionId', sessionId)
+        const url = new URL(baseUrl)
+        localStorage.setItem('een_hostname', url.hostname)
+        if (url.port) localStorage.setItem('een_port', url.port)
+      },
+      authState
+    )
+
+    await page.goto('/recorded')
+
+    // Should show the recorded image page
+    await expect(page.getByRole('heading', { name: 'Recorded Images' })).toBeVisible()
+
+    // Wait for cameras to load
+    await page.waitForSelector('[data-testid="camera-select"], .no-cameras', {
+      timeout: 30000
+    })
+
+    const hasCameras = await page.getByTestId('camera-select').isVisible().catch(() => false)
+
+    if (hasCameras) {
+      console.log('Cameras found - checking recorded image controls')
+
+      // Verify controls are present
+      await expect(page.getByTestId('datetime-input')).toBeVisible()
+      await expect(page.getByTestId('go-button')).toBeVisible()
+      await expect(page.getByTestId('prev-button')).toBeVisible()
+      await expect(page.getByTestId('next-button')).toBeVisible()
+
+      // Initially prev/next should be disabled (no image loaded yet or no tokens)
+      const prevDisabled = await page.getByTestId('prev-button').isDisabled()
+      const nextDisabled = await page.getByTestId('next-button').isDisabled()
+      console.log(`Navigation buttons: prev=${prevDisabled ? 'disabled' : 'enabled'}, next=${nextDisabled ? 'disabled' : 'enabled'}`)
+    } else {
+      console.log('No cameras in account')
+    }
+  })
+
+  test('recorded image page auto-loads image on mount', async ({ page }) => {
+    await page.goto('/')
+
+    // Inject auth state into individual localStorage keys
+    await page.evaluate(
+      ({ token, baseUrl, sessionId, tokenExpiration }) => {
+        localStorage.setItem('een_token', token)
+        localStorage.setItem('een_tokenExpiration', String(tokenExpiration))
+        localStorage.setItem('een_refreshTokenMarker', 'present')
+        localStorage.setItem('een_sessionId', sessionId)
+        const url = new URL(baseUrl)
+        localStorage.setItem('een_hostname', url.hostname)
+        if (url.port) localStorage.setItem('een_port', url.port)
+      },
+      authState
+    )
+
+    await page.goto('/recorded')
+
+    // Wait for cameras to load
+    await page.waitForSelector('[data-testid="camera-select"], .no-cameras', {
+      timeout: 30000
+    })
+
+    const hasCameras = await page.getByTestId('camera-select').isVisible().catch(() => false)
+
+    if (hasCameras) {
+      // Wait for image to load (auto-loads on page mount with default time of 1 hour ago)
+      await page.waitForSelector('[data-testid="recorded-image"], .no-image, .error', {
+        timeout: 45000
+      })
+
+      const hasImage = await page.getByTestId('recorded-image').isVisible().catch(() => false)
+
+      if (hasImage) {
+        console.log('Recorded image loaded successfully')
+
+        // Check timestamp is shown
+        const timestamp = page.getByTestId('timestamp')
+        await expect(timestamp).toBeVisible()
+
+        // Time picker should be updated with the image timestamp
+        const datetimeInput = page.getByTestId('datetime-input')
+        const inputValue = await datetimeInput.inputValue()
+        expect(inputValue).toBeTruthy()
+        console.log(`Time picker value: ${inputValue}`)
+      } else {
+        console.log('No recorded image available (no recordings in time range)')
+      }
+    } else {
+      console.log('No cameras to test with')
+    }
+  })
+
+  test('recorded image navigation buttons work', async ({ page }) => {
+    await page.goto('/')
+
+    // Inject auth state into individual localStorage keys
+    await page.evaluate(
+      ({ token, baseUrl, sessionId, tokenExpiration }) => {
+        localStorage.setItem('een_token', token)
+        localStorage.setItem('een_tokenExpiration', String(tokenExpiration))
+        localStorage.setItem('een_refreshTokenMarker', 'present')
+        localStorage.setItem('een_sessionId', sessionId)
+        const url = new URL(baseUrl)
+        localStorage.setItem('een_hostname', url.hostname)
+        if (url.port) localStorage.setItem('een_port', url.port)
+      },
+      authState
+    )
+
+    await page.goto('/recorded')
+
+    // Wait for cameras to load
+    await page.waitForSelector('[data-testid="camera-select"], .no-cameras', {
+      timeout: 30000
+    })
+
+    const hasCameras = await page.getByTestId('camera-select').isVisible().catch(() => false)
+
+    if (hasCameras) {
+      // Wait for an image to load
+      await page.waitForSelector('[data-testid="recorded-image"], .no-image', {
+        timeout: 45000
+      })
+
+      const hasImage = await page.getByTestId('recorded-image').isVisible().catch(() => false)
+
+      if (hasImage) {
+        // Check if next button is enabled
+        const nextButton = page.getByTestId('next-button')
+        const isNextEnabled = !(await nextButton.isDisabled())
+
+        if (isNextEnabled) {
+          // Get current timestamp
+          const initialTimestamp = await page.getByTestId('timestamp').textContent()
+
+          // Click next
+          await nextButton.click()
+
+          // Wait for potential update
+          await page.waitForTimeout(2000)
+
+          // Check timestamp changed
+          const newTimestamp = await page.getByTestId('timestamp').textContent()
+          console.log(`Navigated: ${initialTimestamp} -> ${newTimestamp}`)
+
+          // Check if prev button is now enabled
+          const prevButton = page.getByTestId('prev-button')
+          const isPrevEnabled = !(await prevButton.isDisabled())
+
+          if (isPrevEnabled) {
+            // Navigate back
+            await prevButton.click()
+            await page.waitForTimeout(2000)
+            console.log('Previous navigation successful')
+          }
+        } else {
+          console.log('Next button disabled - only one image available')
+        }
+      } else {
+        console.log('No recorded image to navigate from')
+      }
+    } else {
+      console.log('No cameras to test navigation with')
+    }
+  })
+
+  test('recorded image page loads with past date via Go button', async ({ page }) => {
+    await page.goto('/')
+
+    // Inject auth state into individual localStorage keys
+    await page.evaluate(
+      ({ token, baseUrl, sessionId, tokenExpiration }) => {
+        localStorage.setItem('een_token', token)
+        localStorage.setItem('een_tokenExpiration', String(tokenExpiration))
+        localStorage.setItem('een_refreshTokenMarker', 'present')
+        localStorage.setItem('een_sessionId', sessionId)
+        const url = new URL(baseUrl)
+        localStorage.setItem('een_hostname', url.hostname)
+        if (url.port) localStorage.setItem('een_port', url.port)
+      },
+      authState
+    )
+
+    await page.goto('/recorded')
+
+    // Wait for cameras to load
+    await page.waitForSelector('[data-testid="camera-select"], .no-cameras', {
+      timeout: 30000
+    })
+
+    const hasCameras = await page.getByTestId('camera-select').isVisible().catch(() => false)
+
+    if (hasCameras) {
+      // Set the date/time to 24 hours ago
+      const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000)
+      const year = yesterday.getFullYear()
+      const month = String(yesterday.getMonth() + 1).padStart(2, '0')
+      const day = String(yesterday.getDate()).padStart(2, '0')
+      const hours = String(yesterday.getHours()).padStart(2, '0')
+      const minutes = String(yesterday.getMinutes()).padStart(2, '0')
+      const dateTimeValue = `${year}-${month}-${day}T${hours}:${minutes}`
+
+      // Fill in the datetime input with yesterday's date
+      await page.getByTestId('datetime-input').fill(dateTimeValue)
+
+      // Click Go button to load image from that time
+      await page.getByTestId('go-button').click()
+
+      // Wait for the image to load or error to appear
+      await page.waitForSelector('[data-testid="recorded-image"], .error, .no-image', {
+        timeout: 45000
+      })
+
+      // Check results
+      const hasImage = await page.getByTestId('recorded-image').isVisible().catch(() => false)
+      const hasError = await page.locator('.error').isVisible().catch(() => false)
+
+      if (hasImage) {
+        console.log('Image loaded successfully with past date')
+        // Check timestamp is shown
+        const timestamp = page.getByTestId('timestamp')
+        await expect(timestamp).toBeVisible()
+      } else if (hasError) {
+        const errorText = await page.locator('.error').textContent()
+        console.log('Error loading image with past date:', errorText)
+        // A 404 "Not found" is acceptable if no recordings exist for that time
+        expect(errorText).toMatch(/Not found|No recordings|Unknown error/)
+      } else {
+        console.log('No image or error visible - no recordings for past date')
+      }
+    } else {
+      console.log('No cameras to test past date with')
+    }
+  })
+
+  test('camera selection persists between live and recorded pages', async ({ page }) => {
+    await page.goto('/')
+
+    // Inject auth state into individual localStorage keys
+    await page.evaluate(
+      ({ token, baseUrl, sessionId, tokenExpiration }) => {
+        localStorage.setItem('een_token', token)
+        localStorage.setItem('een_tokenExpiration', String(tokenExpiration))
+        localStorage.setItem('een_refreshTokenMarker', 'present')
+        localStorage.setItem('een_sessionId', sessionId)
+        const url = new URL(baseUrl)
+        localStorage.setItem('een_hostname', url.hostname)
+        if (url.port) localStorage.setItem('een_port', url.port)
+      },
+      authState
+    )
+
+    await page.goto('/live')
+
+    // Wait for cameras to load
+    await page.waitForSelector('[data-testid="camera-select"], .no-cameras', {
+      timeout: 30000
+    })
+
+    const cameraSelect = page.getByTestId('camera-select')
+    const hasCameras = await cameraSelect.isVisible().catch(() => false)
+
+    if (hasCameras) {
+      // Get all camera options
+      const options = await cameraSelect.locator('option').all()
+
+      if (options.length >= 2) {
+        // Get the second camera's value
+        const secondCameraValue = await options[1].getAttribute('value')
+        console.log(`Selecting camera: ${secondCameraValue}`)
+
+        // Select the second camera
+        await cameraSelect.selectOption(secondCameraValue!)
+
+        // Wait for selection to be applied
+        await page.waitForTimeout(1000)
+
+        // Navigate to recorded page
+        await page.goto('/recorded')
+
+        // Wait for cameras to load on recorded page
+        await page.waitForSelector('[data-testid="camera-select"]', {
+          timeout: 30000
+        })
+
+        // Check that the same camera is selected
+        const recordedCameraSelect = page.getByTestId('camera-select')
+        const selectedValue = await recordedCameraSelect.inputValue()
+
+        expect(selectedValue).toBe(secondCameraValue)
+        console.log(`Camera selection persisted: ${selectedValue}`)
+
+        // Navigate back to live page
+        await page.goto('/live')
+
+        // Wait for cameras to load
+        await page.waitForSelector('[data-testid="camera-select"]', {
+          timeout: 30000
+        })
+
+        // Verify selection still persists
+        const liveCameraSelect = page.getByTestId('camera-select')
+        const liveSelectedValue = await liveCameraSelect.inputValue()
+
+        expect(liveSelectedValue).toBe(secondCameraValue)
+        console.log('Camera selection persisted across page navigations')
+      } else {
+        console.log('Only one camera available - cannot test persistence')
+      }
+    } else {
+      console.log('No cameras to test with')
     }
   })
 })

--- a/examples/vue-media/src/App.vue
+++ b/examples/vue-media/src/App.vue
@@ -1,7 +1,13 @@
 <script setup lang="ts">
+import { onMounted } from 'vue'
 import { useAuthStore } from 'een-api-toolkit'
 
 const authStore = useAuthStore()
+
+// Initialize auth store from localStorage on app mount
+onMounted(() => {
+  authStore.initialize()
+})
 </script>
 
 <template>
@@ -12,6 +18,7 @@ const authStore = useAuthStore()
         <router-link to="/" data-testid="nav-home">Home</router-link>
         <router-link v-if="!authStore.isAuthenticated" to="/login" data-testid="nav-login">Login</router-link>
         <router-link v-if="authStore.isAuthenticated" to="/live" data-testid="nav-live">Live Camera</router-link>
+        <router-link v-if="authStore.isAuthenticated" to="/recorded" data-testid="nav-recorded">Recorded</router-link>
         <router-link v-if="authStore.isAuthenticated" to="/logout" data-testid="nav-logout">Logout</router-link>
       </nav>
     </header>

--- a/examples/vue-media/src/composables/useSelectedCamera.ts
+++ b/examples/vue-media/src/composables/useSelectedCamera.ts
@@ -1,0 +1,31 @@
+import { ref, watch } from 'vue'
+
+// Global reactive state for selected camera ID
+const selectedCameraId = ref<string | null>(null)
+
+// Load from localStorage on initialization
+const stored = localStorage.getItem('vue-media-selected-camera')
+if (stored) {
+  selectedCameraId.value = stored
+}
+
+// Persist to localStorage when changed
+watch(selectedCameraId, (newValue) => {
+  if (newValue) {
+    localStorage.setItem('vue-media-selected-camera', newValue)
+  } else {
+    localStorage.removeItem('vue-media-selected-camera')
+  }
+})
+
+/**
+ * Composable for sharing selected camera ID across pages
+ */
+export function useSelectedCamera() {
+  return {
+    selectedCameraId,
+    setSelectedCamera(id: string | null) {
+      selectedCameraId.value = id
+    }
+  }
+}

--- a/examples/vue-media/src/composables/useSelectedCamera.ts
+++ b/examples/vue-media/src/composables/useSelectedCamera.ts
@@ -1,20 +1,79 @@
 import { ref, watch } from 'vue'
 
+const STORAGE_KEY = 'vue-media-selected-camera'
+
+// Camera ID validation pattern (alphanumeric, typically 8 characters)
+const CAMERA_ID_PATTERN = /^[a-zA-Z0-9]{1,32}$/
+
+/**
+ * Validate camera ID format to prevent XSS via localStorage injection
+ */
+function isValidCameraId(id: string): boolean {
+  return CAMERA_ID_PATTERN.test(id)
+}
+
+/**
+ * Safe localStorage getter with error handling
+ */
+function safeGetItem(key: string): string | null {
+  try {
+    return localStorage.getItem(key)
+  } catch {
+    // localStorage may be disabled or unavailable (private browsing, etc.)
+    return null
+  }
+}
+
+/**
+ * Safe localStorage setter with error handling
+ */
+function safeSetItem(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value)
+  } catch {
+    // localStorage may be full, disabled, or unavailable
+  }
+}
+
+/**
+ * Safe localStorage remover with error handling
+ */
+function safeRemoveItem(key: string): void {
+  try {
+    localStorage.removeItem(key)
+  } catch {
+    // localStorage may be disabled or unavailable
+  }
+}
+
 // Global reactive state for selected camera ID
 const selectedCameraId = ref<string | null>(null)
 
-// Load from localStorage on initialization
-const stored = localStorage.getItem('vue-media-selected-camera')
-if (stored) {
-  selectedCameraId.value = stored
+// Initialization flag to prevent race conditions
+let isInitialized = false
+
+/**
+ * Initialize from localStorage (called once on first use)
+ */
+function initializeFromStorage(): void {
+  if (isInitialized) return
+  isInitialized = true
+
+  const stored = safeGetItem(STORAGE_KEY)
+  if (stored && isValidCameraId(stored)) {
+    selectedCameraId.value = stored
+  }
 }
+
+// Initialize on module load
+initializeFromStorage()
 
 // Persist to localStorage when changed
 watch(selectedCameraId, (newValue) => {
-  if (newValue) {
-    localStorage.setItem('vue-media-selected-camera', newValue)
+  if (newValue && isValidCameraId(newValue)) {
+    safeSetItem(STORAGE_KEY, newValue)
   } else {
-    localStorage.removeItem('vue-media-selected-camera')
+    safeRemoveItem(STORAGE_KEY)
   }
 })
 
@@ -22,10 +81,15 @@ watch(selectedCameraId, (newValue) => {
  * Composable for sharing selected camera ID across pages
  */
 export function useSelectedCamera() {
+  // Ensure initialization on first use (handles lazy loading scenarios)
+  initializeFromStorage()
+
   return {
     selectedCameraId,
     setSelectedCamera(id: string | null) {
-      selectedCameraId.value = id
+      if (id === null || isValidCameraId(id)) {
+        selectedCameraId.value = id
+      }
     }
   }
 }

--- a/examples/vue-media/src/router/index.ts
+++ b/examples/vue-media/src/router/index.ts
@@ -4,6 +4,7 @@ import Home from '../views/Home.vue'
 import Login from '../views/Login.vue'
 import Callback from '../views/Callback.vue'
 import LiveCamera from '../views/LiveCamera.vue'
+import RecordedImage from '../views/RecordedImage.vue'
 import Logout from '../views/Logout.vue'
 
 const router = createRouter({
@@ -37,6 +38,12 @@ const router = createRouter({
       path: '/live',
       name: 'live',
       component: LiveCamera,
+      meta: { requiresAuth: true }
+    },
+    {
+      path: '/recorded',
+      name: 'recorded',
+      component: RecordedImage,
       meta: { requiresAuth: true }
     },
     {

--- a/examples/vue-media/src/views/Home.vue
+++ b/examples/vue-media/src/views/Home.vue
@@ -17,20 +17,26 @@ const authStore = useAuthStore()
 
     <div v-else class="authenticated" data-testid="authenticated">
       <p>You are logged in!</p>
-      <router-link to="/live">
-        <button data-testid="view-live-button">View Live Camera</button>
-      </router-link>
+      <div class="button-group">
+        <router-link to="/live">
+          <button data-testid="view-live-button">View Live Camera</button>
+        </router-link>
+        <router-link to="/recorded">
+          <button data-testid="view-recorded-button">View Recorded Images</button>
+        </router-link>
+      </div>
     </div>
 
     <div class="description">
       <h3>About This Example</h3>
       <p>
-        This example demonstrates using the EEN Media API to fetch live images from cameras.
+        This example demonstrates using the EEN Media API to fetch live and recorded images from cameras.
         It showcases the following toolkit functions:
       </p>
       <ul>
         <li><code>getCameras()</code> - List available cameras</li>
         <li><code>getLiveImage()</code> - Fetch live preview images</li>
+        <li><code>getRecordedImage()</code> - Fetch recorded images with timeline navigation</li>
       </ul>
     </div>
   </div>
@@ -55,6 +61,13 @@ const authStore = useAuthStore()
 .authenticated p {
   margin-bottom: 20px;
   color: #666;
+}
+
+.button-group {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  flex-wrap: wrap;
 }
 
 .description {

--- a/examples/vue-media/src/views/LiveCamera.vue
+++ b/examples/vue-media/src/views/LiveCamera.vue
@@ -2,9 +2,10 @@
 import { ref, onMounted, onUnmounted } from 'vue'
 import { getCameras, getLiveImage } from 'een-api-toolkit'
 import type { Camera } from 'een-api-toolkit'
+import { useSelectedCamera } from '../composables/useSelectedCamera'
 
 const cameras = ref<Camera[]>([])
-const selectedCameraId = ref<string | null>(null)
+const { selectedCameraId, setSelectedCamera } = useSelectedCamera()
 const imageData = ref<string | null>(null)
 const imageTimestamp = ref<string | null>(null)
 const loading = ref(true)
@@ -44,9 +45,13 @@ async function loadCameras() {
   cameras.value = result.data?.results || []
   loading.value = false
 
-  // Auto-select first camera if available
-  if (cameras.value.length > 0 && !selectedCameraId.value) {
-    selectedCameraId.value = cameras.value[0].id
+  // Use shared camera if valid, otherwise auto-select first camera
+  if (cameras.value.length > 0) {
+    const isValidCamera = selectedCameraId.value &&
+      cameras.value.some(c => c.id === selectedCameraId.value)
+    if (!isValidCamera) {
+      setSelectedCamera(cameras.value[0].id)
+    }
     await fetchLiveImage()
   }
 }
@@ -93,7 +98,7 @@ async function fetchLiveImage() {
 }
 
 async function selectCamera(cameraId: string) {
-  selectedCameraId.value = cameraId
+  setSelectedCamera(cameraId)
   imageData.value = null
   error.value = null
   consecutiveErrors.value = 0
@@ -229,6 +234,9 @@ onUnmounted(() => {
     <div class="navigation">
       <router-link to="/">
         <button>Back to Home</button>
+      </router-link>
+      <router-link to="/recorded">
+        <button data-testid="view-recorded-button">View Recorded Images</button>
       </router-link>
       <router-link to="/logout">
         <button>Logout</button>

--- a/examples/vue-media/src/views/RecordedImage.vue
+++ b/examples/vue-media/src/views/RecordedImage.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue'
 import { getCameras, getRecordedImage } from 'een-api-toolkit'
-import type { Camera } from 'een-api-toolkit'
+import type { Camera, GetRecordedImageParams } from 'een-api-toolkit'
 import { useSelectedCamera } from '../composables/useSelectedCamera'
+
+// Constants
+const ONE_HOUR_MS = 60 * 60 * 1000
 
 const cameras = ref<Camera[]>([])
 const { selectedCameraId, setSelectedCamera } = useSelectedCamera()
@@ -26,7 +29,7 @@ let currentRequestId = 0
 const selectedDateTime = ref(getDefaultDateTime())
 
 function getDefaultDateTime(): string {
-  const date = new Date(Date.now() - 3600000) // 1 hour ago
+  const date = new Date(Date.now() - ONE_HOUR_MS)
   return formatDateTimeLocal(date)
 }
 
@@ -113,30 +116,37 @@ async function loadCameras() {
   }
 }
 
-async function fetchImageFromPicker() {
-  if (!selectedCameraId.value) return
+/**
+ * Clear all image-related state
+ */
+function clearImageState() {
+  imageData.value = null
+  imageTimestamp.value = null
+  nextToken.value = null
+  prevToken.value = null
+}
 
+/**
+ * Core image fetching function - handles loading state, race conditions, and error handling
+ */
+async function _fetchImage(params: GetRecordedImageParams) {
   const requestId = ++currentRequestId
-  const cameraId = selectedCameraId.value
-
   loadingImage.value = true
   error.value = null
 
-  const timestamp = toApiTimestamp(selectedDateTime.value)
+  const result = await getRecordedImage(params)
 
-  const result = await getRecordedImage({
-    deviceId: cameraId,
-    type: 'preview',
-    timestamp__gte: timestamp
-  })
-
+  // Check if component is still mounted and this is still the current request
   if (!isMounted.value || requestId !== currentRequestId) {
     return
   }
 
+  loadingImage.value = false
+
   if (result.error) {
     error.value = result.error.message
-    loadingImage.value = false
+    // Clear stale data on error to avoid showing outdated image
+    clearImageState()
     return
   }
 
@@ -146,79 +156,53 @@ async function fetchImageFromPicker() {
     nextToken.value = result.data.nextToken
     prevToken.value = result.data.prevToken
     updateTimePickerFromImage()
+  } else {
+    // Handle successful responses that don't contain an image
+    clearImageState()
   }
-  loadingImage.value = false
+}
+
+async function fetchImageFromPicker() {
+  if (!selectedCameraId.value) return
+
+  const timestamp = toApiTimestamp(selectedDateTime.value)
+  await _fetchImage({
+    deviceId: selectedCameraId.value,
+    type: 'preview',
+    timestamp__gte: timestamp
+  })
 }
 
 async function navigatePrev() {
   if (!prevToken.value) return
-
-  const requestId = ++currentRequestId
-  loadingImage.value = true
-  error.value = null
-
-  const result = await getRecordedImage({
-    pageToken: prevToken.value
-  })
-
-  if (!isMounted.value || requestId !== currentRequestId) {
-    return
-  }
-
-  if (result.error) {
-    error.value = result.error.message
-    loadingImage.value = false
-    return
-  }
-
-  if (result.data) {
-    imageData.value = result.data.imageData
-    imageTimestamp.value = result.data.timestamp
-    nextToken.value = result.data.nextToken
-    prevToken.value = result.data.prevToken
-    updateTimePickerFromImage()
-  }
-  loadingImage.value = false
+  await _fetchImage({ pageToken: prevToken.value })
 }
 
 async function navigateNext() {
   if (!nextToken.value) return
-
-  const requestId = ++currentRequestId
-  loadingImage.value = true
-  error.value = null
-
-  const result = await getRecordedImage({
-    pageToken: nextToken.value
-  })
-
-  if (!isMounted.value || requestId !== currentRequestId) {
-    return
-  }
-
-  if (result.error) {
-    error.value = result.error.message
-    loadingImage.value = false
-    return
-  }
-
-  if (result.data) {
-    imageData.value = result.data.imageData
-    imageTimestamp.value = result.data.timestamp
-    nextToken.value = result.data.nextToken
-    prevToken.value = result.data.prevToken
-    updateTimePickerFromImage()
-  }
-  loadingImage.value = false
+  await _fetchImage({ pageToken: nextToken.value })
 }
 
+/**
+ * Handle camera selection change with proper race condition handling
+ */
 async function selectCamera(cameraId: string) {
+  if (!isMounted.value) return
+
   setSelectedCamera(cameraId)
-  imageData.value = null
+  clearImageState()
   error.value = null
-  nextToken.value = null
-  prevToken.value = null
   await fetchImageFromPicker()
+}
+
+/**
+ * Typed event handler for camera select change
+ */
+function handleCameraChange(event: Event) {
+  const target = event.target as HTMLSelectElement | null
+  if (target?.value) {
+    selectCamera(target.value)
+  }
 }
 
 onMounted(() => {
@@ -253,8 +237,9 @@ onUnmounted(() => {
         <select
           id="camera-select"
           :value="selectedCameraId"
-          @change="selectCamera(($event.target as HTMLSelectElement).value)"
+          @change="handleCameraChange"
           data-testid="camera-select"
+          aria-label="Select a camera to view recorded images"
         >
           <option v-for="camera in cameras" :key="camera.id" :value="camera.id">
             {{ camera.name || camera.id }}
@@ -269,8 +254,14 @@ onUnmounted(() => {
           type="datetime-local"
           v-model="selectedDateTime"
           data-testid="datetime-input"
+          aria-label="Select date and time for recorded image"
         />
-        <button @click="fetchImageFromPicker" :disabled="loadingImage" data-testid="go-button">
+        <button
+          @click="fetchImageFromPicker"
+          :disabled="loadingImage"
+          data-testid="go-button"
+          aria-label="Load image from selected time"
+        >
           Go
         </button>
       </div>
@@ -280,6 +271,7 @@ onUnmounted(() => {
           @click="navigatePrev"
           :disabled="loadingImage || !prevToken"
           data-testid="prev-button"
+          aria-label="Go to previous recorded image"
         >
           ← Previous
         </button>
@@ -287,6 +279,7 @@ onUnmounted(() => {
           @click="navigateNext"
           :disabled="loadingImage || !nextToken"
           data-testid="next-button"
+          aria-label="Go to next recorded image"
         >
           Next →
         </button>

--- a/examples/vue-media/src/views/RecordedImage.vue
+++ b/examples/vue-media/src/views/RecordedImage.vue
@@ -1,0 +1,455 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue'
+import { getCameras, getRecordedImage } from 'een-api-toolkit'
+import type { Camera } from 'een-api-toolkit'
+import { useSelectedCamera } from '../composables/useSelectedCamera'
+
+const cameras = ref<Camera[]>([])
+const { selectedCameraId, setSelectedCamera } = useSelectedCamera()
+const imageData = ref<string | null>(null)
+const imageTimestamp = ref<string | null>(null)
+const loading = ref(true)
+const loadingImage = ref(false)
+const error = ref<string | null>(null)
+
+// Navigation tokens
+const nextToken = ref<string | null>(null)
+const prevToken = ref<string | null>(null)
+
+// Track component lifecycle to prevent memory leaks
+const isMounted = ref(true)
+
+// Track current request to handle race conditions
+let currentRequestId = 0
+
+// Time picker state - default to 1 hour ago
+const selectedDateTime = ref(getDefaultDateTime())
+
+function getDefaultDateTime(): string {
+  const date = new Date(Date.now() - 3600000) // 1 hour ago
+  return formatDateTimeLocal(date)
+}
+
+function formatDateTimeLocal(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  const hours = String(date.getHours()).padStart(2, '0')
+  const minutes = String(date.getMinutes()).padStart(2, '0')
+  return `${year}-${month}-${day}T${hours}:${minutes}`
+}
+
+/**
+ * Convert a datetime-local input value to ISO 8601 format with timezone offset.
+ * The EEN API requires format like: 2025-12-30T07:57:37.000+00:00
+ */
+function toApiTimestamp(dateTimeLocalValue: string): string {
+  const date = new Date(dateTimeLocalValue)
+
+  const offsetMinutes = date.getTimezoneOffset()
+  const offsetSign = offsetMinutes <= 0 ? '+' : '-'
+  const offsetHours = String(Math.floor(Math.abs(offsetMinutes) / 60)).padStart(2, '0')
+  const offsetMins = String(Math.abs(offsetMinutes) % 60).padStart(2, '0')
+  const offset = `${offsetSign}${offsetHours}:${offsetMins}`
+
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  const hours = String(date.getHours()).padStart(2, '0')
+  const minutes = String(date.getMinutes()).padStart(2, '0')
+  const seconds = String(date.getSeconds()).padStart(2, '0')
+
+  return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}.000${offset}`
+}
+
+function formatTimestamp(timestamp: string | null): string {
+  if (!timestamp) return 'N/A'
+  try {
+    return new Date(timestamp).toLocaleString()
+  } catch {
+    return timestamp
+  }
+}
+
+/**
+ * Update the time picker to reflect the current image timestamp
+ */
+function updateTimePickerFromImage() {
+  if (imageTimestamp.value) {
+    try {
+      const date = new Date(imageTimestamp.value)
+      selectedDateTime.value = formatDateTimeLocal(date)
+    } catch {
+      // Keep current value if parsing fails
+    }
+  }
+}
+
+async function loadCameras() {
+  loading.value = true
+  error.value = null
+
+  const result = await getCameras()
+
+  if (!isMounted.value) return
+
+  if (result.error) {
+    error.value = result.error.message
+    loading.value = false
+    return
+  }
+
+  cameras.value = result.data?.results || []
+  loading.value = false
+
+  // Use shared camera if valid, otherwise auto-select first camera
+  if (cameras.value.length > 0) {
+    const isValidCamera = selectedCameraId.value &&
+      cameras.value.some(c => c.id === selectedCameraId.value)
+    if (!isValidCamera) {
+      setSelectedCamera(cameras.value[0].id)
+    }
+    await fetchImageFromPicker()
+  }
+}
+
+async function fetchImageFromPicker() {
+  if (!selectedCameraId.value) return
+
+  const requestId = ++currentRequestId
+  const cameraId = selectedCameraId.value
+
+  loadingImage.value = true
+  error.value = null
+
+  const timestamp = toApiTimestamp(selectedDateTime.value)
+
+  const result = await getRecordedImage({
+    deviceId: cameraId,
+    type: 'preview',
+    timestamp__gte: timestamp
+  })
+
+  if (!isMounted.value || requestId !== currentRequestId) {
+    return
+  }
+
+  if (result.error) {
+    error.value = result.error.message
+    loadingImage.value = false
+    return
+  }
+
+  if (result.data) {
+    imageData.value = result.data.imageData
+    imageTimestamp.value = result.data.timestamp
+    nextToken.value = result.data.nextToken
+    prevToken.value = result.data.prevToken
+    updateTimePickerFromImage()
+  }
+  loadingImage.value = false
+}
+
+async function navigatePrev() {
+  if (!prevToken.value) return
+
+  const requestId = ++currentRequestId
+  loadingImage.value = true
+  error.value = null
+
+  const result = await getRecordedImage({
+    pageToken: prevToken.value
+  })
+
+  if (!isMounted.value || requestId !== currentRequestId) {
+    return
+  }
+
+  if (result.error) {
+    error.value = result.error.message
+    loadingImage.value = false
+    return
+  }
+
+  if (result.data) {
+    imageData.value = result.data.imageData
+    imageTimestamp.value = result.data.timestamp
+    nextToken.value = result.data.nextToken
+    prevToken.value = result.data.prevToken
+    updateTimePickerFromImage()
+  }
+  loadingImage.value = false
+}
+
+async function navigateNext() {
+  if (!nextToken.value) return
+
+  const requestId = ++currentRequestId
+  loadingImage.value = true
+  error.value = null
+
+  const result = await getRecordedImage({
+    pageToken: nextToken.value
+  })
+
+  if (!isMounted.value || requestId !== currentRequestId) {
+    return
+  }
+
+  if (result.error) {
+    error.value = result.error.message
+    loadingImage.value = false
+    return
+  }
+
+  if (result.data) {
+    imageData.value = result.data.imageData
+    imageTimestamp.value = result.data.timestamp
+    nextToken.value = result.data.nextToken
+    prevToken.value = result.data.prevToken
+    updateTimePickerFromImage()
+  }
+  loadingImage.value = false
+}
+
+async function selectCamera(cameraId: string) {
+  setSelectedCamera(cameraId)
+  imageData.value = null
+  error.value = null
+  nextToken.value = null
+  prevToken.value = null
+  await fetchImageFromPicker()
+}
+
+onMounted(() => {
+  loadCameras()
+})
+
+onUnmounted(() => {
+  isMounted.value = false
+})
+</script>
+
+<template>
+  <div class="recorded-image">
+    <h2>Recorded Images</h2>
+
+    <div v-if="loading" class="loading">
+      <p>Loading cameras...</p>
+    </div>
+
+    <div v-else-if="error && cameras.length === 0" class="error-state">
+      <p class="error">{{ error }}</p>
+      <button @click="loadCameras">Retry</button>
+    </div>
+
+    <div v-else-if="cameras.length === 0" class="no-cameras">
+      <p>No cameras found in your account.</p>
+    </div>
+
+    <div v-else class="camera-view">
+      <div class="camera-selector">
+        <label for="camera-select">Select Camera:</label>
+        <select
+          id="camera-select"
+          :value="selectedCameraId"
+          @change="selectCamera(($event.target as HTMLSelectElement).value)"
+          data-testid="camera-select"
+        >
+          <option v-for="camera in cameras" :key="camera.id" :value="camera.id">
+            {{ camera.name || camera.id }}
+          </option>
+        </select>
+      </div>
+
+      <div class="time-picker">
+        <label for="datetime-input">Select Date/Time:</label>
+        <input
+          id="datetime-input"
+          type="datetime-local"
+          v-model="selectedDateTime"
+          data-testid="datetime-input"
+        />
+        <button @click="fetchImageFromPicker" :disabled="loadingImage" data-testid="go-button">
+          Go
+        </button>
+      </div>
+
+      <div class="controls">
+        <button
+          @click="navigatePrev"
+          :disabled="loadingImage || !prevToken"
+          data-testid="prev-button"
+        >
+          ← Previous
+        </button>
+        <button
+          @click="navigateNext"
+          :disabled="loadingImage || !nextToken"
+          data-testid="next-button"
+        >
+          Next →
+        </button>
+      </div>
+
+      <div v-if="error" class="error-banner">
+        <p class="error">{{ error }}</p>
+      </div>
+
+      <div class="image-container" data-testid="image-container">
+        <div v-if="loadingImage && !imageData" class="image-loading">
+          <p>Loading image...</p>
+        </div>
+
+        <img
+          v-else-if="imageData"
+          :src="imageData"
+          alt="Recorded camera image"
+          class="recorded-image-display"
+          data-testid="recorded-image"
+        />
+
+        <div v-else class="no-image">
+          <p>Select a time to view recorded images</p>
+        </div>
+      </div>
+
+      <div v-if="imageTimestamp" class="timestamp" data-testid="timestamp">
+        <small>Timestamp: {{ formatTimestamp(imageTimestamp) }}</small>
+      </div>
+    </div>
+
+    <div class="navigation">
+      <router-link to="/">
+        <button>Back to Home</button>
+      </router-link>
+      <router-link to="/live">
+        <button>View Live Camera</button>
+      </router-link>
+      <router-link to="/logout">
+        <button>Logout</button>
+      </router-link>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.recorded-image {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+h2 {
+  margin-bottom: 20px;
+  text-align: center;
+}
+
+.loading,
+.error-state,
+.no-cameras {
+  text-align: center;
+  padding: 40px;
+}
+
+.camera-selector {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 15px;
+}
+
+.camera-selector label {
+  font-weight: bold;
+}
+
+.camera-selector select {
+  flex: 1;
+  padding: 8px;
+  font-size: 14px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+}
+
+.time-picker {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 15px;
+  flex-wrap: wrap;
+}
+
+.time-picker label {
+  font-weight: bold;
+}
+
+.time-picker input {
+  padding: 8px;
+  font-size: 14px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+}
+
+.time-picker button {
+  padding: 8px 16px;
+}
+
+.controls {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 15px;
+}
+
+.controls button {
+  padding: 8px 16px;
+}
+
+.controls button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.error-banner {
+  margin-bottom: 15px;
+}
+
+.image-container {
+  background: #f8f9fa;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  min-height: 300px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.image-loading,
+.no-image {
+  text-align: center;
+  color: #666;
+}
+
+.recorded-image-display {
+  max-width: 100%;
+  max-height: 500px;
+  object-fit: contain;
+}
+
+.timestamp {
+  margin-top: 10px;
+  text-align: center;
+  color: #666;
+}
+
+.navigation {
+  margin-top: 30px;
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.error {
+  color: #dc3545;
+}
+</style>


### PR DESCRIPTION
## Summary

Adds a new RecordedImage page to the vue-media example app with shared camera selection between Live and Recorded pages.

### Changes
- **RecordedImage.vue**: New page with date/time picker, prev/next navigation for browsing recorded images
- **useSelectedCamera composable**: Shared camera state persisted via localStorage across pages
- **LiveCamera.vue**: Added "View Recorded Images" button, uses shared camera composable
- **Navigation**: Updated App.vue nav and Home.vue with links to Recorded page
- **Router**: Added /recorded route
- **E2E Tests**: Comprehensive tests for recorded image functionality and camera persistence

### Commits
- 61e4e88 feat: Add RecordedImage page with shared camera selection

## Test Results
- Lint: ✅ Passed (1 warning)
- Unit tests: ✅ 131 passed
- Build: ✅ Passed

## Version
`0.1.7`

🤖 Generated with [Claude Code](https://claude.com/claude-code)