### PR TITLE
Release v0.3.20: Add media buttons to event modal lightboxes

### DIFF
--- a/examples/vue-event-subscriptions/package-lock.json
+++ b/examples/vue-event-subscriptions/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "een-api-toolkit": "file:../..",
+        "hls.js": "^1.6.15",
         "pinia": "^3.0.4",
         "vue": "^3.4.0",
         "vue-router": "^4.2.0"
@@ -23,7 +24,7 @@
       }
     },
     "../..": {
-      "version": "0.3.16",
+      "version": "0.3.20",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.39.2",
@@ -1275,6 +1276,12 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/hls.js": {
+      "version": "1.6.15",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.15.tgz",
+      "integrity": "sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA==",
+      "license": "Apache-2.0"
     },
     "node_modules/hookable": {
       "version": "5.5.3",

--- a/examples/vue-event-subscriptions/package.json
+++ b/examples/vue-event-subscriptions/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "een-api-toolkit": "file:../..",
+    "hls.js": "^1.6.15",
     "pinia": "^3.0.4",
     "vue": "^3.4.0",
     "vue-router": "^4.2.0"

--- a/examples/vue-event-subscriptions/src/App.vue
+++ b/examples/vue-event-subscriptions/src/App.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useAuthStore } from 'een-api-toolkit'
-import { computed, ref, onMounted, onUnmounted } from 'vue'
+import { computed } from 'vue'
 import { useRouter } from 'vue-router'
 
 const authStore = useAuthStore()
@@ -10,33 +10,6 @@ const isAuthenticated = computed(() => authStore.isAuthenticated)
 const refreshFailed = computed(() => authStore.refreshFailed)
 const refreshFailedMessage = computed(() => authStore.refreshFailedMessage)
 const isRefreshing = computed(() => authStore.isRefreshing)
-
-// Reactive tick to force re-computation of tokenExpiresIn
-const tick = ref(0)
-let tickInterval: ReturnType<typeof setInterval> | null = null
-
-const tokenExpiresIn = computed(() => {
-  // Reference tick to trigger reactivity
-  void tick.value
-  const ms = authStore.tokenExpiresIn
-  if (!ms) return null
-  const minutes = Math.floor(ms / 60000)
-  const seconds = Math.floor((ms % 60000) / 1000)
-  return `${minutes}m ${seconds}s`
-})
-
-onMounted(() => {
-  // Update every 10 seconds
-  tickInterval = setInterval(() => {
-    tick.value++
-  }, 10000)
-})
-
-onUnmounted(() => {
-  if (tickInterval) {
-    clearInterval(tickInterval)
-  }
-})
 
 function dismissRefreshError() {
   authStore.clearRefreshFailed()
@@ -70,9 +43,6 @@ function handleRelogin() {
         <router-link data-testid="nav-live" v-if="isAuthenticated" to="/live">Live Events</router-link>
         <router-link data-testid="nav-login" v-if="!isAuthenticated" to="/login">Login</router-link>
         <router-link data-testid="nav-logout" v-if="isAuthenticated" to="/logout">Logout</router-link>
-        <span v-if="isAuthenticated && tokenExpiresIn" class="token-info" title="Token expires in">
-          {{ tokenExpiresIn }}
-        </span>
       </nav>
     </header>
     <main>
@@ -219,15 +189,5 @@ button.secondary:hover {
 button.small {
   padding: 6px 12px;
   font-size: 12px;
-}
-
-/* Token expiry indicator */
-.token-info {
-  font-size: 12px;
-  color: #888;
-  padding: 4px 8px;
-  background: #f5f5f5;
-  border-radius: 4px;
-  font-family: monospace;
 }
 </style>

--- a/examples/vue-event-subscriptions/src/composables/useHlsPlayer.ts
+++ b/examples/vue-event-subscriptions/src/composables/useHlsPlayer.ts
@@ -1,0 +1,285 @@
+import { ref, nextTick, onUnmounted, type Ref } from 'vue'
+import { listMedia, initMediaSession, formatTimestamp, useAuthStore } from 'een-api-toolkit'
+import Hls from 'hls.js'
+
+// Constants
+const SEARCH_WINDOW_MS = 60 * 60 * 1000 // 1 hour before/after target timestamp
+const MAX_MEDIA_PAGE_SIZE = 100 // Limit results for performance
+const MAX_NETWORK_RETRIES = 3 // Maximum retry attempts for network errors
+
+// Debug utility - logs only when VITE_DEBUG=true
+const isDebug = import.meta.env?.VITE_DEBUG === 'true'
+function debugError(...args: unknown[]): void {
+  if (isDebug) {
+    console.error('[useHlsPlayer]', ...args)
+  }
+}
+
+// Cache media session to avoid redundant initialization calls
+let mediaSessionInitialized = false
+let mediaSessionPromise: Promise<boolean> | null = null
+
+/** Return type for the useHlsPlayer composable */
+export interface HlsPlayerReturn {
+  videoUrl: Ref<string | null>
+  videoError: Ref<string | null>
+  loadingVideo: Ref<boolean>
+  videoRef: Ref<HTMLVideoElement | null>
+  loadVideo: (deviceId: string, timestamp: string) => Promise<void>
+  resetVideo: () => void
+  destroyHls: () => void
+}
+
+/**
+ * Composable for HLS video playback from EEN recordings.
+ * Handles media session initialization, interval search, and HLS.js setup.
+ */
+export function useHlsPlayer(): HlsPlayerReturn {
+  const authStore = useAuthStore()
+
+  // State
+  const videoUrl = ref<string | null>(null)
+  const videoError = ref<string | null>(null)
+  const loadingVideo = ref(false)
+  const videoRef = ref<HTMLVideoElement | null>(null)
+
+  let hlsInstance: Hls | null = null
+  let networkRetryCount = 0
+
+  /**
+   * Initialize media session with caching.
+   * Only calls the API once per session, subsequent calls return cached result.
+   */
+  async function ensureMediaSession(): Promise<boolean> {
+    // Return cached result if already initialized
+    if (mediaSessionInitialized) {
+      return true
+    }
+
+    // If initialization is in progress, wait for it
+    if (mediaSessionPromise) {
+      return mediaSessionPromise
+    }
+
+    // Start new initialization
+    mediaSessionPromise = (async () => {
+      const result = await initMediaSession()
+      if (result.error) {
+        videoError.value = `Media session error: ${result.error.message}`
+        mediaSessionPromise = null
+        return false
+      }
+      mediaSessionInitialized = true
+      return true
+    })()
+
+    return mediaSessionPromise
+  }
+
+  /**
+   * Destroy the HLS instance and clean up resources.
+   */
+  function destroyHls() {
+    if (hlsInstance) {
+      hlsInstance.destroy()
+      hlsInstance = null
+    }
+  }
+
+  /**
+   * Initialize HLS.js with proper authentication and error handling.
+   */
+  function initHls() {
+    if (!videoUrl.value || !videoRef.value) return
+
+    destroyHls()
+
+    // Always use hls.js even on Safari - native HLS cannot send Authorization headers
+    if (!Hls.isSupported()) {
+      videoError.value = 'HLS is not supported in this browser. Please use a modern browser like Chrome, Firefox, or Edge.'
+      return
+    }
+
+    // Configure hls.js to send Authorization header for authentication
+    hlsInstance = new Hls({
+      xhrSetup: function(xhr) {
+        xhr.setRequestHeader('Authorization', `Bearer ${authStore.token}`)
+      }
+    })
+
+    hlsInstance.loadSource(videoUrl.value)
+    hlsInstance.attachMedia(videoRef.value)
+
+    hlsInstance.on(Hls.Events.MANIFEST_PARSED, () => {
+      videoRef.value?.play().catch(() => {
+        // Autoplay may be blocked, user can manually play
+      })
+    })
+
+    // Reset retry counter on successful load
+    networkRetryCount = 0
+
+    // Enhanced error handling for different error types
+    hlsInstance.on(Hls.Events.ERROR, (_, data) => {
+      debugError('HLS error:', data)
+
+      if (data.fatal) {
+        switch (data.type) {
+          case Hls.ErrorTypes.NETWORK_ERROR:
+            // Network error - could be auth issue or connectivity
+            if (data.response?.code === 401) {
+              videoError.value = 'Authentication expired. Please refresh the page and try again.'
+              // Don't retry on auth errors - requires user action
+              destroyHls()
+            } else if (data.response?.code === 403) {
+              videoError.value = 'Access denied to video stream.'
+              // Don't retry on permission errors
+              destroyHls()
+            } else {
+              // Retry other network errors with limit
+              networkRetryCount++
+              if (networkRetryCount <= MAX_NETWORK_RETRIES) {
+                videoError.value = `Network error loading video: ${data.details}. Retry ${networkRetryCount}/${MAX_NETWORK_RETRIES}...`
+                hlsInstance?.startLoad()
+              } else {
+                videoError.value = `Network error loading video: ${data.details}. Max retries (${MAX_NETWORK_RETRIES}) exceeded.`
+                destroyHls()
+              }
+            }
+            break
+
+          case Hls.ErrorTypes.MEDIA_ERROR:
+            // Media error - try to recover
+            videoError.value = `Media error: ${data.details}. Attempting recovery...`
+            hlsInstance?.recoverMediaError()
+            break
+
+          default:
+            // Other fatal errors
+            videoError.value = `HLS error: ${data.type} - ${data.details}`
+            destroyHls()
+        }
+      }
+    })
+  }
+
+  /**
+   * Load and play HLS video for a given device and timestamp.
+   *
+   * @param deviceId - The camera device ID
+   * @param timestamp - ISO timestamp string (the target time to find video for)
+   * @returns Promise that resolves when video is ready or error occurs
+   */
+  async function loadVideo(deviceId: string, timestamp: string): Promise<void> {
+    loadingVideo.value = true
+    videoError.value = null
+    videoUrl.value = null
+
+    // Initialize media session (cached after first call)
+    const sessionOk = await ensureMediaSession()
+    if (!sessionOk) {
+      loadingVideo.value = false
+      return
+    }
+
+    // Search for recordings around the target timestamp
+    const targetTime = new Date(timestamp)
+    const searchStartTime = new Date(targetTime.getTime() - SEARCH_WINDOW_MS)
+    const searchEndTime = new Date(targetTime.getTime() + SEARCH_WINDOW_MS)
+
+    // Use 'main' type for video - HLS is typically only available for main feeds
+    const result = await listMedia({
+      deviceId: deviceId,
+      type: 'main',
+      mediaType: 'video',
+      startTimestamp: formatTimestamp(searchStartTime.toISOString()),
+      endTimestamp: formatTimestamp(searchEndTime.toISOString()),
+      include: ['hlsUrl'],
+      pageSize: MAX_MEDIA_PAGE_SIZE
+    })
+
+    if (result.error) {
+      videoError.value = result.error.message
+      loadingVideo.value = false
+      return
+    }
+
+    const intervals = result.data?.results ?? []
+
+    // Validate target timestamp
+    const targetTimeMs = targetTime.getTime()
+    if (isNaN(targetTimeMs)) {
+      videoError.value = `Invalid timestamp format: ${timestamp}`
+      loadingVideo.value = false
+      return
+    }
+
+    // Find an interval that contains the target timestamp and has an HLS URL
+    const interval = intervals.find(i => {
+      if (!i.hlsUrl) return false
+      const intervalStart = new Date(i.startTimestamp).getTime()
+      const intervalEnd = new Date(i.endTimestamp).getTime()
+      // Skip intervals with invalid timestamps
+      if (isNaN(intervalStart) || isNaN(intervalEnd)) return false
+      return targetTimeMs >= intervalStart && targetTimeMs <= intervalEnd
+    })
+
+    if (!interval?.hlsUrl) {
+      // Provide detailed error message
+      if (intervals.length === 0) {
+        videoError.value = 'No recordings found for this time range'
+      } else if (!intervals.some(i => i.hlsUrl)) {
+        videoError.value = 'Recordings found but HLS not available'
+      } else {
+        videoError.value = `No recording contains timestamp ${timestamp}`
+      }
+      loadingVideo.value = false
+      return
+    }
+
+    // Set the HLS URL
+    videoUrl.value = interval.hlsUrl
+    loadingVideo.value = false
+
+    // Initialize HLS.js after the DOM has been updated
+    await nextTick()
+    initHls()
+  }
+
+  /**
+   * Reset all video state.
+   */
+  function resetVideo() {
+    destroyHls()
+    videoUrl.value = null
+    videoError.value = null
+    loadingVideo.value = false
+  }
+
+  // Cleanup on unmount
+  onUnmounted(() => {
+    destroyHls()
+  })
+
+  return {
+    // State
+    videoUrl,
+    videoError,
+    loadingVideo,
+    videoRef,
+
+    // Methods
+    loadVideo,
+    resetVideo,
+    destroyHls
+  }
+}
+
+/**
+ * Reset the media session cache.
+ * Call this when the user logs out or the session expires.
+ */
+export function resetMediaSessionCache() {
+  mediaSessionInitialized = false
+  mediaSessionPromise = null
+}

--- a/examples/vue-event-subscriptions/src/composables/useHlsPlayer.ts
+++ b/examples/vue-event-subscriptions/src/composables/useHlsPlayer.ts
@@ -15,9 +15,11 @@ function debugError(...args: unknown[]): void {
   }
 }
 
-// Cache media session to avoid redundant initialization calls
+// Cache media session state to avoid redundant initialization calls
+// Module-level state is shared across all component instances intentionally
 let mediaSessionInitialized = false
 let mediaSessionPromise: Promise<boolean> | null = null
+let mediaSessionError: string | null = null
 
 /** Return type for the useHlsPlayer composable */
 export interface HlsPlayerReturn {
@@ -49,6 +51,7 @@ export function useHlsPlayer(): HlsPlayerReturn {
   /**
    * Initialize media session with caching.
    * Only calls the API once per session, subsequent calls return cached result.
+   * Uses module-level state so all component instances share the same session status.
    */
   async function ensureMediaSession(): Promise<boolean> {
     // Return cached result if already initialized
@@ -56,16 +59,28 @@ export function useHlsPlayer(): HlsPlayerReturn {
       return true
     }
 
+    // If previous initialization failed, return cached error
+    if (mediaSessionError) {
+      videoError.value = mediaSessionError
+      return false
+    }
+
     // If initialization is in progress, wait for it
     if (mediaSessionPromise) {
-      return mediaSessionPromise
+      const result = await mediaSessionPromise
+      // Copy any cached error to this component's state
+      if (!result && mediaSessionError) {
+        videoError.value = mediaSessionError
+      }
+      return result
     }
 
     // Start new initialization
     mediaSessionPromise = (async () => {
       const result = await initMediaSession()
       if (result.error) {
-        videoError.value = `Media session error: ${result.error.message}`
+        mediaSessionError = `Media session error: ${result.error.message}`
+        videoError.value = mediaSessionError
         mediaSessionPromise = null
         return false
       }
@@ -111,13 +126,12 @@ export function useHlsPlayer(): HlsPlayerReturn {
     hlsInstance.attachMedia(videoRef.value)
 
     hlsInstance.on(Hls.Events.MANIFEST_PARSED, () => {
+      // Reset retry counter on successful manifest parse
+      networkRetryCount = 0
       videoRef.value?.play().catch(() => {
         // Autoplay may be blocked, user can manually play
       })
     })
-
-    // Reset retry counter on successful load
-    networkRetryCount = 0
 
     // Enhanced error handling for different error types
     hlsInstance.on(Hls.Events.ERROR, (_, data) => {
@@ -174,6 +188,7 @@ export function useHlsPlayer(): HlsPlayerReturn {
     loadingVideo.value = true
     videoError.value = null
     videoUrl.value = null
+    networkRetryCount = 0 // Reset retry counter for new video load
 
     // Initialize media session (cached after first call)
     const sessionOk = await ensureMediaSession()
@@ -189,7 +204,7 @@ export function useHlsPlayer(): HlsPlayerReturn {
 
     // Use 'main' type for video - HLS is typically only available for main feeds
     const result = await listMedia({
-      deviceId: deviceId,
+      deviceId,
       type: 'main',
       mediaType: 'video',
       startTimestamp: formatTimestamp(searchStartTime.toISOString()),
@@ -277,9 +292,15 @@ export function useHlsPlayer(): HlsPlayerReturn {
 
 /**
  * Reset the media session cache.
- * Call this when the user logs out or the session expires.
+ * Call this when the user logs out or the session expires to ensure
+ * a fresh media session is initialized on next use.
+ *
+ * @remarks
+ * This clears the module-level cached state shared by all component instances.
+ * Should be called during logout to prevent stale session data.
  */
-export function resetMediaSessionCache() {
+export function resetMediaSessionCache(): void {
   mediaSessionInitialized = false
   mediaSessionPromise = null
+  mediaSessionError = null
 }

--- a/examples/vue-event-subscriptions/src/composables/useHlsPlayer.ts
+++ b/examples/vue-event-subscriptions/src/composables/useHlsPlayer.ts
@@ -1,6 +1,7 @@
 import { ref, nextTick, onUnmounted, type Ref } from 'vue'
-import { listMedia, initMediaSession, formatTimestamp, useAuthStore } from 'een-api-toolkit'
+import { listMedia, formatTimestamp, useAuthStore } from 'een-api-toolkit'
 import Hls from 'hls.js'
+import { useMediaSessionStore } from '../stores/mediaSession'
 
 // Constants
 const SEARCH_WINDOW_MS = 60 * 60 * 1000 // 1 hour before/after target timestamp
@@ -14,12 +15,6 @@ function debugError(...args: unknown[]): void {
     console.error('[useHlsPlayer]', ...args)
   }
 }
-
-// Cache media session state to avoid redundant initialization calls
-// Module-level state is shared across all component instances intentionally
-let mediaSessionInitialized = false
-let mediaSessionPromise: Promise<boolean> | null = null
-let mediaSessionError: string | null = null
 
 /** Return type for the useHlsPlayer composable */
 export interface HlsPlayerReturn {
@@ -35,9 +30,12 @@ export interface HlsPlayerReturn {
 /**
  * Composable for HLS video playback from EEN recordings.
  * Handles media session initialization, interval search, and HLS.js setup.
+ * Uses Pinia store for media session state to ensure consistent behavior
+ * across all component instances.
  */
 export function useHlsPlayer(): HlsPlayerReturn {
   const authStore = useAuthStore()
+  const mediaSessionStore = useMediaSessionStore()
 
   // State
   const videoUrl = ref<string | null>(null)
@@ -49,46 +47,15 @@ export function useHlsPlayer(): HlsPlayerReturn {
   let networkRetryCount = 0
 
   /**
-   * Initialize media session with caching.
+   * Initialize media session with caching via Pinia store.
    * Only calls the API once per session, subsequent calls return cached result.
-   * Uses module-level state so all component instances share the same session status.
    */
   async function ensureMediaSession(): Promise<boolean> {
-    // Return cached result if already initialized
-    if (mediaSessionInitialized) {
-      return true
+    const success = await mediaSessionStore.ensureInitialized()
+    if (!success && mediaSessionStore.error) {
+      videoError.value = mediaSessionStore.error
     }
-
-    // If previous initialization failed, return cached error
-    if (mediaSessionError) {
-      videoError.value = mediaSessionError
-      return false
-    }
-
-    // If initialization is in progress, wait for it
-    if (mediaSessionPromise) {
-      const result = await mediaSessionPromise
-      // Copy any cached error to this component's state
-      if (!result && mediaSessionError) {
-        videoError.value = mediaSessionError
-      }
-      return result
-    }
-
-    // Start new initialization
-    mediaSessionPromise = (async () => {
-      const result = await initMediaSession()
-      if (result.error) {
-        mediaSessionError = `Media session error: ${result.error.message}`
-        videoError.value = mediaSessionError
-        mediaSessionPromise = null
-        return false
-      }
-      mediaSessionInitialized = true
-      return true
-    })()
-
-    return mediaSessionPromise
+    return success
   }
 
   /**
@@ -296,11 +263,10 @@ export function useHlsPlayer(): HlsPlayerReturn {
  * a fresh media session is initialized on next use.
  *
  * @remarks
- * This clears the module-level cached state shared by all component instances.
- * Should be called during logout to prevent stale session data.
+ * This delegates to the Pinia media session store's reset method.
+ * Must be called from within a Vue component context or after Pinia is installed.
  */
 export function resetMediaSessionCache(): void {
-  mediaSessionInitialized = false
-  mediaSessionPromise = null
-  mediaSessionError = null
+  const mediaSessionStore = useMediaSessionStore()
+  mediaSessionStore.reset()
 }

--- a/examples/vue-event-subscriptions/src/main.ts
+++ b/examples/vue-event-subscriptions/src/main.ts
@@ -9,13 +9,13 @@ const app = createApp(App)
 // Install Pinia (required before initEenToolkit)
 app.use(createPinia())
 
-// Initialize EEN API Toolkit with memory storage for maximum security
-// Note: Using 'memory' storage means tokens are lost on page refresh
+// Initialize EEN API Toolkit with sessionStorage
+// Note: Using 'sessionStorage' means tokens persist within the browser tab session
 initEenToolkit({
   proxyUrl: import.meta.env.VITE_PROXY_URL,
   clientId: import.meta.env.VITE_EEN_CLIENT_ID,
   redirectUri: import.meta.env.VITE_REDIRECT_URI,
-  storageStrategy: 'memory',
+  storageStrategy: 'sessionStorage',
   debug: import.meta.env.VITE_DEBUG === 'true'
 })
 

--- a/examples/vue-event-subscriptions/src/stores/connection.ts
+++ b/examples/vue-event-subscriptions/src/stores/connection.ts
@@ -14,7 +14,6 @@ export const useConnectionStore = defineStore('connection', () => {
   const connectionStatus = ref<SSEConnectionStatus>('disconnected')
   const connectionError = ref<EenError | null>(null)
   const connectedSubscriptionId = ref<string | null>(null)
-  const connectedSseUrl = ref<string | null>(null)
 
   // Events state
   const events = ref<SSEEvent[]>([])
@@ -36,7 +35,6 @@ export const useConnectionStore = defineStore('connection', () => {
     connectionError.value = null
     events.value = []
     connectedSubscriptionId.value = subscriptionId
-    connectedSseUrl.value = sseUrl
 
     const result = connectToEventSubscription(sseUrl, {
       onEvent: (event) => {
@@ -57,10 +55,17 @@ export const useConnectionStore = defineStore('connection', () => {
     if (result.error) {
       connectionError.value = result.error
       connectedSubscriptionId.value = null
-      connectedSseUrl.value = null
     } else {
       connection.value = result.data
     }
+  }
+
+  /**
+   * Set a connection error.
+   * Use this action instead of directly mutating connectionError.
+   */
+  function setConnectionError(error: EenError) {
+    connectionError.value = error
   }
 
   function disconnect() {
@@ -70,7 +75,6 @@ export const useConnectionStore = defineStore('connection', () => {
     }
     connectionStatus.value = 'disconnected'
     connectedSubscriptionId.value = null
-    connectedSseUrl.value = null
   }
 
   function clearEvents() {
@@ -83,7 +87,6 @@ export const useConnectionStore = defineStore('connection', () => {
     connectionStatus,
     connectionError,
     connectedSubscriptionId,
-    connectedSseUrl,
     events,
     maxEvents,
     // Computed
@@ -92,6 +95,7 @@ export const useConnectionStore = defineStore('connection', () => {
     // Actions
     connect,
     disconnect,
-    clearEvents
+    clearEvents,
+    setConnectionError
   }
 })

--- a/examples/vue-event-subscriptions/src/stores/connection.ts
+++ b/examples/vue-event-subscriptions/src/stores/connection.ts
@@ -1,0 +1,97 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import {
+  connectToEventSubscription,
+  type SSEConnection,
+  type SSEConnectionStatus,
+  type SSEEvent,
+  type EenError
+} from 'een-api-toolkit'
+
+export const useConnectionStore = defineStore('connection', () => {
+  // Connection state
+  const connection = ref<SSEConnection | null>(null)
+  const connectionStatus = ref<SSEConnectionStatus>('disconnected')
+  const connectionError = ref<EenError | null>(null)
+  const connectedSubscriptionId = ref<string | null>(null)
+  const connectedSseUrl = ref<string | null>(null)
+
+  // Events state
+  const events = ref<SSEEvent[]>([])
+  const maxEvents = 100
+
+  // Computed
+  const isConnected = computed(() => connectionStatus.value === 'connected')
+  const isConnecting = computed(() => connectionStatus.value === 'connecting')
+
+  function connect(subscriptionId: string, sseUrl: string) {
+    // If already connected to same subscription, do nothing
+    if (connection.value && connectedSubscriptionId.value === subscriptionId) {
+      return
+    }
+
+    // Disconnect any existing connection
+    disconnect()
+
+    connectionError.value = null
+    events.value = []
+    connectedSubscriptionId.value = subscriptionId
+    connectedSseUrl.value = sseUrl
+
+    const result = connectToEventSubscription(sseUrl, {
+      onEvent: (event) => {
+        // Add new event at the beginning, limit to maxEvents
+        events.value.unshift(event)
+        if (events.value.length > maxEvents) {
+          events.value.pop()
+        }
+      },
+      onError: (error) => {
+        connectionError.value = { code: 'NETWORK_ERROR', message: error.message }
+      },
+      onStatusChange: (status) => {
+        connectionStatus.value = status
+      }
+    })
+
+    if (result.error) {
+      connectionError.value = result.error
+      connectedSubscriptionId.value = null
+      connectedSseUrl.value = null
+    } else {
+      connection.value = result.data
+    }
+  }
+
+  function disconnect() {
+    if (connection.value) {
+      connection.value.close()
+      connection.value = null
+    }
+    connectionStatus.value = 'disconnected'
+    connectedSubscriptionId.value = null
+    connectedSseUrl.value = null
+  }
+
+  function clearEvents() {
+    events.value = []
+  }
+
+  return {
+    // State
+    connection,
+    connectionStatus,
+    connectionError,
+    connectedSubscriptionId,
+    connectedSseUrl,
+    events,
+    maxEvents,
+    // Computed
+    isConnected,
+    isConnecting,
+    // Actions
+    connect,
+    disconnect,
+    clearEvents
+  }
+})

--- a/examples/vue-event-subscriptions/src/stores/mediaSession.ts
+++ b/examples/vue-event-subscriptions/src/stores/mediaSession.ts
@@ -1,0 +1,79 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { initMediaSession } from 'een-api-toolkit'
+
+/**
+ * Pinia store for managing media session state.
+ * Centralizes media session initialization to avoid redundant API calls
+ * and ensures consistent state across all components using HLS playback.
+ */
+export const useMediaSessionStore = defineStore('mediaSession', () => {
+  // State
+  const initialized = ref(false)
+  const error = ref<string | null>(null)
+  const initPromise = ref<Promise<boolean> | null>(null)
+
+  // Computed
+  const isReady = computed(() => initialized.value && !error.value)
+  const hasError = computed(() => error.value !== null)
+
+  /**
+   * Initialize the media session.
+   * Only calls the API once per session, subsequent calls return cached result.
+   * Safe to call from multiple components simultaneously.
+   *
+   * @returns Promise that resolves to true if session is ready, false if failed
+   */
+  async function ensureInitialized(): Promise<boolean> {
+    // Return cached result if already initialized
+    if (initialized.value) {
+      return true
+    }
+
+    // If previous initialization failed, return cached error state
+    if (error.value) {
+      return false
+    }
+
+    // If initialization is in progress, wait for it
+    if (initPromise.value) {
+      return initPromise.value
+    }
+
+    // Start new initialization
+    initPromise.value = (async () => {
+      const result = await initMediaSession()
+      if (result.error) {
+        error.value = `Media session error: ${result.error.message}`
+        initPromise.value = null
+        return false
+      }
+      initialized.value = true
+      return true
+    })()
+
+    return initPromise.value
+  }
+
+  /**
+   * Reset the media session state.
+   * Call this when the user logs out or the session expires.
+   */
+  function reset() {
+    initialized.value = false
+    error.value = null
+    initPromise.value = null
+  }
+
+  return {
+    // State (read-only access)
+    initialized,
+    error,
+    // Computed
+    isReady,
+    hasError,
+    // Actions
+    ensureInitialized,
+    reset
+  }
+})

--- a/examples/vue-event-subscriptions/src/views/LiveEvents.vue
+++ b/examples/vue-event-subscriptions/src/views/LiveEvents.vue
@@ -1,35 +1,37 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import {
   listEventSubscriptions,
-  connectToEventSubscription,
+  getRecordedImage,
   type EventSubscription,
-  type SSEConnection,
-  type SSEConnectionStatus,
-  type SSEEvent,
-  type EenError
+  type SSEEvent
 } from 'een-api-toolkit'
+import { useConnectionStore } from '../stores/connection'
+import { useHlsPlayer } from '../composables/useHlsPlayer'
 
 const route = useRoute()
+const connectionStore = useConnectionStore()
+
+// Initialize HLS player composable
+const hlsPlayer = useHlsPlayer()
+const { videoUrl, videoError, loadingVideo, loadVideo, resetVideo } = hlsPlayer
 
 // Subscriptions state
 const subscriptions = ref<EventSubscription[]>([])
 const selectedSubscriptionId = ref<string | null>(null)
 const loadingSubscriptions = ref(false)
 
-// Connection state
-const connection = ref<SSEConnection | null>(null)
-const connectionStatus = ref<SSEConnectionStatus>('disconnected')
-const connectionError = ref<EenError | null>(null)
-
-// Events state
-const events = ref<SSEEvent[]>([])
-const maxEvents = 100
-
 // Modal state
 const selectedEvent = ref<SSEEvent | null>(null)
 const showModal = ref(false)
+
+// Lightbox state
+const showLightbox = ref(false)
+const lightboxImageUrl = ref<string | null>(null)
+const loadingImage = ref(false)
+const imageError = ref<string | null>(null)
+const showVideo = ref(false)
 
 const selectedSubscription = computed(() => {
   return subscriptions.value.find(s => s.id === selectedSubscriptionId.value)
@@ -41,8 +43,13 @@ const canConnect = computed(() => {
   return !!selectedSubscription.value.deliveryConfig.sseUrl
 })
 
-const isConnected = computed(() => connectionStatus.value === 'connected')
-const isConnecting = computed(() => connectionStatus.value === 'connecting')
+// Use store computed values
+const isConnected = computed(() => connectionStore.isConnected)
+const isConnecting = computed(() => connectionStore.isConnecting)
+const connectionStatus = computed(() => connectionStore.connectionStatus)
+const connectionError = computed(() => connectionStore.connectionError)
+const events = computed(() => connectionStore.events)
+const maxEvents = connectionStore.maxEvents
 
 async function loadSubscriptions() {
   loadingSubscriptions.value = true
@@ -58,51 +65,52 @@ async function loadSubscriptions() {
   loadingSubscriptions.value = false
 }
 
-function connect() {
+async function connect() {
   if (!canConnect.value || !selectedSubscription.value) return
 
-  const sseUrl = selectedSubscription.value.deliveryConfig.type === 'serverSentEvents.v1'
-    ? selectedSubscription.value.deliveryConfig.sseUrl
-    : undefined
+  const subscriptionId = selectedSubscription.value.id
 
-  if (!sseUrl) return
+  // Reload all subscriptions to get fresh SSE URLs
+  // SSE URLs become invalid after disconnecting
+  await loadSubscriptions()
 
-  connectionError.value = null
-  events.value = []
-
-  const result = connectToEventSubscription(sseUrl, {
-    onEvent: (event) => {
-      // Add new event at the beginning, limit to maxEvents
-      // Using unshift + pop is more efficient than spread operator for large arrays
-      events.value.unshift(event)
-      if (events.value.length > maxEvents) {
-        events.value.pop()
-      }
-    },
-    onError: (error) => {
-      connectionError.value = { code: 'NETWORK_ERROR', message: error.message }
-    },
-    onStatusChange: (status) => {
-      connectionStatus.value = status
-    }
-  })
-
-  if (result.error) {
-    connectionError.value = result.error
-  } else {
-    connection.value = result.data
+  // Find the subscription in the refreshed list
+  const freshSubscription = subscriptions.value.find(s => s.id === subscriptionId)
+  if (!freshSubscription) {
+    connectionStore.connectionError = { code: 'NOT_FOUND', message: 'Subscription no longer exists' }
+    return
   }
+
+  if (freshSubscription.deliveryConfig.type !== 'serverSentEvents.v1') {
+    connectionStore.connectionError = { code: 'VALIDATION_ERROR', message: 'Subscription is not an SSE type' }
+    return
+  }
+
+  const sseUrl = freshSubscription.deliveryConfig.sseUrl
+  if (!sseUrl) {
+    connectionStore.connectionError = { code: 'VALIDATION_ERROR', message: 'No SSE URL available' }
+    return
+  }
+
+  connectionStore.connect(subscriptionId, sseUrl)
 }
 
 function disconnect() {
-  if (connection.value) {
-    connection.value.close()
-    connection.value = null
+  // Get the subscription ID before disconnecting
+  const disconnectedId = connectionStore.connectedSubscriptionId
+
+  connectionStore.disconnect()
+
+  // Remove the subscription from the list since SSE URLs are single-use
+  // and cannot be reconnected
+  if (disconnectedId) {
+    subscriptions.value = subscriptions.value.filter(s => s.id !== disconnectedId)
+    selectedSubscriptionId.value = null
   }
 }
 
 function clearEvents() {
-  events.value = []
+  connectionStore.clearEvents()
 }
 
 function formatTimestamp(timestamp: string): string {
@@ -138,8 +146,12 @@ function closeModal() {
 }
 
 function handleKeyDown(e: KeyboardEvent) {
-  if (e.key === 'Escape' && showModal.value) {
-    closeModal()
+  if (e.key === 'Escape') {
+    if (showLightbox.value) {
+      closeLightbox()
+    } else if (showModal.value) {
+      closeModal()
+    }
   }
 }
 
@@ -149,28 +161,128 @@ function handleModalBackdropClick(e: MouseEvent) {
   }
 }
 
+// Extract the image URL from event data
+function getEventImageUrl(event: SSEEvent): string | null {
+  if (!event.data) return null
+  const fullFrameData = event.data.find(d => d.type === 'een.fullFrameImageUrl.v1')
+  if (fullFrameData && typeof fullFrameData.httpsUrl === 'string') {
+    return fullFrameData.httpsUrl
+  }
+  return null
+}
+
+// Check if event has media URLs
+function hasMediaUrls(event: SSEEvent): boolean {
+  return getEventImageUrl(event) !== null
+}
+
+// Parse the image URL to extract parameters for getRecordedImage
+function parseImageUrlParams(url: string): { deviceId: string; type: 'preview' | 'main'; timestamp: string } | null {
+  try {
+    const urlObj = new URL(url)
+    const deviceId = urlObj.searchParams.get('deviceId')
+    const type = urlObj.searchParams.get('type') as 'preview' | 'main'
+    const timestamp = urlObj.searchParams.get('timestamp__gte')
+
+    if (deviceId && type && timestamp) {
+      return { deviceId, type, timestamp }
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+// Handle image click (preview or HD)
+async function handleImageClick(quality: 'preview' | 'main' = 'preview') {
+  if (!selectedEvent.value) return
+
+  const imageUrl = getEventImageUrl(selectedEvent.value)
+  if (!imageUrl) return
+
+  loadingImage.value = true
+  imageError.value = null
+  lightboxImageUrl.value = null
+  showLightbox.value = true
+  showVideo.value = false
+
+  // Parse the URL to extract parameters
+  const params = parseImageUrlParams(imageUrl)
+  if (!params) {
+    imageError.value = 'Invalid image URL format'
+    loadingImage.value = false
+    return
+  }
+
+  // Use the toolkit's getRecordedImage function
+  const result = await getRecordedImage({
+    deviceId: params.deviceId,
+    type: quality,
+    timestamp__gte: params.timestamp
+  })
+
+  if (result.error) {
+    imageError.value = result.error.message
+  } else if (result.data?.imageData) {
+    lightboxImageUrl.value = result.data.imageData
+  } else {
+    imageError.value = 'No image data returned'
+  }
+
+  loadingImage.value = false
+}
+
+// Handle video click
+async function handleVideoClick() {
+  if (!selectedEvent.value) return
+
+  const imageUrl = getEventImageUrl(selectedEvent.value)
+  if (!imageUrl) return
+
+  // Parse the URL to extract parameters
+  const params = parseImageUrlParams(imageUrl)
+  if (!params) {
+    return
+  }
+
+  showVideo.value = true
+  showLightbox.value = true
+
+  // Use the composable to load and play video
+  await loadVideo(params.deviceId, params.timestamp)
+}
+
+// Close lightbox
+function closeLightbox() {
+  showLightbox.value = false
+  lightboxImageUrl.value = null
+  imageError.value = null
+  // Cleanup video if it was playing
+  resetVideo()
+  showVideo.value = false
+}
+
 // Load subscriptions on mount
 onMounted(async () => {
   await loadSubscriptions()
 
-  // Check for subscriptionId in query params
-  const queryId = route.query.subscriptionId as string | undefined
-  if (queryId) {
-    selectedSubscriptionId.value = queryId
+  // If already connected, set the selected subscription to match
+  if (connectionStore.connectedSubscriptionId) {
+    selectedSubscriptionId.value = connectionStore.connectedSubscriptionId
+  } else {
+    // Check for subscriptionId in query params
+    const queryId = route.query.subscriptionId as string | undefined
+    if (queryId) {
+      selectedSubscriptionId.value = queryId
+    }
   }
 })
 
-// Clean up connection on unmount
-onUnmounted(() => {
-  disconnect()
-})
-
-// Auto-disconnect when changing subscription
-watch(selectedSubscriptionId, () => {
-  if (connection.value) {
+// Auto-disconnect when changing subscription (but not if selecting the already connected one)
+watch(selectedSubscriptionId, (newId) => {
+  if (newId && newId !== connectionStore.connectedSubscriptionId && connectionStore.isConnected) {
     disconnect()
   }
-  events.value = []
 })
 </script>
 
@@ -283,6 +395,12 @@ watch(selectedSubscriptionId, () => {
         <li>Maximum {{ maxEvents }} events are displayed (oldest removed first)</li>
         <li>Click on an event card to view detailed information</li>
       </ul>
+      <h4>Important</h4>
+      <ul class="warning-list">
+        <li>SSE URLs are single-use. Once disconnected, the subscription cannot be reconnected.</li>
+        <li>To receive events again after disconnecting, create a new subscription.</li>
+        <li>Subscriptions have a 15-minute TTL and expire if not connected.</li>
+      </ul>
     </div>
 
     <!-- Event Details Modal -->
@@ -297,7 +415,30 @@ watch(selectedSubscriptionId, () => {
       <div class="modal-content" role="document">
         <div class="modal-header">
           <h3 id="modal-title">{{ formatEventType(selectedEvent.type) }}</h3>
-          <button class="modal-close" @click="closeModal" aria-label="Close modal">&times;</button>
+          <div class="modal-header-buttons">
+            <button
+              v-if="hasMediaUrls(selectedEvent)"
+              class="image-button"
+              @click="handleImageClick('preview')"
+            >
+              Preview
+            </button>
+            <button
+              v-if="hasMediaUrls(selectedEvent)"
+              class="image-button image-button-hd"
+              @click="handleImageClick('main')"
+            >
+              HD Image
+            </button>
+            <button
+              v-if="hasMediaUrls(selectedEvent)"
+              class="image-button image-button-video"
+              @click="handleVideoClick"
+            >
+              Video
+            </button>
+            <button class="close-button" @click="closeModal" aria-label="Close modal">&times;</button>
+          </div>
         </div>
         <div class="modal-body">
           <div class="modal-section">
@@ -338,6 +479,39 @@ watch(selectedSubscriptionId, () => {
             <p class="no-data-text">No additional data available for this event.</p>
           </div>
         </div>
+      </div>
+
+    </div>
+
+    <!-- Image/Video Lightbox -->
+    <div v-if="showLightbox" class="lightbox-overlay" @click.self="closeLightbox">
+      <div class="lightbox-content">
+        <button class="lightbox-close" @click="closeLightbox">&times;</button>
+        <!-- Video mode -->
+        <template v-if="showVideo">
+          <div v-if="loadingVideo" class="lightbox-loading">Loading video...</div>
+          <div v-else-if="videoError" class="lightbox-error">{{ videoError }}</div>
+          <video
+            v-else-if="videoUrl"
+            :ref="(el) => hlsPlayer.videoRef.value = el as HTMLVideoElement | null"
+            class="lightbox-video"
+            controls
+            autoplay
+            muted
+            playsinline
+          />
+        </template>
+        <!-- Image mode -->
+        <template v-else>
+          <div v-if="loadingImage" class="lightbox-loading">Loading image...</div>
+          <div v-else-if="imageError" class="lightbox-error">{{ imageError }}</div>
+          <img
+            v-else-if="lightboxImageUrl"
+            :src="lightboxImageUrl"
+            alt="Event image"
+            class="lightbox-image"
+          />
+        </template>
       </div>
     </div>
   </div>
@@ -498,8 +672,8 @@ h2 {
   position: fixed;
   top: 0;
   left: 0;
-  width: 100%;
-  height: 100%;
+  right: 0;
+  bottom: 0;
   background: rgba(0, 0, 0, 0.5);
   display: flex;
   align-items: center;
@@ -509,49 +683,77 @@ h2 {
 
 .modal-content {
   background: white;
-  border-radius: 12px;
-  width: 90%;
-  max-width: 600px;
+  border-radius: 8px;
+  width: 80%;
   max-height: 80vh;
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
 }
 
 .modal-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 20px;
-  border-bottom: 1px solid #e2e3e5;
-  background: #f8f9fa;
+  padding: 16px 20px;
+  border-bottom: 1px solid #eee;
 }
 
 .modal-header h3 {
   margin: 0;
-  color: #42b883;
+  font-size: 1.1rem;
+  color: #333;
 }
 
-.modal-close {
+.modal-header-buttons {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.image-button {
+  padding: 6px 14px;
+  background: #42b883;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.image-button:hover {
+  background: #3aa876;
+}
+
+.image-button-hd {
+  background: #3b82f6;
+}
+
+.image-button-hd:hover {
+  background: #2563eb;
+}
+
+.image-button-video {
+  background: #9b59b6;
+}
+
+.image-button-video:hover {
+  background: #8e44ad;
+}
+
+.close-button {
   background: none;
   border: none;
-  font-size: 28px;
+  font-size: 1.5rem;
   cursor: pointer;
   color: #666;
   padding: 0;
   line-height: 1;
-  width: 36px;
-  height: 36px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 50%;
-  transition: background-color 0.15s ease;
 }
 
-.modal-close:hover {
-  background: #e2e3e5;
+.close-button:hover {
   color: #333;
 }
 
@@ -636,5 +838,83 @@ h2 {
 
 .help-section li {
   margin-bottom: 5px;
+}
+
+.help-section .warning-list {
+  color: #856404;
+  background: #fff3cd;
+  padding: 10px 10px 10px 30px;
+  border-radius: 4px;
+  margin-top: 10px;
+}
+
+.help-section .warning-list li {
+  margin-bottom: 4px;
+}
+
+/* Lightbox styles */
+.lightbox-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1100;
+}
+
+.lightbox-content {
+  position: relative;
+  max-width: 90vw;
+  max-height: 90vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.lightbox-close {
+  position: absolute;
+  top: -40px;
+  right: 0;
+  background: none;
+  border: none;
+  color: white;
+  font-size: 2rem;
+  cursor: pointer;
+  padding: 5px 10px;
+  line-height: 1;
+}
+
+.lightbox-close:hover {
+  color: #ccc;
+}
+
+.lightbox-image {
+  max-width: 90vw;
+  max-height: 90vh;
+  object-fit: contain;
+  border-radius: 4px;
+}
+
+.lightbox-video {
+  max-width: 90vw;
+  max-height: 90vh;
+  width: 100%;
+  background: #000;
+  border-radius: 4px;
+}
+
+.lightbox-loading,
+.lightbox-error {
+  color: white;
+  font-size: 1.1rem;
+  padding: 40px;
+}
+
+.lightbox-error {
+  color: #ff6b6b;
 }
 </style>

--- a/examples/vue-event-subscriptions/src/views/LiveEvents.vue
+++ b/examples/vue-event-subscriptions/src/views/LiveEvents.vue
@@ -77,18 +77,18 @@ async function connect() {
   // Find the subscription in the refreshed list
   const freshSubscription = subscriptions.value.find(s => s.id === subscriptionId)
   if (!freshSubscription) {
-    connectionStore.connectionError = { code: 'NOT_FOUND', message: 'Subscription no longer exists' }
+    connectionStore.setConnectionError({ code: 'NOT_FOUND', message: 'Subscription no longer exists' })
     return
   }
 
   if (freshSubscription.deliveryConfig.type !== 'serverSentEvents.v1') {
-    connectionStore.connectionError = { code: 'VALIDATION_ERROR', message: 'Subscription is not an SSE type' }
+    connectionStore.setConnectionError({ code: 'VALIDATION_ERROR', message: 'Subscription is not an SSE type' })
     return
   }
 
   const sseUrl = freshSubscription.deliveryConfig.sseUrl
   if (!sseUrl) {
-    connectionStore.connectionError = { code: 'VALIDATION_ERROR', message: 'No SSE URL available' }
+    connectionStore.setConnectionError({ code: 'VALIDATION_ERROR', message: 'No SSE URL available' })
     return
   }
 

--- a/examples/vue-event-subscriptions/src/views/Logout.vue
+++ b/examples/vue-event-subscriptions/src/views/Logout.vue
@@ -2,12 +2,18 @@
 import { onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { revokeToken } from 'een-api-toolkit'
+import { useConnectionStore } from '../stores/connection'
 
 const router = useRouter()
+const connectionStore = useConnectionStore()
 const processing = ref(true)
 const error = ref<string | null>(null)
 
 onMounted(async () => {
+  // Close any active SSE connection and clear events
+  connectionStore.disconnect()
+  connectionStore.clearEvents()
+
   const result = await revokeToken()
 
   if (result.error) {

--- a/examples/vue-event-subscriptions/src/views/Subscriptions.vue
+++ b/examples/vue-event-subscriptions/src/views/Subscriptions.vue
@@ -172,13 +172,6 @@ function getDeliveryType(sub: EventSubscription): string {
   return sub.deliveryConfig.type
 }
 
-function getSseUrl(sub: EventSubscription): string | undefined {
-  if (sub.deliveryConfig.type === 'serverSentEvents.v1') {
-    return sub.deliveryConfig.sseUrl
-  }
-  return undefined
-}
-
 onMounted(async () => {
   await Promise.all([
     fetchSubscriptions(),
@@ -267,12 +260,6 @@ onMounted(async () => {
               <td>{{ sub.subscriptionConfig?.lifeCycle || '-' }}</td>
               <td>{{ sub.subscriptionConfig?.timeToLiveSeconds ? `${sub.subscriptionConfig.timeToLiveSeconds}s` : '-' }}</td>
               <td class="actions">
-                <router-link
-                  v-if="getSseUrl(sub)"
-                  :to="{ path: '/live', query: { subscriptionId: sub.id } }"
-                >
-                  <button class="secondary small">Listen</button>
-                </router-link>
                 <button
                   class="danger small"
                   @click="handleDelete(sub.id)"

--- a/examples/vue-events/package-lock.json
+++ b/examples/vue-events/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "een-api-toolkit": "file:../..",
+        "hls.js": "^1.6.15",
         "pinia": "^3.0.4",
         "vue": "^3.4.0",
         "vue-router": "^4.2.0"
@@ -23,7 +24,7 @@
       }
     },
     "../..": {
-      "version": "0.3.11",
+      "version": "0.3.20",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.39.2",
@@ -1275,6 +1276,12 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/hls.js": {
+      "version": "1.6.15",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.15.tgz",
+      "integrity": "sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA==",
+      "license": "Apache-2.0"
     },
     "node_modules/hookable": {
       "version": "5.5.3",

--- a/examples/vue-events/package.json
+++ b/examples/vue-events/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "een-api-toolkit": "file:../..",
+    "hls.js": "^1.6.15",
     "pinia": "^3.0.4",
     "vue": "^3.4.0",
     "vue-router": "^4.2.0"

--- a/examples/vue-events/src/components/EventsModal.vue
+++ b/examples/vue-events/src/components/EventsModal.vue
@@ -10,6 +10,11 @@ import {
   type EventType,
   type EenError
 } from 'een-api-toolkit'
+import { useHlsPlayer } from '../composables/useHlsPlayer'
+
+// Initialize HLS player composable
+const hlsPlayer = useHlsPlayer()
+const { videoUrl, videoError, loadingVideo, loadVideo, resetVideo } = hlsPlayer
 
 /**
  * Bounding box from object detection data.
@@ -81,6 +86,13 @@ const eventImages = ref<Map<string, string>>(new Map())
 const imageLoadingIds = ref<Set<string>>(new Set()) // Track which images are currently loading
 const boundingBoxCache = ref<Map<string, BoundingBox[]>>(new Map()) // Cache bounding boxes per event
 const enlargedEventId = ref<string | null>(null)
+
+// Lightbox media state
+const showVideo = ref(false)
+const hdImageUrl = ref<string | null>(null)
+const loadingHdImage = ref(false)
+const hdImageError = ref<string | null>(null)
+const currentMediaType = ref<'preview' | 'hd' | 'video'>('preview')
 
 // Computed
 const hasNextPage = computed(() => !!nextPageToken.value)
@@ -382,11 +394,68 @@ function toggleAllEventTypes() {
 // Open enlarged image view
 function openEnlargedImage(eventId: string) {
   enlargedEventId.value = eventId
+  currentMediaType.value = 'preview'
+  showVideo.value = false
+  hdImageUrl.value = null
+  hdImageError.value = null
+  resetVideo()
 }
 
 // Close enlarged image view
 function closeEnlargedImage() {
   enlargedEventId.value = null
+  showVideo.value = false
+  hdImageUrl.value = null
+  hdImageError.value = null
+  currentMediaType.value = 'preview'
+  resetVideo()
+}
+
+// Switch to preview mode
+function showPreview() {
+  currentMediaType.value = 'preview'
+  showVideo.value = false
+  resetVideo()
+}
+
+// Load and show HD image
+async function showHdImage() {
+  if (!enlargedEvent.value) return
+
+  currentMediaType.value = 'hd'
+  showVideo.value = false
+  loadingHdImage.value = true
+  hdImageError.value = null
+  hdImageUrl.value = null
+  resetVideo()
+
+  const result = await getRecordedImage({
+    deviceId: enlargedEvent.value.actorId,
+    type: 'main',
+    timestamp__gte: enlargedEvent.value.startTimestamp
+  })
+
+  if (result.error) {
+    hdImageError.value = result.error.message
+  } else if (result.data?.imageData) {
+    hdImageUrl.value = result.data.imageData
+  } else {
+    hdImageError.value = 'No image data returned'
+  }
+
+  loadingHdImage.value = false
+}
+
+// Load and show video
+async function showVideoPlayer() {
+  if (!enlargedEvent.value) return
+
+  currentMediaType.value = 'video'
+  showVideo.value = true
+  hdImageUrl.value = null
+  hdImageError.value = null
+
+  await loadVideo(enlargedEvent.value.actorId, enlargedEvent.value.startTimestamp)
 }
 
 // Handle keyboard events for accessibility
@@ -546,56 +615,147 @@ watch([timeRange, selectedEventTypes], () => {
 
       <!-- Enlarged image lightbox -->
       <div
-        v-if="enlargedEventId && enlargedImage"
+        v-if="enlargedEventId && (enlargedImage || showVideo)"
         class="lightbox-overlay"
         @click.self="closeEnlargedImage"
         data-testid="lightbox-overlay"
       >
         <div class="lightbox-content">
-          <button
-            class="lightbox-close"
-            @click="closeEnlargedImage"
-            aria-label="Close enlarged image"
-            data-testid="lightbox-close"
-          >&times;</button>
-          <div class="lightbox-image-container">
-            <img :src="enlargedImage" :alt="enlargedEvent?.type || 'Event image'" class="lightbox-image" />
-            <!-- Bounding box overlay -->
-            <svg
-              v-if="enlargedBoundingBoxes.length > 0"
-              class="bounding-box-overlay"
-              viewBox="0 0 100 100"
-              preserveAspectRatio="none"
-              data-testid="bounding-box-overlay"
-            >
-              <rect
-                v-for="(box, index) in enlargedBoundingBoxes"
-                :key="index"
-                :x="box.x * NORMALIZED_TO_PERCENT"
-                :y="box.y * NORMALIZED_TO_PERCENT"
-                :width="box.width * NORMALIZED_TO_PERCENT"
-                :height="box.height * NORMALIZED_TO_PERCENT"
-                class="bounding-box"
-                data-testid="bounding-box"
-              />
-            </svg>
-            <!-- Bounding box labels -->
-            <div
-              v-for="(box, index) in enlargedBoundingBoxes"
-              :key="'label-' + index"
-              class="bounding-box-label"
-              :style="{
-                left: (box.x * NORMALIZED_TO_PERCENT) + '%',
-                top: (box.y * NORMALIZED_TO_PERCENT) + '%'
-              }"
-              data-testid="bounding-box-label"
-            >
-              {{ box.label || 'Object' }}
-              <span v-if="box.confidence" class="confidence">
-                {{ Math.round(box.confidence * 100) }}%
-              </span>
+          <!-- Header with buttons -->
+          <div class="lightbox-header">
+            <div class="lightbox-buttons">
+              <button
+                class="media-button"
+                :class="{ active: currentMediaType === 'preview' }"
+                @click="showPreview"
+              >
+                Preview
+              </button>
+              <button
+                class="media-button media-button-hd"
+                :class="{ active: currentMediaType === 'hd' }"
+                @click="showHdImage"
+              >
+                HD Image
+              </button>
+              <button
+                class="media-button media-button-video"
+                :class="{ active: currentMediaType === 'video' }"
+                @click="showVideoPlayer"
+              >
+                Video
+              </button>
             </div>
+            <button
+              class="lightbox-close"
+              @click="closeEnlargedImage"
+              aria-label="Close enlarged image"
+              data-testid="lightbox-close"
+            >&times;</button>
           </div>
+
+          <!-- Video mode -->
+          <template v-if="showVideo">
+            <div v-if="loadingVideo" class="lightbox-loading">Loading video...</div>
+            <div v-else-if="videoError" class="lightbox-error">{{ videoError }}</div>
+            <video
+              v-else-if="videoUrl"
+              :ref="(el) => hlsPlayer.videoRef.value = el as HTMLVideoElement | null"
+              class="lightbox-video"
+              controls
+              autoplay
+              muted
+              playsinline
+            />
+          </template>
+
+          <!-- HD Image mode -->
+          <template v-else-if="currentMediaType === 'hd'">
+            <div v-if="loadingHdImage" class="lightbox-loading">Loading HD image...</div>
+            <div v-else-if="hdImageError" class="lightbox-error">{{ hdImageError }}</div>
+            <div v-else-if="hdImageUrl" class="lightbox-image-container">
+              <img :src="hdImageUrl" :alt="enlargedEvent?.type || 'Event image'" class="lightbox-image" />
+              <!-- Bounding box overlay for HD -->
+              <svg
+                v-if="enlargedBoundingBoxes.length > 0"
+                class="bounding-box-overlay"
+                viewBox="0 0 100 100"
+                preserveAspectRatio="none"
+                data-testid="bounding-box-overlay"
+              >
+                <rect
+                  v-for="(box, index) in enlargedBoundingBoxes"
+                  :key="index"
+                  :x="box.x * NORMALIZED_TO_PERCENT"
+                  :y="box.y * NORMALIZED_TO_PERCENT"
+                  :width="box.width * NORMALIZED_TO_PERCENT"
+                  :height="box.height * NORMALIZED_TO_PERCENT"
+                  class="bounding-box"
+                  data-testid="bounding-box"
+                />
+              </svg>
+              <!-- Bounding box labels for HD -->
+              <div
+                v-for="(box, index) in enlargedBoundingBoxes"
+                :key="'label-' + index"
+                class="bounding-box-label"
+                :style="{
+                  left: (box.x * NORMALIZED_TO_PERCENT) + '%',
+                  top: (box.y * NORMALIZED_TO_PERCENT) + '%'
+                }"
+                data-testid="bounding-box-label"
+              >
+                {{ box.label || 'Object' }}
+                <span v-if="box.confidence" class="confidence">
+                  {{ Math.round(box.confidence * 100) }}%
+                </span>
+              </div>
+            </div>
+          </template>
+
+          <!-- Preview mode (default) -->
+          <template v-else>
+            <div v-if="!enlargedImage" class="lightbox-loading">Loading preview...</div>
+            <div v-else class="lightbox-image-container">
+              <img :src="enlargedImage" :alt="enlargedEvent?.type || 'Event image'" class="lightbox-image" />
+              <!-- Bounding box overlay -->
+              <svg
+                v-if="enlargedBoundingBoxes.length > 0"
+                class="bounding-box-overlay"
+                viewBox="0 0 100 100"
+                preserveAspectRatio="none"
+                data-testid="bounding-box-overlay"
+              >
+                <rect
+                  v-for="(box, index) in enlargedBoundingBoxes"
+                  :key="index"
+                  :x="box.x * NORMALIZED_TO_PERCENT"
+                  :y="box.y * NORMALIZED_TO_PERCENT"
+                  :width="box.width * NORMALIZED_TO_PERCENT"
+                  :height="box.height * NORMALIZED_TO_PERCENT"
+                  class="bounding-box"
+                  data-testid="bounding-box"
+                />
+              </svg>
+              <!-- Bounding box labels -->
+              <div
+                v-for="(box, index) in enlargedBoundingBoxes"
+                :key="'label-' + index"
+                class="bounding-box-label"
+                :style="{
+                  left: (box.x * NORMALIZED_TO_PERCENT) + '%',
+                  top: (box.y * NORMALIZED_TO_PERCENT) + '%'
+                }"
+                data-testid="bounding-box-label"
+              >
+                {{ box.label || 'Object' }}
+                <span v-if="box.confidence" class="confidence">
+                  {{ Math.round(box.confidence * 100) }}%
+                </span>
+              </div>
+            </div>
+          </template>
+
           <div v-if="enlargedEvent" class="lightbox-info">
             <div class="lightbox-event-line">
               <span class="lightbox-camera-info">{{ camera.name }} ({{ camera.id }})</span>
@@ -887,10 +1047,50 @@ watch([timeRange, selectedEventTypes], () => {
   align-items: center;
 }
 
+.lightbox-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  margin-bottom: 15px;
+}
+
+.lightbox-buttons {
+  display: flex;
+  gap: 10px;
+}
+
+.media-button {
+  padding: 8px 16px;
+  background: #42b883;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 500;
+  opacity: 0.7;
+  transition: opacity 0.2s, background 0.2s;
+}
+
+.media-button:hover {
+  opacity: 1;
+}
+
+.media-button.active {
+  opacity: 1;
+  box-shadow: 0 0 0 2px white;
+}
+
+.media-button-hd {
+  background: #3b82f6;
+}
+
+.media-button-video {
+  background: #9b59b6;
+}
+
 .lightbox-close {
-  position: absolute;
-  top: -40px;
-  right: -10px;
   background: none;
   border: none;
   color: white;
@@ -898,11 +1098,33 @@ watch([timeRange, selectedEventTypes], () => {
   cursor: pointer;
   padding: 5px 10px;
   line-height: 1;
-  z-index: 2001;
 }
 
 .lightbox-close:hover {
   color: #ccc;
+}
+
+.lightbox-loading,
+.lightbox-error {
+  color: white;
+  font-size: 1.1rem;
+  padding: 40px;
+  min-height: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.lightbox-error {
+  color: #ff6b6b;
+}
+
+.lightbox-video {
+  max-width: 90vw;
+  max-height: 70vh;
+  width: 100%;
+  background: #000;
+  border-radius: 4px;
 }
 
 .lightbox-info {

--- a/examples/vue-events/src/composables/useHlsPlayer.ts
+++ b/examples/vue-events/src/composables/useHlsPlayer.ts
@@ -1,0 +1,285 @@
+import { ref, nextTick, onUnmounted, type Ref } from 'vue'
+import { listMedia, initMediaSession, formatTimestamp, useAuthStore } from 'een-api-toolkit'
+import Hls from 'hls.js'
+
+// Constants
+const SEARCH_WINDOW_MS = 60 * 60 * 1000 // 1 hour before/after target timestamp
+const MAX_MEDIA_PAGE_SIZE = 100 // Limit results for performance
+const MAX_NETWORK_RETRIES = 3 // Maximum retry attempts for network errors
+
+// Debug utility - logs only when VITE_DEBUG=true
+const isDebug = import.meta.env?.VITE_DEBUG === 'true'
+function debugError(...args: unknown[]): void {
+  if (isDebug) {
+    console.error('[useHlsPlayer]', ...args)
+  }
+}
+
+// Cache media session to avoid redundant initialization calls
+let mediaSessionInitialized = false
+let mediaSessionPromise: Promise<boolean> | null = null
+
+/** Return type for the useHlsPlayer composable */
+export interface HlsPlayerReturn {
+  videoUrl: Ref<string | null>
+  videoError: Ref<string | null>
+  loadingVideo: Ref<boolean>
+  videoRef: Ref<HTMLVideoElement | null>
+  loadVideo: (deviceId: string, timestamp: string) => Promise<void>
+  resetVideo: () => void
+  destroyHls: () => void
+}
+
+/**
+ * Composable for HLS video playback from EEN recordings.
+ * Handles media session initialization, interval search, and HLS.js setup.
+ */
+export function useHlsPlayer(): HlsPlayerReturn {
+  const authStore = useAuthStore()
+
+  // State
+  const videoUrl = ref<string | null>(null)
+  const videoError = ref<string | null>(null)
+  const loadingVideo = ref(false)
+  const videoRef = ref<HTMLVideoElement | null>(null)
+
+  let hlsInstance: Hls | null = null
+  let networkRetryCount = 0
+
+  /**
+   * Initialize media session with caching.
+   * Only calls the API once per session, subsequent calls return cached result.
+   */
+  async function ensureMediaSession(): Promise<boolean> {
+    // Return cached result if already initialized
+    if (mediaSessionInitialized) {
+      return true
+    }
+
+    // If initialization is in progress, wait for it
+    if (mediaSessionPromise) {
+      return mediaSessionPromise
+    }
+
+    // Start new initialization
+    mediaSessionPromise = (async () => {
+      const result = await initMediaSession()
+      if (result.error) {
+        videoError.value = `Media session error: ${result.error.message}`
+        mediaSessionPromise = null
+        return false
+      }
+      mediaSessionInitialized = true
+      return true
+    })()
+
+    return mediaSessionPromise
+  }
+
+  /**
+   * Destroy the HLS instance and clean up resources.
+   */
+  function destroyHls() {
+    if (hlsInstance) {
+      hlsInstance.destroy()
+      hlsInstance = null
+    }
+  }
+
+  /**
+   * Initialize HLS.js with proper authentication and error handling.
+   */
+  function initHls() {
+    if (!videoUrl.value || !videoRef.value) return
+
+    destroyHls()
+
+    // Always use hls.js even on Safari - native HLS cannot send Authorization headers
+    if (!Hls.isSupported()) {
+      videoError.value = 'HLS is not supported in this browser. Please use a modern browser like Chrome, Firefox, or Edge.'
+      return
+    }
+
+    // Configure hls.js to send Authorization header for authentication
+    hlsInstance = new Hls({
+      xhrSetup: function(xhr) {
+        xhr.setRequestHeader('Authorization', `Bearer ${authStore.token}`)
+      }
+    })
+
+    hlsInstance.loadSource(videoUrl.value)
+    hlsInstance.attachMedia(videoRef.value)
+
+    hlsInstance.on(Hls.Events.MANIFEST_PARSED, () => {
+      videoRef.value?.play().catch(() => {
+        // Autoplay may be blocked, user can manually play
+      })
+    })
+
+    // Reset retry counter on successful load
+    networkRetryCount = 0
+
+    // Enhanced error handling for different error types
+    hlsInstance.on(Hls.Events.ERROR, (_, data) => {
+      debugError('HLS error:', data)
+
+      if (data.fatal) {
+        switch (data.type) {
+          case Hls.ErrorTypes.NETWORK_ERROR:
+            // Network error - could be auth issue or connectivity
+            if (data.response?.code === 401) {
+              videoError.value = 'Authentication expired. Please refresh the page and try again.'
+              // Don't retry on auth errors - requires user action
+              destroyHls()
+            } else if (data.response?.code === 403) {
+              videoError.value = 'Access denied to video stream.'
+              // Don't retry on permission errors
+              destroyHls()
+            } else {
+              // Retry other network errors with limit
+              networkRetryCount++
+              if (networkRetryCount <= MAX_NETWORK_RETRIES) {
+                videoError.value = `Network error loading video: ${data.details}. Retry ${networkRetryCount}/${MAX_NETWORK_RETRIES}...`
+                hlsInstance?.startLoad()
+              } else {
+                videoError.value = `Network error loading video: ${data.details}. Max retries (${MAX_NETWORK_RETRIES}) exceeded.`
+                destroyHls()
+              }
+            }
+            break
+
+          case Hls.ErrorTypes.MEDIA_ERROR:
+            // Media error - try to recover
+            videoError.value = `Media error: ${data.details}. Attempting recovery...`
+            hlsInstance?.recoverMediaError()
+            break
+
+          default:
+            // Other fatal errors
+            videoError.value = `HLS error: ${data.type} - ${data.details}`
+            destroyHls()
+        }
+      }
+    })
+  }
+
+  /**
+   * Load and play HLS video for a given device and timestamp.
+   *
+   * @param deviceId - The camera device ID
+   * @param timestamp - ISO timestamp string (the target time to find video for)
+   * @returns Promise that resolves when video is ready or error occurs
+   */
+  async function loadVideo(deviceId: string, timestamp: string): Promise<void> {
+    loadingVideo.value = true
+    videoError.value = null
+    videoUrl.value = null
+
+    // Initialize media session (cached after first call)
+    const sessionOk = await ensureMediaSession()
+    if (!sessionOk) {
+      loadingVideo.value = false
+      return
+    }
+
+    // Search for recordings around the target timestamp
+    const targetTime = new Date(timestamp)
+    const searchStartTime = new Date(targetTime.getTime() - SEARCH_WINDOW_MS)
+    const searchEndTime = new Date(targetTime.getTime() + SEARCH_WINDOW_MS)
+
+    // Use 'main' type for video - HLS is typically only available for main feeds
+    const result = await listMedia({
+      deviceId: deviceId,
+      type: 'main',
+      mediaType: 'video',
+      startTimestamp: formatTimestamp(searchStartTime.toISOString()),
+      endTimestamp: formatTimestamp(searchEndTime.toISOString()),
+      include: ['hlsUrl'],
+      pageSize: MAX_MEDIA_PAGE_SIZE
+    })
+
+    if (result.error) {
+      videoError.value = result.error.message
+      loadingVideo.value = false
+      return
+    }
+
+    const intervals = result.data?.results ?? []
+
+    // Validate target timestamp
+    const targetTimeMs = targetTime.getTime()
+    if (isNaN(targetTimeMs)) {
+      videoError.value = `Invalid timestamp format: ${timestamp}`
+      loadingVideo.value = false
+      return
+    }
+
+    // Find an interval that contains the target timestamp and has an HLS URL
+    const interval = intervals.find(i => {
+      if (!i.hlsUrl) return false
+      const intervalStart = new Date(i.startTimestamp).getTime()
+      const intervalEnd = new Date(i.endTimestamp).getTime()
+      // Skip intervals with invalid timestamps
+      if (isNaN(intervalStart) || isNaN(intervalEnd)) return false
+      return targetTimeMs >= intervalStart && targetTimeMs <= intervalEnd
+    })
+
+    if (!interval?.hlsUrl) {
+      // Provide detailed error message
+      if (intervals.length === 0) {
+        videoError.value = 'No recordings found for this time range'
+      } else if (!intervals.some(i => i.hlsUrl)) {
+        videoError.value = 'Recordings found but HLS not available'
+      } else {
+        videoError.value = `No recording contains timestamp ${timestamp}`
+      }
+      loadingVideo.value = false
+      return
+    }
+
+    // Set the HLS URL
+    videoUrl.value = interval.hlsUrl
+    loadingVideo.value = false
+
+    // Initialize HLS.js after the DOM has been updated
+    await nextTick()
+    initHls()
+  }
+
+  /**
+   * Reset all video state.
+   */
+  function resetVideo() {
+    destroyHls()
+    videoUrl.value = null
+    videoError.value = null
+    loadingVideo.value = false
+  }
+
+  // Cleanup on unmount
+  onUnmounted(() => {
+    destroyHls()
+  })
+
+  return {
+    // State
+    videoUrl,
+    videoError,
+    loadingVideo,
+    videoRef,
+
+    // Methods
+    loadVideo,
+    resetVideo,
+    destroyHls
+  }
+}
+
+/**
+ * Reset the media session cache.
+ * Call this when the user logs out or the session expires.
+ */
+export function resetMediaSessionCache() {
+  mediaSessionInitialized = false
+  mediaSessionPromise = null
+}

--- a/examples/vue-events/src/composables/useHlsPlayer.ts
+++ b/examples/vue-events/src/composables/useHlsPlayer.ts
@@ -15,9 +15,11 @@ function debugError(...args: unknown[]): void {
   }
 }
 
-// Cache media session to avoid redundant initialization calls
+// Cache media session state to avoid redundant initialization calls
+// Module-level state is shared across all component instances intentionally
 let mediaSessionInitialized = false
 let mediaSessionPromise: Promise<boolean> | null = null
+let mediaSessionError: string | null = null
 
 /** Return type for the useHlsPlayer composable */
 export interface HlsPlayerReturn {
@@ -49,6 +51,7 @@ export function useHlsPlayer(): HlsPlayerReturn {
   /**
    * Initialize media session with caching.
    * Only calls the API once per session, subsequent calls return cached result.
+   * Uses module-level state so all component instances share the same session status.
    */
   async function ensureMediaSession(): Promise<boolean> {
     // Return cached result if already initialized
@@ -56,16 +59,28 @@ export function useHlsPlayer(): HlsPlayerReturn {
       return true
     }
 
+    // If previous initialization failed, return cached error
+    if (mediaSessionError) {
+      videoError.value = mediaSessionError
+      return false
+    }
+
     // If initialization is in progress, wait for it
     if (mediaSessionPromise) {
-      return mediaSessionPromise
+      const result = await mediaSessionPromise
+      // Copy any cached error to this component's state
+      if (!result && mediaSessionError) {
+        videoError.value = mediaSessionError
+      }
+      return result
     }
 
     // Start new initialization
     mediaSessionPromise = (async () => {
       const result = await initMediaSession()
       if (result.error) {
-        videoError.value = `Media session error: ${result.error.message}`
+        mediaSessionError = `Media session error: ${result.error.message}`
+        videoError.value = mediaSessionError
         mediaSessionPromise = null
         return false
       }
@@ -111,13 +126,12 @@ export function useHlsPlayer(): HlsPlayerReturn {
     hlsInstance.attachMedia(videoRef.value)
 
     hlsInstance.on(Hls.Events.MANIFEST_PARSED, () => {
+      // Reset retry counter on successful manifest parse
+      networkRetryCount = 0
       videoRef.value?.play().catch(() => {
         // Autoplay may be blocked, user can manually play
       })
     })
-
-    // Reset retry counter on successful load
-    networkRetryCount = 0
 
     // Enhanced error handling for different error types
     hlsInstance.on(Hls.Events.ERROR, (_, data) => {
@@ -174,6 +188,7 @@ export function useHlsPlayer(): HlsPlayerReturn {
     loadingVideo.value = true
     videoError.value = null
     videoUrl.value = null
+    networkRetryCount = 0 // Reset retry counter for new video load
 
     // Initialize media session (cached after first call)
     const sessionOk = await ensureMediaSession()
@@ -189,7 +204,7 @@ export function useHlsPlayer(): HlsPlayerReturn {
 
     // Use 'main' type for video - HLS is typically only available for main feeds
     const result = await listMedia({
-      deviceId: deviceId,
+      deviceId,
       type: 'main',
       mediaType: 'video',
       startTimestamp: formatTimestamp(searchStartTime.toISOString()),
@@ -277,9 +292,15 @@ export function useHlsPlayer(): HlsPlayerReturn {
 
 /**
  * Reset the media session cache.
- * Call this when the user logs out or the session expires.
+ * Call this when the user logs out or the session expires to ensure
+ * a fresh media session is initialized on next use.
+ *
+ * @remarks
+ * This clears the module-level cached state shared by all component instances.
+ * Should be called during logout to prevent stale session data.
  */
-export function resetMediaSessionCache() {
+export function resetMediaSessionCache(): void {
   mediaSessionInitialized = false
   mediaSessionPromise = null
+  mediaSessionError = null
 }

--- a/examples/vue-events/src/composables/useHlsPlayer.ts
+++ b/examples/vue-events/src/composables/useHlsPlayer.ts
@@ -1,6 +1,7 @@
 import { ref, nextTick, onUnmounted, type Ref } from 'vue'
-import { listMedia, initMediaSession, formatTimestamp, useAuthStore } from 'een-api-toolkit'
+import { listMedia, formatTimestamp, useAuthStore } from 'een-api-toolkit'
 import Hls from 'hls.js'
+import { useMediaSessionStore } from '../stores/mediaSession'
 
 // Constants
 const SEARCH_WINDOW_MS = 60 * 60 * 1000 // 1 hour before/after target timestamp
@@ -14,12 +15,6 @@ function debugError(...args: unknown[]): void {
     console.error('[useHlsPlayer]', ...args)
   }
 }
-
-// Cache media session state to avoid redundant initialization calls
-// Module-level state is shared across all component instances intentionally
-let mediaSessionInitialized = false
-let mediaSessionPromise: Promise<boolean> | null = null
-let mediaSessionError: string | null = null
 
 /** Return type for the useHlsPlayer composable */
 export interface HlsPlayerReturn {
@@ -35,9 +30,12 @@ export interface HlsPlayerReturn {
 /**
  * Composable for HLS video playback from EEN recordings.
  * Handles media session initialization, interval search, and HLS.js setup.
+ * Uses Pinia store for media session state to ensure consistent behavior
+ * across all component instances.
  */
 export function useHlsPlayer(): HlsPlayerReturn {
   const authStore = useAuthStore()
+  const mediaSessionStore = useMediaSessionStore()
 
   // State
   const videoUrl = ref<string | null>(null)
@@ -49,46 +47,15 @@ export function useHlsPlayer(): HlsPlayerReturn {
   let networkRetryCount = 0
 
   /**
-   * Initialize media session with caching.
+   * Initialize media session with caching via Pinia store.
    * Only calls the API once per session, subsequent calls return cached result.
-   * Uses module-level state so all component instances share the same session status.
    */
   async function ensureMediaSession(): Promise<boolean> {
-    // Return cached result if already initialized
-    if (mediaSessionInitialized) {
-      return true
+    const success = await mediaSessionStore.ensureInitialized()
+    if (!success && mediaSessionStore.error) {
+      videoError.value = mediaSessionStore.error
     }
-
-    // If previous initialization failed, return cached error
-    if (mediaSessionError) {
-      videoError.value = mediaSessionError
-      return false
-    }
-
-    // If initialization is in progress, wait for it
-    if (mediaSessionPromise) {
-      const result = await mediaSessionPromise
-      // Copy any cached error to this component's state
-      if (!result && mediaSessionError) {
-        videoError.value = mediaSessionError
-      }
-      return result
-    }
-
-    // Start new initialization
-    mediaSessionPromise = (async () => {
-      const result = await initMediaSession()
-      if (result.error) {
-        mediaSessionError = `Media session error: ${result.error.message}`
-        videoError.value = mediaSessionError
-        mediaSessionPromise = null
-        return false
-      }
-      mediaSessionInitialized = true
-      return true
-    })()
-
-    return mediaSessionPromise
+    return success
   }
 
   /**
@@ -296,11 +263,10 @@ export function useHlsPlayer(): HlsPlayerReturn {
  * a fresh media session is initialized on next use.
  *
  * @remarks
- * This clears the module-level cached state shared by all component instances.
- * Should be called during logout to prevent stale session data.
+ * This delegates to the Pinia media session store's reset method.
+ * Must be called from within a Vue component context or after Pinia is installed.
  */
 export function resetMediaSessionCache(): void {
-  mediaSessionInitialized = false
-  mediaSessionPromise = null
-  mediaSessionError = null
+  const mediaSessionStore = useMediaSessionStore()
+  mediaSessionStore.reset()
 }

--- a/examples/vue-events/src/stores/mediaSession.ts
+++ b/examples/vue-events/src/stores/mediaSession.ts
@@ -1,0 +1,79 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { initMediaSession } from 'een-api-toolkit'
+
+/**
+ * Pinia store for managing media session state.
+ * Centralizes media session initialization to avoid redundant API calls
+ * and ensures consistent state across all components using HLS playback.
+ */
+export const useMediaSessionStore = defineStore('mediaSession', () => {
+  // State
+  const initialized = ref(false)
+  const error = ref<string | null>(null)
+  const initPromise = ref<Promise<boolean> | null>(null)
+
+  // Computed
+  const isReady = computed(() => initialized.value && !error.value)
+  const hasError = computed(() => error.value !== null)
+
+  /**
+   * Initialize the media session.
+   * Only calls the API once per session, subsequent calls return cached result.
+   * Safe to call from multiple components simultaneously.
+   *
+   * @returns Promise that resolves to true if session is ready, false if failed
+   */
+  async function ensureInitialized(): Promise<boolean> {
+    // Return cached result if already initialized
+    if (initialized.value) {
+      return true
+    }
+
+    // If previous initialization failed, return cached error state
+    if (error.value) {
+      return false
+    }
+
+    // If initialization is in progress, wait for it
+    if (initPromise.value) {
+      return initPromise.value
+    }
+
+    // Start new initialization
+    initPromise.value = (async () => {
+      const result = await initMediaSession()
+      if (result.error) {
+        error.value = `Media session error: ${result.error.message}`
+        initPromise.value = null
+        return false
+      }
+      initialized.value = true
+      return true
+    })()
+
+    return initPromise.value
+  }
+
+  /**
+   * Reset the media session state.
+   * Call this when the user logs out or the session expires.
+   */
+  function reset() {
+    initialized.value = false
+    error.value = null
+    initPromise.value = null
+  }
+
+  return {
+    // State (read-only access)
+    initialized,
+    error,
+    // Computed
+    isReady,
+    hasError,
+    // Actions
+    ensureInitialized,
+    reset
+  }
+})


### PR DESCRIPTION
## Summary

- Added Preview, HD Image, and Video buttons to event modal lightboxes in vue-events and vue-event-subscriptions example apps
- Implemented proper authentication for media fetching using `getRecordedImage` and HLS player with Authorization headers
- Created `useHlsPlayer` composable for both apps following vue-alerts-metrics pattern

## Changes

- **vue-events**: Updated EventsModal.vue with media buttons and HLS video support
- **vue-event-subscriptions**: Updated LiveEvents.vue with media buttons and HLS video support
- Added hls.js dependency to both example apps
- Created composables/useHlsPlayer.ts in both apps

## Test Plan

- [x] Unit tests: 341 passed
- [x] Build: successful
- [x] E2E tests for all 8 example apps passed (123 total):
  - vue-users: 14 passed
  - vue-cameras: 13 passed
  - vue-bridges: 13 passed
  - vue-events: 16 passed
  - vue-feeds: 12 passed
  - vue-media: 20 passed
  - vue-alerts-metrics: 20 passed
  - vue-event-subscriptions: 15 passed

## Version

v0.3.20

## Commits

- 8f11b04 feat: Add media buttons to event modal lightboxes in vue-events and vue-event-subscriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)