### PR TITLE
feat: Add debug logging for storage fallback and display storage strategy

### DIFF
--- a/docs/AI-CONTEXT.md
+++ b/docs/AI-CONTEXT.md
@@ -1,6 +1,6 @@
 # EEN API Toolkit - AI Reference
 
-> **Version:** 0.3.8
+> **Version:** 0.3.9
 >
 > This file is optimized for AI assistants. It contains all API signatures,
 > types, and usage patterns in a single, parseable document.

--- a/docs/AI-CONTEXT.md
+++ b/docs/AI-CONTEXT.md
@@ -1,6 +1,6 @@
 # EEN API Toolkit - AI Reference
 
-> **Version:** 0.3.9
+> **Version:** 0.3.10
 >
 > This file is optimized for AI assistants. It contains all API signatures,
 > types, and usage patterns in a single, parseable document.
@@ -309,6 +309,25 @@ interface EenToolkitConfig {
   storageStrategy?: StorageStrategy  // Token storage: 'localStorage' (default), 'sessionStorage', or 'memory'
   debug?: boolean             // Enable debug logging
 }
+```
+
+### Storage Strategy Descriptions
+
+Human-readable descriptions for each storage strategy, useful for displaying in UI components:
+
+```typescript
+import { getStorageStrategy, STORAGE_STRATEGY_DESCRIPTIONS } from 'een-api-toolkit'
+
+// STORAGE_STRATEGY_DESCRIPTIONS is a Record<StorageStrategy, string>:
+// {
+//   localStorage: 'persists across sessions',
+//   sessionStorage: 'per-tab, cleared on tab close',
+//   memory: 'tokens lost on page refresh'
+// }
+
+const strategy = getStorageStrategy()
+const description = STORAGE_STRATEGY_DESCRIPTIONS[strategy]
+console.log(`Using ${strategy}: ${description}`)
 ```
 
 ---

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -218,6 +218,47 @@ The toolkit already implements secure practices:
 
 For applications where XSS is a significant concern, consider using `sessionStorage` or `memory` in combination with Content Security Policy (CSP) headers.
 
+#### Displaying Storage Strategy in UI
+
+The toolkit exports `STORAGE_STRATEGY_DESCRIPTIONS` - a mapping of storage strategies to human-readable descriptions. This is useful for displaying the current storage strategy to users, especially on login pages.
+
+```typescript
+import { getStorageStrategy, STORAGE_STRATEGY_DESCRIPTIONS } from 'een-api-toolkit'
+
+const strategy = getStorageStrategy()
+const description = STORAGE_STRATEGY_DESCRIPTIONS[strategy]
+
+console.log(`Using ${strategy}: ${description}`)
+// Example output: "Using sessionStorage: per-tab, cleared on tab close"
+```
+
+**Available descriptions:**
+
+| Strategy | Description |
+|----------|-------------|
+| `localStorage` | "persists across sessions" |
+| `sessionStorage` | "per-tab, cleared on tab close" |
+| `memory` | "tokens lost on page refresh" |
+
+**Vue 3 Example:**
+
+```vue
+<script setup lang="ts">
+import { getStorageStrategy, STORAGE_STRATEGY_DESCRIPTIONS } from 'een-api-toolkit'
+
+const storageStrategy = getStorageStrategy()
+const storageDescription = STORAGE_STRATEGY_DESCRIPTIONS[storageStrategy]
+</script>
+
+<template>
+  <p class="storage-note">
+    Storage strategy: <strong>{{ storageStrategy }}</strong> ({{ storageDescription }})
+  </p>
+</template>
+```
+
+This approach ensures the displayed information always stays in sync with the actual configuration, even if the storage strategy is changed in `initEenToolkit()`.
+
 ## Authentication Flow
 
 ### OAuth Flow Overview

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,8 +1,8 @@
-**EEN API Toolkit v0.3.8**
+**EEN API Toolkit v0.3.9**
 
 ***
 
-# EEN API Toolkit v0.3.8
+# EEN API Toolkit v0.3.9
 
 ## Interfaces
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,8 +1,8 @@
-**EEN API Toolkit v0.3.9**
+**EEN API Toolkit v0.3.10**
 
 ***
 
-# EEN API Toolkit v0.3.9
+# EEN API Toolkit v0.3.10
 
 ## Interfaces
 
@@ -96,6 +96,12 @@
 - [MediaStreamType](type-aliases/MediaStreamType.md)
 
 ## Variables
+
+### Configuration
+
+- [STORAGE\_STRATEGY\_DESCRIPTIONS](variables/STORAGE_STRATEGY_DESCRIPTIONS.md)
+
+### Other
 
 - [useAuthStore](variables/useAuthStore.md)
 

--- a/docs/api/functions/getAccessToken.md
+++ b/docs/api/functions/getAccessToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAccessToken.md
+++ b/docs/api/functions/getAccessToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAuthUrl.md
+++ b/docs/api/functions/getAuthUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAuthUrl.md
+++ b/docs/api/functions/getAuthUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridge.md
+++ b/docs/api/functions/getBridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridge.md
+++ b/docs/api/functions/getBridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridges.md
+++ b/docs/api/functions/getBridges.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridges.md
+++ b/docs/api/functions/getBridges.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCamera.md
+++ b/docs/api/functions/getCamera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCamera.md
+++ b/docs/api/functions/getCamera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameras.md
+++ b/docs/api/functions/getCameras.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameras.md
+++ b/docs/api/functions/getCameras.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/functions/getClientId.md
+++ b/docs/api/functions/getClientId.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/functions/getClientId.md
+++ b/docs/api/functions/getClientId.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/functions/getConfig.md
+++ b/docs/api/functions/getConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/functions/getConfig.md
+++ b/docs/api/functions/getConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCurrentUser.md
+++ b/docs/api/functions/getCurrentUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCurrentUser.md
+++ b/docs/api/functions/getCurrentUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLiveImage.md
+++ b/docs/api/functions/getLiveImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLiveImage.md
+++ b/docs/api/functions/getLiveImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/functions/getMediaSession.md
+++ b/docs/api/functions/getMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/functions/getMediaSession.md
+++ b/docs/api/functions/getMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/functions/getProxyUrl.md
+++ b/docs/api/functions/getProxyUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/functions/getProxyUrl.md
+++ b/docs/api/functions/getProxyUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRecordedImage.md
+++ b/docs/api/functions/getRecordedImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRecordedImage.md
+++ b/docs/api/functions/getRecordedImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRedirectUri.md
+++ b/docs/api/functions/getRedirectUri.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRedirectUri.md
+++ b/docs/api/functions/getRedirectUri.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/functions/getStorageStrategy.md
+++ b/docs/api/functions/getStorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **getStorageStrategy**(): [`StorageStrategy`](../type-aliases/StorageStrategy.md)
 
-Defined in: [src/utils/storage.ts:97](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/utils/storage.ts#L97)
+Defined in: [src/utils/storage.ts:118](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/utils/storage.ts#L118)
 
 Get the current storage strategy.
 

--- a/docs/api/functions/getStorageStrategy.md
+++ b/docs/api/functions/getStorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **getStorageStrategy**(): [`StorageStrategy`](../type-aliases/StorageStrategy.md)
 
-Defined in: [src/utils/storage.ts:96](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/utils/storage.ts#L96)
+Defined in: [src/utils/storage.ts:97](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/utils/storage.ts#L97)
 
 Get the current storage strategy.
 

--- a/docs/api/functions/getUser.md
+++ b/docs/api/functions/getUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUser.md
+++ b/docs/api/functions/getUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUsers.md
+++ b/docs/api/functions/getUsers.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUsers.md
+++ b/docs/api/functions/getUsers.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/functions/handleAuthCallback.md
+++ b/docs/api/functions/handleAuthCallback.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/functions/handleAuthCallback.md
+++ b/docs/api/functions/handleAuthCallback.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/functions/initEenToolkit.md
+++ b/docs/api/functions/initEenToolkit.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/functions/initEenToolkit.md
+++ b/docs/api/functions/initEenToolkit.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/functions/initMediaSession.md
+++ b/docs/api/functions/initMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/functions/initMediaSession.md
+++ b/docs/api/functions/initMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/functions/listFeeds.md
+++ b/docs/api/functions/listFeeds.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/functions/listFeeds.md
+++ b/docs/api/functions/listFeeds.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/functions/listMedia.md
+++ b/docs/api/functions/listMedia.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/functions/listMedia.md
+++ b/docs/api/functions/listMedia.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/functions/refreshToken.md
+++ b/docs/api/functions/refreshToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/functions/refreshToken.md
+++ b/docs/api/functions/refreshToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/functions/revokeToken.md
+++ b/docs/api/functions/revokeToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/functions/revokeToken.md
+++ b/docs/api/functions/revokeToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Bridge.md
+++ b/docs/api/interfaces/Bridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Bridge.md
+++ b/docs/api/interfaces/Bridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDeviceInfo.md
+++ b/docs/api/interfaces/BridgeDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDeviceInfo.md
+++ b/docs/api/interfaces/BridgeDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDevicePosition.md
+++ b/docs/api/interfaces/BridgeDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDevicePosition.md
+++ b/docs/api/interfaces/BridgeDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeNetworkInfo.md
+++ b/docs/api/interfaces/BridgeNetworkInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeNetworkInfo.md
+++ b/docs/api/interfaces/BridgeNetworkInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Camera.md
+++ b/docs/api/interfaces/Camera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Camera.md
+++ b/docs/api/interfaces/Camera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDeviceInfo.md
+++ b/docs/api/interfaces/CameraDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDeviceInfo.md
+++ b/docs/api/interfaces/CameraDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDevicePosition.md
+++ b/docs/api/interfaces/CameraDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDevicePosition.md
+++ b/docs/api/interfaces/CameraDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRecordingModes.md
+++ b/docs/api/interfaces/CameraRecordingModes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRecordingModes.md
+++ b/docs/api/interfaces/CameraRecordingModes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRtspConnectionSettings.md
+++ b/docs/api/interfaces/CameraRtspConnectionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRtspConnectionSettings.md
+++ b/docs/api/interfaces/CameraRtspConnectionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraShareDetails.md
+++ b/docs/api/interfaces/CameraShareDetails.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraShareDetails.md
+++ b/docs/api/interfaces/CameraShareDetails.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStreamUrls.md
+++ b/docs/api/interfaces/CameraStreamUrls.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStreamUrls.md
+++ b/docs/api/interfaces/CameraStreamUrls.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenError.md
+++ b/docs/api/interfaces/EenError.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenError.md
+++ b/docs/api/interfaces/EenError.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenToolkitConfig.md
+++ b/docs/api/interfaces/EenToolkitConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenToolkitConfig.md
+++ b/docs/api/interfaces/EenToolkitConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Feed.md
+++ b/docs/api/interfaces/Feed.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Feed.md
+++ b/docs/api/interfaces/Feed.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetBridgeParams.md
+++ b/docs/api/interfaces/GetBridgeParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetBridgeParams.md
+++ b/docs/api/interfaces/GetBridgeParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetCameraParams.md
+++ b/docs/api/interfaces/GetCameraParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetCameraParams.md
+++ b/docs/api/interfaces/GetCameraParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLiveImageParams.md
+++ b/docs/api/interfaces/GetLiveImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLiveImageParams.md
+++ b/docs/api/interfaces/GetLiveImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetRecordedImageParams.md
+++ b/docs/api/interfaces/GetRecordedImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetRecordedImageParams.md
+++ b/docs/api/interfaces/GetRecordedImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetUserParams.md
+++ b/docs/api/interfaces/GetUserParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetUserParams.md
+++ b/docs/api/interfaces/GetUserParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListBridgesParams.md
+++ b/docs/api/interfaces/ListBridgesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListBridgesParams.md
+++ b/docs/api/interfaces/ListBridgesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListCamerasParams.md
+++ b/docs/api/interfaces/ListCamerasParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListCamerasParams.md
+++ b/docs/api/interfaces/ListCamerasParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsParams.md
+++ b/docs/api/interfaces/ListFeedsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsParams.md
+++ b/docs/api/interfaces/ListFeedsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsResult.md
+++ b/docs/api/interfaces/ListFeedsResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsResult.md
+++ b/docs/api/interfaces/ListFeedsResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListMediaParams.md
+++ b/docs/api/interfaces/ListMediaParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListMediaParams.md
+++ b/docs/api/interfaces/ListMediaParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListUsersParams.md
+++ b/docs/api/interfaces/ListUsersParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListUsersParams.md
+++ b/docs/api/interfaces/ListUsersParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LiveImageResult.md
+++ b/docs/api/interfaces/LiveImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LiveImageResult.md
+++ b/docs/api/interfaces/LiveImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaInterval.md
+++ b/docs/api/interfaces/MediaInterval.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaInterval.md
+++ b/docs/api/interfaces/MediaInterval.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResponse.md
+++ b/docs/api/interfaces/MediaSessionResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResponse.md
+++ b/docs/api/interfaces/MediaSessionResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResult.md
+++ b/docs/api/interfaces/MediaSessionResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResult.md
+++ b/docs/api/interfaces/MediaSessionResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginatedResult.md
+++ b/docs/api/interfaces/PaginatedResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginatedResult.md
+++ b/docs/api/interfaces/PaginatedResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginationParams.md
+++ b/docs/api/interfaces/PaginationParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginationParams.md
+++ b/docs/api/interfaces/PaginationParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/RecordedImageResult.md
+++ b/docs/api/interfaces/RecordedImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/RecordedImageResult.md
+++ b/docs/api/interfaces/RecordedImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/TokenResponse.md
+++ b/docs/api/interfaces/TokenResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/TokenResponse.md
+++ b/docs/api/interfaces/TokenResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/User.md
+++ b/docs/api/interfaces/User.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/User.md
+++ b/docs/api/interfaces/User.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UserProfile.md
+++ b/docs/api/interfaces/UserProfile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UserProfile.md
+++ b/docs/api/interfaces/UserProfile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/BridgeStatus.md
+++ b/docs/api/type-aliases/BridgeStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/BridgeStatus.md
+++ b/docs/api/type-aliases/BridgeStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraStatus.md
+++ b/docs/api/type-aliases/CameraStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraStatus.md
+++ b/docs/api/type-aliases/CameraStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ErrorCode.md
+++ b/docs/api/type-aliases/ErrorCode.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ErrorCode.md
+++ b/docs/api/type-aliases/ErrorCode.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedIncludeOption.md
+++ b/docs/api/type-aliases/FeedIncludeOption.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedIncludeOption.md
+++ b/docs/api/type-aliases/FeedIncludeOption.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedMediaType.md
+++ b/docs/api/type-aliases/FeedMediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedMediaType.md
+++ b/docs/api/type-aliases/FeedMediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedStreamType.md
+++ b/docs/api/type-aliases/FeedStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedStreamType.md
+++ b/docs/api/type-aliases/FeedStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaStreamType.md
+++ b/docs/api/type-aliases/MediaStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaStreamType.md
+++ b/docs/api/type-aliases/MediaStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaType.md
+++ b/docs/api/type-aliases/MediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaType.md
+++ b/docs/api/type-aliases/MediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/Result.md
+++ b/docs/api/type-aliases/Result.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/Result.md
+++ b/docs/api/type-aliases/Result.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/StorageStrategy.md
+++ b/docs/api/type-aliases/StorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/StorageStrategy.md
+++ b/docs/api/type-aliases/StorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
+++ b/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
@@ -1,0 +1,24 @@
+[**EEN API Toolkit v0.3.10**](../README.md)
+
+***
+
+[EEN API Toolkit](../README.md) / STORAGE\_STRATEGY\_DESCRIPTIONS
+
+# Variable: STORAGE\_STRATEGY\_DESCRIPTIONS
+
+> `const` **STORAGE\_STRATEGY\_DESCRIPTIONS**: `Record`\<[`StorageStrategy`](../type-aliases/StorageStrategy.md), `string`\>
+
+Defined in: [src/utils/storage.ts:23](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/utils/storage.ts#L23)
+
+Human-readable descriptions for each storage strategy.
+Useful for displaying storage information in UI components.
+
+## Example
+
+```typescript
+import { getStorageStrategy, STORAGE_STRATEGY_DESCRIPTIONS } from 'een-api-toolkit'
+
+const strategy = getStorageStrategy()
+const description = STORAGE_STRATEGY_DESCRIPTIONS[strategy]
+console.log(`Using ${strategy}: ${description}`)
+```

--- a/docs/api/variables/useAuthStore.md
+++ b/docs/api/variables/useAuthStore.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.8**](../README.md)
+[**EEN API Toolkit v0.3.9**](../README.md)
 
 ***
 

--- a/docs/api/variables/useAuthStore.md
+++ b/docs/api/variables/useAuthStore.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.9**](../README.md)
+[**EEN API Toolkit v0.3.10**](../README.md)
 
 ***
 

--- a/examples/vue-bridges/src/views/Home.vue
+++ b/examples/vue-bridges/src/views/Home.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
-import { useAuthStore, getCurrentUser, type UserProfile, type EenError } from 'een-api-toolkit'
+import { useAuthStore, getCurrentUser, getStorageStrategy, STORAGE_STRATEGY_DESCRIPTIONS, type UserProfile, type EenError } from 'een-api-toolkit'
 import { computed, ref, onMounted } from 'vue'
 
 const authStore = useAuthStore()
 const isAuthenticated = computed(() => authStore.isAuthenticated)
+
+const storageStrategy = getStorageStrategy()
+const storageDescription = STORAGE_STRATEGY_DESCRIPTIONS[storageStrategy]
 
 // Reactive state for current user
 const user = ref<UserProfile | null>(null)
@@ -74,6 +77,9 @@ onMounted(() => {
         <li>View bridge details</li>
         <li>Display device and network information</li>
       </ul>
+      <p class="storage-note" data-testid="storage-strategy">
+        Storage strategy: <strong>{{ storageStrategy }}</strong> ({{ storageDescription }})
+      </p>
     </div>
   </div>
 </template>
@@ -146,5 +152,13 @@ h2 {
   padding: 2px 6px;
   border-radius: 3px;
   font-size: 0.9em;
+}
+
+.storage-note {
+  margin-top: 20px;
+  padding-top: 15px;
+  border-top: 1px solid #ddd;
+  font-size: 0.85em;
+  color: #888;
 }
 </style>

--- a/examples/vue-bridges/src/views/Login.vue
+++ b/examples/vue-bridges/src/views/Login.vue
@@ -1,8 +1,5 @@
 <script setup lang="ts">
-import { getAuthUrl, getStorageStrategy, STORAGE_STRATEGY_DESCRIPTIONS } from 'een-api-toolkit'
-
-const storageStrategy = getStorageStrategy()
-const storageDescription = STORAGE_STRATEGY_DESCRIPTIONS[storageStrategy]
+import { getAuthUrl } from 'een-api-toolkit'
 
 function login() {
   // Redirect to EEN OAuth login
@@ -15,7 +12,6 @@ function login() {
     <h2>Login</h2>
     <p>Click the button below to login with your Eagle Eye Networks account.</p>
     <button @click="login">Login with Eagle Eye Networks</button>
-    <p class="storage-note" data-testid="storage-strategy">Storage strategy: <strong>{{ storageStrategy }}</strong> ({{ storageDescription }})</p>
   </div>
 </template>
 
@@ -33,11 +29,5 @@ h2 {
 p {
   margin-bottom: 20px;
   color: #666;
-}
-
-.storage-note {
-  margin-top: 30px;
-  font-size: 0.85em;
-  color: #888;
 }
 </style>

--- a/examples/vue-bridges/src/views/Login.vue
+++ b/examples/vue-bridges/src/views/Login.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
-import { getAuthUrl } from 'een-api-toolkit'
+import { getAuthUrl, getStorageStrategy, STORAGE_STRATEGY_DESCRIPTIONS } from 'een-api-toolkit'
+
+const storageStrategy = getStorageStrategy()
+const storageDescription = STORAGE_STRATEGY_DESCRIPTIONS[storageStrategy]
 
 function login() {
   // Redirect to EEN OAuth login
@@ -12,7 +15,7 @@ function login() {
     <h2>Login</h2>
     <p>Click the button below to login with your Eagle Eye Networks account.</p>
     <button @click="login">Login with Eagle Eye Networks</button>
-    <p class="storage-note">Storage strategy: <strong>localStorage</strong> (persists across sessions)</p>
+    <p class="storage-note" data-testid="storage-strategy">Storage strategy: <strong>{{ storageStrategy }}</strong> ({{ storageDescription }})</p>
   </div>
 </template>
 

--- a/examples/vue-bridges/src/views/Login.vue
+++ b/examples/vue-bridges/src/views/Login.vue
@@ -12,6 +12,7 @@ function login() {
     <h2>Login</h2>
     <p>Click the button below to login with your Eagle Eye Networks account.</p>
     <button @click="login">Login with Eagle Eye Networks</button>
+    <p class="storage-note">Storage strategy: <strong>localStorage</strong> (persists across sessions)</p>
   </div>
 </template>
 
@@ -29,5 +30,11 @@ h2 {
 p {
   margin-bottom: 20px;
   color: #666;
+}
+
+.storage-note {
+  margin-top: 30px;
+  font-size: 0.85em;
+  color: #888;
 }
 </style>

--- a/examples/vue-cameras/src/views/Home.vue
+++ b/examples/vue-cameras/src/views/Home.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
-import { useAuthStore, getCurrentUser, type UserProfile, type EenError } from 'een-api-toolkit'
+import { useAuthStore, getCurrentUser, getStorageStrategy, STORAGE_STRATEGY_DESCRIPTIONS, type UserProfile, type EenError } from 'een-api-toolkit'
 import { computed, ref, onMounted } from 'vue'
 
 const authStore = useAuthStore()
 const isAuthenticated = computed(() => authStore.isAuthenticated)
+
+const storageStrategy = getStorageStrategy()
+const storageDescription = STORAGE_STRATEGY_DESCRIPTIONS[storageStrategy]
 
 // Reactive state for current user
 const user = ref<UserProfile | null>(null)
@@ -74,6 +77,9 @@ onMounted(() => {
         <li>View camera details</li>
         <li>Display device information</li>
       </ul>
+      <p class="storage-note" data-testid="storage-strategy">
+        Storage strategy: <strong>{{ storageStrategy }}</strong> ({{ storageDescription }})
+      </p>
     </div>
   </div>
 </template>
@@ -146,5 +152,13 @@ h2 {
   padding: 2px 6px;
   border-radius: 3px;
   font-size: 0.9em;
+}
+
+.storage-note {
+  margin-top: 20px;
+  padding-top: 15px;
+  border-top: 1px solid #ddd;
+  font-size: 0.85em;
+  color: #888;
 }
 </style>

--- a/examples/vue-cameras/src/views/Login.vue
+++ b/examples/vue-cameras/src/views/Login.vue
@@ -1,8 +1,5 @@
 <script setup lang="ts">
-import { getAuthUrl, getStorageStrategy, STORAGE_STRATEGY_DESCRIPTIONS } from 'een-api-toolkit'
-
-const storageStrategy = getStorageStrategy()
-const storageDescription = STORAGE_STRATEGY_DESCRIPTIONS[storageStrategy]
+import { getAuthUrl } from 'een-api-toolkit'
 
 function login() {
   // Redirect to EEN OAuth login
@@ -15,7 +12,6 @@ function login() {
     <h2>Login</h2>
     <p>Click the button below to login with your Eagle Eye Networks account.</p>
     <button @click="login">Login with Eagle Eye Networks</button>
-    <p class="storage-note" data-testid="storage-strategy">Storage strategy: <strong>{{ storageStrategy }}</strong> ({{ storageDescription }})</p>
   </div>
 </template>
 
@@ -33,11 +29,5 @@ h2 {
 p {
   margin-bottom: 20px;
   color: #666;
-}
-
-.storage-note {
-  margin-top: 30px;
-  font-size: 0.85em;
-  color: #888;
 }
 </style>

--- a/examples/vue-cameras/src/views/Login.vue
+++ b/examples/vue-cameras/src/views/Login.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
-import { getAuthUrl } from 'een-api-toolkit'
+import { getAuthUrl, getStorageStrategy, STORAGE_STRATEGY_DESCRIPTIONS } from 'een-api-toolkit'
+
+const storageStrategy = getStorageStrategy()
+const storageDescription = STORAGE_STRATEGY_DESCRIPTIONS[storageStrategy]
 
 function login() {
   // Redirect to EEN OAuth login
@@ -12,7 +15,7 @@ function login() {
     <h2>Login</h2>
     <p>Click the button below to login with your Eagle Eye Networks account.</p>
     <button @click="login">Login with Eagle Eye Networks</button>
-    <p class="storage-note">Storage strategy: <strong>localStorage</strong> (persists across sessions)</p>
+    <p class="storage-note" data-testid="storage-strategy">Storage strategy: <strong>{{ storageStrategy }}</strong> ({{ storageDescription }})</p>
   </div>
 </template>
 

--- a/examples/vue-cameras/src/views/Login.vue
+++ b/examples/vue-cameras/src/views/Login.vue
@@ -12,6 +12,7 @@ function login() {
     <h2>Login</h2>
     <p>Click the button below to login with your Eagle Eye Networks account.</p>
     <button @click="login">Login with Eagle Eye Networks</button>
+    <p class="storage-note">Storage strategy: <strong>localStorage</strong> (persists across sessions)</p>
   </div>
 </template>
 
@@ -29,5 +30,11 @@ h2 {
 p {
   margin-bottom: 20px;
   color: #666;
+}
+
+.storage-note {
+  margin-top: 30px;
+  font-size: 0.85em;
+  color: #888;
 }
 </style>

--- a/examples/vue-feeds/src/views/Home.vue
+++ b/examples/vue-feeds/src/views/Home.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
-import { useAuthStore } from 'een-api-toolkit'
+import { useAuthStore, getStorageStrategy, STORAGE_STRATEGY_DESCRIPTIONS } from 'een-api-toolkit'
 
 const authStore = useAuthStore()
+
+const storageStrategy = getStorageStrategy()
+const storageDescription = STORAGE_STRATEGY_DESCRIPTIONS[storageStrategy]
 </script>
 
 <template>
@@ -39,6 +42,9 @@ const authStore = useAuthStore()
       <p class="feature-note">
         Click "View" on any feed with a multipart URL to see a live preview.
         The toolkit handles media session cookie initialization automatically.
+      </p>
+      <p class="storage-note" data-testid="storage-strategy">
+        Storage strategy: <strong>{{ storageStrategy }}</strong> ({{ storageDescription }})
       </p>
     </div>
   </div>
@@ -107,5 +113,13 @@ const authStore = useAuthStore()
   border-radius: 0 4px 4px 0;
   font-size: 14px;
   color: #2c3e50;
+}
+
+.storage-note {
+  margin-top: 20px;
+  padding-top: 15px;
+  border-top: 1px solid #ddd;
+  font-size: 0.85em;
+  color: #888;
 }
 </style>

--- a/examples/vue-feeds/src/views/Login.vue
+++ b/examples/vue-feeds/src/views/Login.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
-import { getAuthUrl } from 'een-api-toolkit'
+import { getAuthUrl, getStorageStrategy, STORAGE_STRATEGY_DESCRIPTIONS } from 'een-api-toolkit'
+
+const storageStrategy = getStorageStrategy()
+const storageDescription = STORAGE_STRATEGY_DESCRIPTIONS[storageStrategy]
 
 function login() {
   window.location.href = getAuthUrl()
@@ -11,7 +14,7 @@ function login() {
     <h2>Login</h2>
     <p>Click the button below to authenticate with Eagle Eye Networks.</p>
     <button @click="login">Login with Eagle Eye Networks</button>
-    <p class="storage-note">Storage strategy: <strong>localStorage</strong> (persists across sessions)</p>
+    <p class="storage-note" data-testid="storage-strategy">Storage strategy: <strong>{{ storageStrategy }}</strong> ({{ storageDescription }})</p>
   </div>
 </template>
 

--- a/examples/vue-feeds/src/views/Login.vue
+++ b/examples/vue-feeds/src/views/Login.vue
@@ -11,6 +11,7 @@ function login() {
     <h2>Login</h2>
     <p>Click the button below to authenticate with Eagle Eye Networks.</p>
     <button @click="login">Login with Eagle Eye Networks</button>
+    <p class="storage-note">Storage strategy: <strong>localStorage</strong> (persists across sessions)</p>
   </div>
 </template>
 
@@ -28,5 +29,11 @@ h2 {
 p {
   margin-bottom: 20px;
   color: #666;
+}
+
+.storage-note {
+  margin-top: 30px;
+  font-size: 0.85em;
+  color: #888;
 }
 </style>

--- a/examples/vue-feeds/src/views/Login.vue
+++ b/examples/vue-feeds/src/views/Login.vue
@@ -1,8 +1,5 @@
 <script setup lang="ts">
-import { getAuthUrl, getStorageStrategy, STORAGE_STRATEGY_DESCRIPTIONS } from 'een-api-toolkit'
-
-const storageStrategy = getStorageStrategy()
-const storageDescription = STORAGE_STRATEGY_DESCRIPTIONS[storageStrategy]
+import { getAuthUrl } from 'een-api-toolkit'
 
 function login() {
   window.location.href = getAuthUrl()
@@ -14,7 +11,6 @@ function login() {
     <h2>Login</h2>
     <p>Click the button below to authenticate with Eagle Eye Networks.</p>
     <button @click="login">Login with Eagle Eye Networks</button>
-    <p class="storage-note" data-testid="storage-strategy">Storage strategy: <strong>{{ storageStrategy }}</strong> ({{ storageDescription }})</p>
   </div>
 </template>
 
@@ -32,11 +28,5 @@ h2 {
 p {
   margin-bottom: 20px;
   color: #666;
-}
-
-.storage-note {
-  margin-top: 30px;
-  font-size: 0.85em;
-  color: #888;
 }
 </style>

--- a/examples/vue-media/src/views/Home.vue
+++ b/examples/vue-media/src/views/Home.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
-import { useAuthStore } from 'een-api-toolkit'
+import { useAuthStore, getStorageStrategy, STORAGE_STRATEGY_DESCRIPTIONS } from 'een-api-toolkit'
 
 const authStore = useAuthStore()
+
+const storageStrategy = getStorageStrategy()
+const storageDescription = STORAGE_STRATEGY_DESCRIPTIONS[storageStrategy]
 </script>
 
 <template>
@@ -38,6 +41,9 @@ const authStore = useAuthStore()
         <li><code>getLiveImage()</code> - Fetch live preview images</li>
         <li><code>getRecordedImage()</code> - Fetch recorded preview images</li>
       </ul>
+      <p class="storage-note" data-testid="storage-strategy">
+        Storage strategy: <strong>{{ storageStrategy }}</strong> ({{ storageDescription }})
+      </p>
     </div>
   </div>
 </template>
@@ -95,5 +101,13 @@ const authStore = useAuthStore()
   padding: 2px 6px;
   border-radius: 3px;
   font-family: monospace;
+}
+
+.storage-note {
+  margin-top: 20px;
+  padding-top: 15px;
+  border-top: 1px solid #ddd;
+  font-size: 0.85em;
+  color: #888;
 }
 </style>

--- a/examples/vue-media/src/views/Login.vue
+++ b/examples/vue-media/src/views/Login.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
-import { getAuthUrl } from 'een-api-toolkit'
+import { getAuthUrl, getStorageStrategy, STORAGE_STRATEGY_DESCRIPTIONS } from 'een-api-toolkit'
+
+const storageStrategy = getStorageStrategy()
+const storageDescription = STORAGE_STRATEGY_DESCRIPTIONS[storageStrategy]
 
 function login() {
   window.location.href = getAuthUrl()
@@ -11,7 +14,7 @@ function login() {
     <h2>Login</h2>
     <p>Click the button below to authenticate with Eagle Eye Networks.</p>
     <button @click="login">Login with Eagle Eye Networks</button>
-    <p class="storage-note">Storage strategy: <strong>sessionStorage</strong> (per-tab, cleared on tab close)</p>
+    <p class="storage-note" data-testid="storage-strategy">Storage strategy: <strong>{{ storageStrategy }}</strong> ({{ storageDescription }})</p>
   </div>
 </template>
 

--- a/examples/vue-media/src/views/Login.vue
+++ b/examples/vue-media/src/views/Login.vue
@@ -1,8 +1,5 @@
 <script setup lang="ts">
-import { getAuthUrl, getStorageStrategy, STORAGE_STRATEGY_DESCRIPTIONS } from 'een-api-toolkit'
-
-const storageStrategy = getStorageStrategy()
-const storageDescription = STORAGE_STRATEGY_DESCRIPTIONS[storageStrategy]
+import { getAuthUrl } from 'een-api-toolkit'
 
 function login() {
   window.location.href = getAuthUrl()
@@ -14,7 +11,6 @@ function login() {
     <h2>Login</h2>
     <p>Click the button below to authenticate with Eagle Eye Networks.</p>
     <button @click="login">Login with Eagle Eye Networks</button>
-    <p class="storage-note" data-testid="storage-strategy">Storage strategy: <strong>{{ storageStrategy }}</strong> ({{ storageDescription }})</p>
   </div>
 </template>
 
@@ -32,11 +28,5 @@ h2 {
 p {
   margin-bottom: 20px;
   color: #666;
-}
-
-.storage-note {
-  margin-top: 30px;
-  font-size: 0.85em;
-  color: #888;
 }
 </style>

--- a/examples/vue-media/src/views/Login.vue
+++ b/examples/vue-media/src/views/Login.vue
@@ -11,6 +11,7 @@ function login() {
     <h2>Login</h2>
     <p>Click the button below to authenticate with Eagle Eye Networks.</p>
     <button @click="login">Login with Eagle Eye Networks</button>
+    <p class="storage-note">Storage strategy: <strong>sessionStorage</strong> (per-tab, cleared on tab close)</p>
   </div>
 </template>
 
@@ -28,5 +29,11 @@ h2 {
 p {
   margin-bottom: 20px;
   color: #666;
+}
+
+.storage-note {
+  margin-top: 30px;
+  font-size: 0.85em;
+  color: #888;
 }
 </style>

--- a/examples/vue-users/package-lock.json
+++ b/examples/vue-users/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-api-toolkit-example",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit-example",
-      "version": "0.0.21",
+      "version": "0.0.22",
       "dependencies": {
         "een-api-toolkit": "file:../..",
         "pinia": "^3.0.4",

--- a/examples/vue-users/package-lock.json
+++ b/examples/vue-users/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-api-toolkit-example",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit-example",
-      "version": "0.0.20",
+      "version": "0.0.21",
       "dependencies": {
         "een-api-toolkit": "file:../..",
         "pinia": "^3.0.4",

--- a/examples/vue-users/package-lock.json
+++ b/examples/vue-users/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-api-toolkit-example",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit-example",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "dependencies": {
         "een-api-toolkit": "file:../..",
         "pinia": "^3.0.4",

--- a/examples/vue-users/package.json
+++ b/examples/vue-users/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit-example",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/vue-users/package.json
+++ b/examples/vue-users/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit-example",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/vue-users/package.json
+++ b/examples/vue-users/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit-example",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/vue-users/src/views/Home.vue
+++ b/examples/vue-users/src/views/Home.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
-import { useAuthStore, getCurrentUser, getAuthUrl, type UserProfile, type EenError } from 'een-api-toolkit'
+import { useAuthStore, getCurrentUser, getAuthUrl, getStorageStrategy, STORAGE_STRATEGY_DESCRIPTIONS, type UserProfile, type EenError } from 'een-api-toolkit'
 import { computed, ref, watch } from 'vue'
 
 const authStore = useAuthStore()
 const isAuthenticated = computed(() => authStore.isAuthenticated)
 const loginError = ref<string | null>(null)
+
+const storageStrategy = getStorageStrategy()
+const storageDescription = STORAGE_STRATEGY_DESCRIPTIONS[storageStrategy]
 
 function login() {
   try {
@@ -82,6 +85,26 @@ watch(
         </router-link>
       </div>
     </div>
+
+    <div class="description">
+      <h3>About This Example</h3>
+      <p>
+        This example demonstrates how to use the <code>getUsers</code>,
+        <code>getUser</code>, and <code>getCurrentUser</code> functions from
+        the EEN API Toolkit to display and manage users from the Eagle Eye
+        Networks platform.
+      </p>
+      <h4>Features</h4>
+      <ul>
+        <li>List users with pagination</li>
+        <li>View current user profile</li>
+        <li>View individual user details</li>
+        <li>OAuth authentication flow</li>
+      </ul>
+      <p class="storage-note" data-testid="storage-strategy">
+        Storage strategy: <strong>{{ storageStrategy }}</strong> ({{ storageDescription }})
+      </p>
+    </div>
   </div>
 </template>
 
@@ -116,5 +139,48 @@ h2 {
 
 .actions {
   margin-top: 20px;
+}
+
+.description {
+  margin-top: 40px;
+  padding: 20px;
+  background: #f8f9fa;
+  border-radius: 8px;
+  text-align: left;
+}
+
+.description h3 {
+  margin-bottom: 10px;
+}
+
+.description h4 {
+  margin-top: 15px;
+  margin-bottom: 10px;
+}
+
+.description p {
+  color: #666;
+  margin-bottom: 15px;
+}
+
+.description ul {
+  list-style: disc;
+  padding-left: 20px;
+  color: #666;
+}
+
+.description code {
+  background: #e9ecef;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 0.9em;
+}
+
+.storage-note {
+  margin-top: 20px;
+  padding-top: 15px;
+  border-top: 1px solid #ddd;
+  font-size: 0.85em;
+  color: #888;
 }
 </style>

--- a/examples/vue-users/src/views/Login.vue
+++ b/examples/vue-users/src/views/Login.vue
@@ -1,8 +1,5 @@
 <script setup lang="ts">
-import { getAuthUrl, getStorageStrategy, STORAGE_STRATEGY_DESCRIPTIONS } from 'een-api-toolkit'
-
-const storageStrategy = getStorageStrategy()
-const storageDescription = STORAGE_STRATEGY_DESCRIPTIONS[storageStrategy]
+import { getAuthUrl } from 'een-api-toolkit'
 
 function login() {
   // Redirect to EEN OAuth login
@@ -15,7 +12,6 @@ function login() {
     <h2 data-testid="login-title">Login</h2>
     <p>Click the button below to login with your Eagle Eye Networks account.</p>
     <button data-testid="login-button" @click="login">Login with Eagle Eye Networks</button>
-    <p class="storage-note" data-testid="storage-strategy">Storage strategy: <strong>{{ storageStrategy }}</strong> ({{ storageDescription }})</p>
   </div>
 </template>
 
@@ -33,11 +29,5 @@ h2 {
 p {
   margin-bottom: 20px;
   color: #666;
-}
-
-.storage-note {
-  margin-top: 30px;
-  font-size: 0.85em;
-  color: #888;
 }
 </style>

--- a/examples/vue-users/src/views/Login.vue
+++ b/examples/vue-users/src/views/Login.vue
@@ -12,6 +12,7 @@ function login() {
     <h2 data-testid="login-title">Login</h2>
     <p>Click the button below to login with your Eagle Eye Networks account.</p>
     <button data-testid="login-button" @click="login">Login with Eagle Eye Networks</button>
+    <p class="storage-note">Storage strategy: <strong>memory</strong> (tokens lost on page refresh)</p>
   </div>
 </template>
 
@@ -29,5 +30,11 @@ h2 {
 p {
   margin-bottom: 20px;
   color: #666;
+}
+
+.storage-note {
+  margin-top: 30px;
+  font-size: 0.85em;
+  color: #888;
 }
 </style>

--- a/examples/vue-users/src/views/Login.vue
+++ b/examples/vue-users/src/views/Login.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
-import { getAuthUrl } from 'een-api-toolkit'
+import { getAuthUrl, getStorageStrategy, STORAGE_STRATEGY_DESCRIPTIONS } from 'een-api-toolkit'
+
+const storageStrategy = getStorageStrategy()
+const storageDescription = STORAGE_STRATEGY_DESCRIPTIONS[storageStrategy]
 
 function login() {
   // Redirect to EEN OAuth login
@@ -12,7 +15,7 @@ function login() {
     <h2 data-testid="login-title">Login</h2>
     <p>Click the button below to login with your Eagle Eye Networks account.</p>
     <button data-testid="login-button" @click="login">Login with Eagle Eye Networks</button>
-    <p class="storage-note">Storage strategy: <strong>memory</strong> (tokens lost on page refresh)</p>
+    <p class="storage-note" data-testid="storage-strategy">Storage strategy: <strong>{{ storageStrategy }}</strong> ({{ storageDescription }})</p>
   </div>
 </template>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "license": "MIT",
       "devDependencies": {
         "@marp-team/marp-cli": "^4.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "license": "MIT",
       "devDependencies": {
         "@marp-team/marp-cli": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "EEN Video platform API v3.0 library for Vue 3",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "EEN Video platform API v3.0 library for Vue 3",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/scripts/generate-ai-context.ts
+++ b/scripts/generate-ai-context.ts
@@ -417,6 +417,25 @@ interface EenToolkitConfig {
 }
 \`\`\`
 
+### Storage Strategy Descriptions
+
+Human-readable descriptions for each storage strategy, useful for displaying in UI components:
+
+\`\`\`typescript
+import { getStorageStrategy, STORAGE_STRATEGY_DESCRIPTIONS } from 'een-api-toolkit'
+
+// STORAGE_STRATEGY_DESCRIPTIONS is a Record<StorageStrategy, string>:
+// {
+//   localStorage: 'persists across sessions',
+//   sessionStorage: 'per-tab, cleared on tab close',
+//   memory: 'tokens lost on page refresh'
+// }
+
+const strategy = getStorageStrategy()
+const description = STORAGE_STRATEGY_DESCRIPTIONS[strategy]
+console.log(\`Using \${strategy}: \${description}\`)
+\`\`\`
+
 ---
 
 `

--- a/src/__tests__/storage.test.ts
+++ b/src/__tests__/storage.test.ts
@@ -284,7 +284,7 @@ describe('Storage Strategy Security Properties', () => {
     ).not.toBe('abc123')
   })
 
-  it('memory storage data should be isolated per getStorageAdapter call', () => {
+  it('memory storage should act as a singleton across getStorageAdapter calls', () => {
     setStorageStrategy('memory')
 
     // All calls to getStorageAdapter should return the same singleton

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 import type { EenToolkitConfig, StorageStrategy } from './types'
-import { setStorageStrategy, getStorageStrategy } from './utils/storage'
+import { setStorageStrategy, getStorageStrategy, STORAGE_STRATEGY_DESCRIPTIONS } from './utils/storage'
 
 /**
  * Global toolkit configuration
@@ -47,7 +47,7 @@ export function initEenToolkit(options: EenToolkitConfig = {}): void {
   }
 }
 
-export { getStorageStrategy }
+export { getStorageStrategy, STORAGE_STRATEGY_DESCRIPTIONS }
 
 /**
  * Get the current configuration

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 // Configuration
-export { initEenToolkit, getConfig, getProxyUrl, getClientId, getRedirectUri, getStorageStrategy } from './config'
+export { initEenToolkit, getConfig, getProxyUrl, getClientId, getRedirectUri, getStorageStrategy, STORAGE_STRATEGY_DESCRIPTIONS } from './config'
 
 // Types
 export type {

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -6,6 +6,27 @@ import { debug } from './debug'
 export type { StorageStrategy }
 
 /**
+ * Human-readable descriptions for each storage strategy.
+ * Useful for displaying storage information in UI components.
+ *
+ * @example
+ * ```typescript
+ * import { getStorageStrategy, STORAGE_STRATEGY_DESCRIPTIONS } from 'een-api-toolkit'
+ *
+ * const strategy = getStorageStrategy()
+ * const description = STORAGE_STRATEGY_DESCRIPTIONS[strategy]
+ * console.log(`Using ${strategy}: ${description}`)
+ * ```
+ *
+ * @category Configuration
+ */
+export const STORAGE_STRATEGY_DESCRIPTIONS: Record<StorageStrategy, string> = {
+  localStorage: 'persists across sessions',
+  sessionStorage: 'per-tab, cleared on tab close',
+  memory: 'tokens lost on page refresh'
+}
+
+/**
  * Storage adapter interface for token persistence.
  * @internal
  */

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,5 +1,6 @@
 // Import StorageStrategy from types to maintain single source of truth
 import type { StorageStrategy } from '../types'
+import { debug } from './debug'
 
 // Re-export for convenience
 export type { StorageStrategy }
@@ -113,6 +114,7 @@ export function getStorageAdapter(): StorageAdapter {
         return new BrowserStorageAdapter(sessionStorage)
       }
       // Fallback to memory if sessionStorage not available
+      debug('sessionStorage unavailable, falling back to memory storage')
       return getMemoryStorage()
     case 'localStorage':
     default:
@@ -120,6 +122,7 @@ export function getStorageAdapter(): StorageAdapter {
         return new BrowserStorageAdapter(localStorage)
       }
       // Fallback to memory if localStorage not available
+      debug('localStorage unavailable, falling back to memory storage')
       return getMemoryStorage()
   }
 }


### PR DESCRIPTION
## Summary

- Add debug logging when localStorage/sessionStorage is unavailable, falling back to memory storage (closes #48)
- Fix misleading test name in storage.test.ts (closes #49)
- Add storage strategy note to all example login pages

## Changes

### Storage fallback logging
When storage is unavailable (SSR, private browsing, etc.), debug messages now inform developers:
- `sessionStorage unavailable, falling back to memory storage`
- `localStorage unavailable, falling back to memory storage`

### Example login pages
Each example now displays its storage strategy on the login page:
| Example | Strategy | Description |
|---------|----------|-------------|
| vue-bridges | localStorage | persists across sessions |
| vue-cameras | localStorage | persists across sessions |
| vue-feeds | localStorage | persists across sessions |
| vue-media | sessionStorage | per-tab, cleared on tab close |
| vue-users | memory | tokens lost on page refresh |

## Commits
- 137efa6 feat: Add debug logging for storage fallback and display storage strategy on login pages

## Test Results
- Lint: Passed (1 pre-existing warning)
- Unit tests: 188/188 passed
- Build: Success

## Version
`0.3.9`

---
Generated with [Claude Code](https://claude.ai/code)