### PR TITLE
docs: Clarify OAuth callback handling and add logout button to prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ npm run test:e2e:ui
 
 - [EEN Developer Portal](https://developer.eagleeyenetworks.com/)
 - [EEN API v3.0 Documentation](https://developer.eagleeyenetworks.com/reference/using-the-api)
+- [EEN OAuth Application Management](https://developer.eagleeyenetworks.com/page/my-application)
 - [een-oauth-proxy](https://github.com/klaushofrichter/een-oauth-proxy) - OAuth proxy server
 
 ## License

--- a/docs/AI-CONTEXT.md
+++ b/docs/AI-CONTEXT.md
@@ -1,6 +1,6 @@
 # EEN API Toolkit - AI Reference
 
-> **Version:** 0.2.0
+> **Version:** 0.2.1
 >
 > This file is optimized for AI assistants. It contains all API signatures,
 > types, and usage patterns in a single, parseable document.

--- a/docs/Prompts.md
+++ b/docs/Prompts.md
@@ -135,6 +135,31 @@ VITE_PROXY_URL=http://127.0.0.1:8787
 - The OAuth proxy must be running before testing the app
 - See [USER-GUIDE.md](./USER-GUIDE.md) for detailed setup instructions
 
+### Logout Implementation
+
+When implementing a logout button, use the `revokeToken()` function from een-api-toolkit:
+
+```typescript
+import { revokeToken } from 'een-api-toolkit'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+
+async function handleLogout() {
+  const { error } = await revokeToken()
+  if (error) {
+    console.error('Logout failed:', error.message)
+  }
+  // Always redirect to login, even if revoke fails
+  router.push('/login')
+}
+```
+
+The `revokeToken()` function:
+- Revokes the session with the OAuth proxy
+- Clears the local authentication state
+- Returns `{ data, error }` like all toolkit functions
+
 ---
 
 ## Contributing Prompts

--- a/docs/Prompts.md
+++ b/docs/Prompts.md
@@ -20,7 +20,7 @@ This document contains example prompts that developers can use with AI coding as
 **Prompt:**
 
 ```
-We are building a Vue 3 web app that accesses the EEN Video Platform by using the een-api-toolkit (npm install een-api-toolkit@latest). The app allows login to the service and lists all users. This should include pagination for accounts with more than 10 users. When clicking on a user, we want to see details for that user in a modal window.
+We are building a Vue 3 web app that accesses the EEN Video Platform by using the een-api-toolkit (npm install een-api-toolkit@latest). The app allows login to the service and lists all users. This should include pagination for accounts with more than 10 users. When clicking on a user, we want to see details for that user in a modal window. Show a logout button.
 
 Refer to https://github.com/klaushofrichter/een-api-toolkit/blob/production/docs/AI-CONTEXT.md for more information about the een-api-toolkit.
 
@@ -52,6 +52,7 @@ We are building a Vue 3 web app that accesses the EEN Video Platform by using th
 3. Pagination for accounts with more than 12 cameras
 4. Click on a camera to see detailed information including device info, location, and tags
 5. A refresh button to reload the camera list
+6. Show a logout button
 
 Refer to https://github.com/klaushofrichter/een-api-toolkit/blob/production/docs/AI-CONTEXT.md for more information about the een-api-toolkit.
 
@@ -84,6 +85,7 @@ We are building a Vue 3 web app that accesses the EEN Video Platform by using th
 3. Pagination when there are more than 9 cameras available
 4. When clicking on a camera card, show a modal window with a live main video feed from that camera
 5. Loading states and error handling
+6. Show a logout button
 
 Refer to https://github.com/klaushofrichter/een-api-toolkit/blob/production/docs/AI-CONTEXT.md for more information about the een-api-toolkit.
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -192,7 +192,41 @@ function login() {
 
 ### Handling the Callback
 
-Create a callback route (e.g., `/callback`) to handle the OAuth redirect:
+> **Important:** The EEN Identity Provider only supports redirects to the **root path** (`/`), not `/callback`. Your router must detect OAuth parameters on the root path and forward them to a callback handler internally.
+
+**Router configuration** (handles OAuth redirect on root path):
+
+```typescript
+// router/index.ts
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [
+    { path: '/login', component: Login },
+    {
+      path: '/callback',
+      name: 'callback',
+      component: Callback  // Internal route - not the OAuth redirect target
+    },
+    {
+      path: '/',
+      name: 'home',
+      component: Dashboard,
+      meta: { requiresAuth: true },
+      // Detect OAuth callback and forward to handler
+      beforeEnter: (to, _from, next) => {
+        if (to.query.code && to.query.state) {
+          // Forward OAuth params to callback handler
+          next({ name: 'callback', query: to.query })
+        } else {
+          next()
+        }
+      }
+    }
+  ]
+})
+```
+
+**Callback component** (processes the forwarded OAuth params):
 
 ```typescript
 // Callback.vue
@@ -224,6 +258,13 @@ onMounted(async () => {
   router.push('/dashboard')
 })
 ```
+
+**How it works:**
+1. User clicks login → redirected to EEN login page
+2. After authentication, EEN redirects to `http://127.0.0.1:3333?code=...&state=...` (root path)
+3. Router's `beforeEnter` guard detects `code` and `state` query params
+4. Router forwards to internal `/callback` route with the params
+5. Callback component exchanges the code for tokens via `handleAuthCallback()`
 
 ### Checking Authentication State
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -198,6 +198,9 @@ function login() {
 
 ```typescript
 // router/index.ts
+import { createRouter, createWebHistory } from 'vue-router'
+import { useAuthStore } from 'een-api-toolkit'
+
 const router = createRouter({
   history: createWebHistory(),
   routes: [
@@ -224,6 +227,24 @@ const router = createRouter({
     }
   ]
 })
+
+// Global navigation guard for authentication
+router.beforeEach((to, _from, next) => {
+  const authStore = useAuthStore()
+
+  // Skip auth check for callback route (it handles its own auth)
+  if (to.name === 'callback') {
+    next()
+  } else if (to.meta.requiresAuth && !authStore.isAuthenticated) {
+    next('/login')
+  } else if (to.path === '/login' && authStore.isAuthenticated) {
+    next('/')
+  } else {
+    next()
+  }
+})
+
+export default router
 ```
 
 **Callback component** (processes the forwarded OAuth params):
@@ -265,6 +286,10 @@ onMounted(async () => {
 3. Router's `beforeEnter` guard detects `code` and `state` query params
 4. Router forwards to internal `/callback` route with the params
 5. Callback component exchanges the code for tokens via `handleAuthCallback()`
+
+> **Security Note:** The `state` parameter provides CSRF protection. The toolkit's `handleAuthCallback()` function validates the state parameter internally against the value stored during `getAuthUrl()`. Invalid or tampered state values will result in an authentication error.
+
+> **Error Handling:** The callback component handles all OAuth error scenarios. If the authorization code is invalid, expired, or the state doesn't match, `handleAuthCallback()` returns an error object with details. Invalid parameters (e.g., manually navigating to `/?code=invalid&state=invalid`) are safely handled and will display an error message rather than cause application crashes.
 
 ### Checking Authentication State
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -282,10 +282,12 @@ onMounted(async () => {
 
 **How it works:**
 1. User clicks login → redirected to EEN login page
-2. After authentication, EEN redirects to `http://127.0.0.1:3333?code=...&state=...` (root path)
+2. After authentication, EEN redirects to your configured `redirectUri` with OAuth params (e.g., `http://127.0.0.1:3333?code=...&state=...`)
 3. Router's `beforeEnter` guard detects `code` and `state` query params
 4. Router forwards to internal `/callback` route with the params
 5. Callback component exchanges the code for tokens via `handleAuthCallback()`
+
+> **Note:** The redirect URL is determined by the `redirectUri` option in `initEenToolkit()` (or `VITE_REDIRECT_URI` env var). This must match exactly what's registered with your EEN OAuth client.
 
 > **Security Note:** The `state` parameter provides CSRF protection. The toolkit's `handleAuthCallback()` function validates the state parameter internally against the value stored during `getAuthUrl()`. Invalid or tampered state values will result in an authentication error.
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,8 +1,8 @@
-**EEN API Toolkit v0.2.0**
+**EEN API Toolkit v0.2.1**
 
 ***
 
-# EEN API Toolkit v0.2.0
+# EEN API Toolkit v0.2.1
 
 ## Interfaces
 

--- a/docs/api/functions/getAccessToken.md
+++ b/docs/api/functions/getAccessToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAuthUrl.md
+++ b/docs/api/functions/getAuthUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridge.md
+++ b/docs/api/functions/getBridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridges.md
+++ b/docs/api/functions/getBridges.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCamera.md
+++ b/docs/api/functions/getCamera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameras.md
+++ b/docs/api/functions/getCameras.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/functions/getClientId.md
+++ b/docs/api/functions/getClientId.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/functions/getConfig.md
+++ b/docs/api/functions/getConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCurrentUser.md
+++ b/docs/api/functions/getCurrentUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLiveImage.md
+++ b/docs/api/functions/getLiveImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/functions/getMediaSession.md
+++ b/docs/api/functions/getMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/functions/getProxyUrl.md
+++ b/docs/api/functions/getProxyUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRecordedImage.md
+++ b/docs/api/functions/getRecordedImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRedirectUri.md
+++ b/docs/api/functions/getRedirectUri.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUser.md
+++ b/docs/api/functions/getUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUsers.md
+++ b/docs/api/functions/getUsers.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/functions/handleAuthCallback.md
+++ b/docs/api/functions/handleAuthCallback.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/functions/initEenToolkit.md
+++ b/docs/api/functions/initEenToolkit.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/functions/initMediaSession.md
+++ b/docs/api/functions/initMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/functions/listFeeds.md
+++ b/docs/api/functions/listFeeds.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/functions/listMedia.md
+++ b/docs/api/functions/listMedia.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/functions/refreshToken.md
+++ b/docs/api/functions/refreshToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/functions/revokeToken.md
+++ b/docs/api/functions/revokeToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Bridge.md
+++ b/docs/api/interfaces/Bridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDeviceInfo.md
+++ b/docs/api/interfaces/BridgeDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDevicePosition.md
+++ b/docs/api/interfaces/BridgeDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeNetworkInfo.md
+++ b/docs/api/interfaces/BridgeNetworkInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Camera.md
+++ b/docs/api/interfaces/Camera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDeviceInfo.md
+++ b/docs/api/interfaces/CameraDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDevicePosition.md
+++ b/docs/api/interfaces/CameraDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRecordingModes.md
+++ b/docs/api/interfaces/CameraRecordingModes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRtspConnectionSettings.md
+++ b/docs/api/interfaces/CameraRtspConnectionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraShareDetails.md
+++ b/docs/api/interfaces/CameraShareDetails.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStreamUrls.md
+++ b/docs/api/interfaces/CameraStreamUrls.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenError.md
+++ b/docs/api/interfaces/EenError.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenToolkitConfig.md
+++ b/docs/api/interfaces/EenToolkitConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Feed.md
+++ b/docs/api/interfaces/Feed.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetBridgeParams.md
+++ b/docs/api/interfaces/GetBridgeParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetCameraParams.md
+++ b/docs/api/interfaces/GetCameraParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLiveImageParams.md
+++ b/docs/api/interfaces/GetLiveImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetRecordedImageParams.md
+++ b/docs/api/interfaces/GetRecordedImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetUserParams.md
+++ b/docs/api/interfaces/GetUserParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListBridgesParams.md
+++ b/docs/api/interfaces/ListBridgesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListCamerasParams.md
+++ b/docs/api/interfaces/ListCamerasParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsParams.md
+++ b/docs/api/interfaces/ListFeedsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsResult.md
+++ b/docs/api/interfaces/ListFeedsResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListMediaParams.md
+++ b/docs/api/interfaces/ListMediaParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListUsersParams.md
+++ b/docs/api/interfaces/ListUsersParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LiveImageResult.md
+++ b/docs/api/interfaces/LiveImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaInterval.md
+++ b/docs/api/interfaces/MediaInterval.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResponse.md
+++ b/docs/api/interfaces/MediaSessionResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResult.md
+++ b/docs/api/interfaces/MediaSessionResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginatedResult.md
+++ b/docs/api/interfaces/PaginatedResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginationParams.md
+++ b/docs/api/interfaces/PaginationParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/RecordedImageResult.md
+++ b/docs/api/interfaces/RecordedImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/TokenResponse.md
+++ b/docs/api/interfaces/TokenResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/User.md
+++ b/docs/api/interfaces/User.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UserProfile.md
+++ b/docs/api/interfaces/UserProfile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/BridgeStatus.md
+++ b/docs/api/type-aliases/BridgeStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraStatus.md
+++ b/docs/api/type-aliases/CameraStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ErrorCode.md
+++ b/docs/api/type-aliases/ErrorCode.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedIncludeOption.md
+++ b/docs/api/type-aliases/FeedIncludeOption.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedMediaType.md
+++ b/docs/api/type-aliases/FeedMediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedStreamType.md
+++ b/docs/api/type-aliases/FeedStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaStreamType.md
+++ b/docs/api/type-aliases/MediaStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaType.md
+++ b/docs/api/type-aliases/MediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/Result.md
+++ b/docs/api/type-aliases/Result.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/docs/api/variables/useAuthStore.md
+++ b/docs/api/variables/useAuthStore.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.2.0**](../README.md)
+[**EEN API Toolkit v0.2.1**](../README.md)
 
 ***
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.1.14",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit",
-      "version": "0.1.14",
+      "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.57.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "EEN Video platform API v3.0 library for Vue 3",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

Documentation improvements for OAuth callback handling and AI prompts:

- **USER-GUIDE.md**: Clarify that OAuth redirects from EEN IDP go to root path (`/`) only, not `/callback`. Added router configuration example showing how to detect OAuth params on root and forward to internal callback handler.
- **Prompts.md**: Add "Show a logout button" instruction to all three AI prompt examples.
- **README.md**: Add link to EEN OAuth Application Management page.

## Commits

- 098653b docs: Clarify OAuth callback handling and add logout button to prompts

## Test Results

- **Lint**: ✅ Passed (1 warning)
- **Unit Tests**: ✅ 164 tests passed
- **Build**: ✅ Successful

## Version

`0.2.1`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)