### PR TITLE
feat: RecordedImage page, code review fixes, and timestamp documentation

### DIFF
--- a/docs/AI-CONTEXT.md
+++ b/docs/AI-CONTEXT.md
@@ -565,6 +565,40 @@ interface RecordedImageResult {
 }
 ```
 
+### EEN Timestamp Format (CRITICAL)
+
+The EEN API requires timestamps in **ISO 8601 format with explicit timezone offset**. The `Z` suffix (UTC) is **not accepted** for recorded image queries.
+
+| Format | Example | Valid |
+|--------|---------|-------|
+| With offset | `2025-01-15T14:30:00.000-08:00` | ✅ Yes |
+| With offset | `2025-01-15T22:30:00.000+00:00` | ✅ Yes |
+| With Z suffix | `2025-01-15T22:30:00.000Z` | ❌ No (400 Bad Request) |
+
+**Correct timestamp formatting:**
+
+```typescript
+function toApiTimestamp(date: Date): string {
+  const offsetMinutes = date.getTimezoneOffset()
+  const offsetSign = offsetMinutes <= 0 ? '+' : '-'
+  const offsetHours = String(Math.floor(Math.abs(offsetMinutes) / 60)).padStart(2, '0')
+  const offsetMins = String(Math.abs(offsetMinutes) % 60).padStart(2, '0')
+  const offset = `${offsetSign}${offsetHours}:${offsetMins}`
+
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  const hours = String(date.getHours()).padStart(2, '0')
+  const minutes = String(date.getMinutes()).padStart(2, '0')
+  const seconds = String(date.getSeconds()).padStart(2, '0')
+
+  return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}.000${offset}`
+}
+// Returns: "2025-01-15T14:30:00.000-08:00"
+```
+
+**Common mistake:** Using `date.toISOString()` returns `Z` suffix which causes 400 Bad Request errors.
+
 ---
 
 ## API Reference

--- a/docs/AI-CONTEXT.md
+++ b/docs/AI-CONTEXT.md
@@ -565,40 +565,6 @@ interface RecordedImageResult {
 }
 ```
 
-### EEN Timestamp Format (CRITICAL)
-
-The EEN API requires timestamps in **ISO 8601 format with explicit timezone offset**. The `Z` suffix (UTC) is **not accepted** for recorded image queries.
-
-| Format | Example | Valid |
-|--------|---------|-------|
-| With offset | `2025-01-15T14:30:00.000-08:00` | ✅ Yes |
-| With offset | `2025-01-15T22:30:00.000+00:00` | ✅ Yes |
-| With Z suffix | `2025-01-15T22:30:00.000Z` | ❌ No (400 Bad Request) |
-
-**Correct timestamp formatting:**
-
-```typescript
-function toApiTimestamp(date: Date): string {
-  const offsetMinutes = date.getTimezoneOffset()
-  const offsetSign = offsetMinutes <= 0 ? '+' : '-'
-  const offsetHours = String(Math.floor(Math.abs(offsetMinutes) / 60)).padStart(2, '0')
-  const offsetMins = String(Math.abs(offsetMinutes) % 60).padStart(2, '0')
-  const offset = `${offsetSign}${offsetHours}:${offsetMins}`
-
-  const year = date.getFullYear()
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  const day = String(date.getDate()).padStart(2, '0')
-  const hours = String(date.getHours()).padStart(2, '0')
-  const minutes = String(date.getMinutes()).padStart(2, '0')
-  const seconds = String(date.getSeconds()).padStart(2, '0')
-
-  return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}.000${offset}`
-}
-// Returns: "2025-01-15T14:30:00.000-08:00"
-```
-
-**Common mistake:** Using `date.toISOString()` returns `Z` suffix which causes 400 Bad Request errors.
-
 ---
 
 ## API Reference

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -374,8 +374,8 @@ const { data: mediaList } = await listMedia({
   deviceId: 'camera-123',
   type: 'preview',
   mediaType: 'video',
-  startTimestamp: '2025-01-01T00:00:00.000Z',
-  endTimestamp: '2025-01-02T00:00:00.000Z'
+  startTimestamp: '2025-01-01T00:00:00.000+00:00',
+  endTimestamp: '2025-01-02T00:00:00.000+00:00'
 })
 ```
 
@@ -427,6 +427,8 @@ const timestamp = new Date().toISOString()
 const timestamp = toApiTimestamp(new Date())
 // Returns: "2025-01-15T14:30:00.000-08:00" ✅
 ```
+
+**Note on milliseconds:** The milliseconds component (`.000`) is included for API format consistency. For `getRecordedImage` queries, the API returns the nearest available image to the requested timestamp, so sub-second precision is typically not critical.
 
 ### Pagination
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -338,6 +338,96 @@ if (camera) {
 }
 ```
 
+### Media API (Live and Recorded Images)
+
+```typescript
+import { getLiveImage, getRecordedImage, listMedia } from 'een-api-toolkit'
+
+// Get live preview image
+const { data: liveImage, error } = await getLiveImage({
+  deviceId: 'camera-123'
+})
+if (liveImage) {
+  // imageData is a base64 data URL (data:image/jpeg;base64,...)
+  imgElement.src = liveImage.imageData
+}
+
+// Get recorded image from a specific time
+const { data: recordedImage } = await getRecordedImage({
+  deviceId: 'camera-123',
+  type: 'preview',
+  timestamp__gte: '2025-01-15T14:30:00.000-08:00'  // ISO 8601 with timezone offset
+})
+if (recordedImage) {
+  imgElement.src = recordedImage.imageData
+
+  // Navigate to next/previous image using tokens
+  if (recordedImage.nextToken) {
+    const { data: nextImage } = await getRecordedImage({
+      pageToken: recordedImage.nextToken
+    })
+  }
+}
+
+// List media intervals (find when recordings exist)
+const { data: mediaList } = await listMedia({
+  deviceId: 'camera-123',
+  type: 'preview',
+  mediaType: 'video',
+  startTimestamp: '2025-01-01T00:00:00.000Z',
+  endTimestamp: '2025-01-02T00:00:00.000Z'
+})
+```
+
+#### EEN Timestamp Format (Critical)
+
+The EEN API requires timestamps in **ISO 8601 format with explicit timezone offset**. The `Z` suffix (UTC) is **not accepted** for recorded image queries.
+
+| Format | Example | Valid |
+|--------|---------|-------|
+| With offset | `2025-01-15T14:30:00.000-08:00` | ✅ Yes |
+| With offset | `2025-01-15T22:30:00.000+00:00` | ✅ Yes |
+| With Z suffix | `2025-01-15T22:30:00.000Z` | ❌ No |
+
+**Correct timestamp formatting function:**
+
+```typescript
+function toApiTimestamp(date: Date): string {
+  // Get timezone offset in minutes
+  const offsetMinutes = date.getTimezoneOffset()
+  const offsetSign = offsetMinutes <= 0 ? '+' : '-'
+  const offsetHours = String(Math.floor(Math.abs(offsetMinutes) / 60)).padStart(2, '0')
+  const offsetMins = String(Math.abs(offsetMinutes) % 60).padStart(2, '0')
+  const offset = `${offsetSign}${offsetHours}:${offsetMins}`
+
+  // Format date components
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  const hours = String(date.getHours()).padStart(2, '0')
+  const minutes = String(date.getMinutes()).padStart(2, '0')
+  const seconds = String(date.getSeconds()).padStart(2, '0')
+
+  return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}.000${offset}`
+}
+
+// Usage
+const timestamp = toApiTimestamp(new Date())
+// Result: "2025-01-15T14:30:00.000-08:00"
+```
+
+**Common mistake:**
+
+```typescript
+// WRONG - toISOString() returns Z suffix which is not accepted
+const timestamp = new Date().toISOString()
+// Returns: "2025-01-15T22:30:00.000Z" ❌
+
+// CORRECT - use explicit timezone offset
+const timestamp = toApiTimestamp(new Date())
+// Returns: "2025-01-15T14:30:00.000-08:00" ✅
+```
+
 ### Pagination
 
 The EEN API uses cursor-based pagination:


### PR DESCRIPTION
## Summary

This PR adds the RecordedImage page to the vue-media example, addresses code review feedback, and documents the critical EEN timestamp format requirement.

### Features
- **RecordedImage.vue**: New page with date/time picker, prev/next navigation for browsing recorded images
- **Shared camera selection**: Camera selection persists between Live and Recorded pages via localStorage
- **Time picker sync**: Automatically updates to show current image timestamp

### Security & Robustness Fixes
- Camera ID validation with regex pattern to prevent XSS via localStorage
- localStorage operations wrapped in try-catch for private browsing support
- Initialization flag to prevent race conditions in composable
- Extracted `_fetchImage` helper to eliminate duplication
- Fixed stale data bug - image data cleared on error
- Added ARIA labels for accessibility

### Documentation
- Added Media API section to USER-GUIDE.md
- Documented EEN timestamp format requirement (ISO 8601 with timezone offset, not Z suffix)
- Added `toApiTimestamp()` helper function example
- Updated AI-CONTEXT.md with same documentation

### Commits
- 52f411b docs: Add EEN timestamp format documentation for recorded images
- c635af2 Merge pull request #35 from klaushofrichter/develop
- 6179fda fix: Address code review feedback for RecordedImage page
- 61e4e88 feat: Add RecordedImage page with shared camera selection

## Test Results
- Lint: ✅ Passed (1 warning)
- Unit tests: ✅ 131 passed
- Build: ✅ Passed

## Version
`0.1.7`

🤖 Generated with [Claude Code](https://claude.com/claude-code)