### PR TITLE
chore: Pin Playwright 1.58.0 and improve docs agent

### DIFF
--- a/.claude/agents/docs-accuracy-reviewer.md
+++ b/.claude/agents/docs-accuracy-reviewer.md
@@ -61,6 +61,8 @@ assistant: "I'll use the docs-accuracy-reviewer agent to verify the README and a
 
 1. **Discovery Phase**:
    - List all markdown files in the project (README.md, docs/**, CLAUDE.md, etc.)
+   - **Scan ALL example directories** (`examples/*/README.md`) - do not skip any
+   - Check agent files in `.claude/agents/*.md`
    - Identify the source code structure for cross-referencing
 
 2. **Analysis Phase**:
@@ -81,6 +83,15 @@ assistant: "I'll use the docs-accuracy-reviewer agent to verify the README and a
    - Add missing documentation for undocumented features when appropriate
 
 ## Specific Checks to Perform
+
+### For Example Application Documentation:
+- **Check ALL example apps** in `examples/*/README.md` (not just one)
+- Verify screenshot references exist and filenames match actual files
+- Confirm all listed API functions are exported from `src/index.ts`
+- Check that `.env.example` files exist when referenced in setup instructions
+- Validate project structure sections match actual directory contents
+- Ensure port numbers are correct (should be `127.0.0.1:3333`)
+- Verify code examples use current API signatures
 
 ### For API Documentation:
 - Compare documented function signatures with `src/index.ts` exports
@@ -141,6 +152,7 @@ When reporting findings, use this structure:
 
 Before completing your review:
 1. Verify you've checked ALL markdown files in the project
-2. Confirm each fix you made is backed by evidence from source code
-3. Re-read modified sections to ensure they're clear and accurate
-4. Check that your fixes didn't introduce new broken links or inconsistencies
+2. **Confirm ALL example app READMEs were reviewed** (list them in your report)
+3. Confirm each fix you made is backed by evidence from source code
+4. Re-read modified sections to ensure they're clear and accurate
+5. Check that your fixes didn't introduce new broken links or inconsistencies

--- a/.claude/agents/een-devices-agent.md
+++ b/.claude/agents/een-devices-agent.md
@@ -69,14 +69,14 @@ interface Camera {
 type CameraStatus =
   | 'online'
   | 'offline'
-  | 'streaming'
-  | 'recording'
-  | 'registered'
   | 'deviceOffline'
   | 'bridgeOffline'
   | 'invalidCredentials'
   | 'error'
-  | 'unknown'
+  | 'streaming'
+  | 'registered'
+  | 'attaching'
+  | 'initializing'
 
 // Status can also be nested in an object:
 // camera.status?.connectionStatus
@@ -97,7 +97,10 @@ type BridgeStatus =
   | 'online'
   | 'offline'
   | 'error'
-  | 'unknown'
+  | 'idle'
+  | 'registered'
+  | 'attaching'
+  | 'initializing'
 ```
 
 ### ListCamerasParams
@@ -141,7 +144,7 @@ async function fetchCameras() {
 async function fetchOnlineCameras() {
   const result = await getCameras({
     include: ['status'],  // Required to display status in UI
-    status__in: ['online', 'streaming', 'recording'],
+    status__in: ['online', 'streaming', 'registered'],
     pageSize: 100
   })
 
@@ -249,7 +252,7 @@ import { getCameras, type Camera, type CameraStatus, type ListCamerasParams } fr
 
 const cameras = ref<Camera[]>([])
 const loading = ref(false)
-const statusFilter = ref<string[]>(['online', 'streaming', 'recording'])
+const statusFilter = ref<string[]>(['online', 'streaming', 'registered'])
 
 // Helper: status can be a string OR an object with connectionStatus
 function getStatusString(status?: CameraStatus | { connectionStatus?: CameraStatus }): string | undefined {

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -75,8 +75,10 @@ jobs:
 
       - name: Install Playwright browsers
         run: |
-          # Install Playwright browsers once (they're shared across examples)
+          # Install Playwright browsers from first example
+          # All examples use the same pinned version (1.58.0)
           FIRST_EXAMPLE=$(echo '${{ steps.discover.outputs.examples }}' | jq -r '.[0]')
+          echo "Installing Playwright browsers from $FIRST_EXAMPLE..."
           (cd "$FIRST_EXAMPLE" && npm exec playwright install -- --with-deps chromium)
 
       - name: Clone OAuth proxy

--- a/docs/AI-CONTEXT.md
+++ b/docs/AI-CONTEXT.md
@@ -1,6 +1,6 @@
 # EEN API Toolkit - AI Reference
 
-> **Version:** 0.3.34
+> **Version:** 0.3.35
 >
 > This documentation is optimized for AI assistants. It provides focused, domain-specific
 > references to help you understand and use the een-api-toolkit efficiently.

--- a/docs/ai-reference/AI-AUTH.md
+++ b/docs/ai-reference/AI-AUTH.md
@@ -1,6 +1,6 @@
 # Authentication - EEN API Toolkit
 
-> **Version:** 0.3.34
+> **Version:** 0.3.35
 >
 > OAuth flow implementation, token management, and session handling.
 > Load this document when implementing login, logout, or auth guards.

--- a/docs/ai-reference/AI-DEVICES.md
+++ b/docs/ai-reference/AI-DEVICES.md
@@ -1,6 +1,6 @@
 # Cameras & Bridges API - EEN API Toolkit
 
-> **Version:** 0.3.34
+> **Version:** 0.3.35
 >
 > Complete reference for camera and bridge management.
 > Load this document when working with devices.

--- a/docs/ai-reference/AI-EVENTS.md
+++ b/docs/ai-reference/AI-EVENTS.md
@@ -1,6 +1,6 @@
 # Events, Alerts & Real-Time Streaming - EEN API Toolkit
 
-> **Version:** 0.3.34
+> **Version:** 0.3.35
 >
 > Complete reference for events, alerts, metrics, and SSE subscriptions.
 > Load this document when implementing event-driven features.

--- a/docs/ai-reference/AI-MEDIA.md
+++ b/docs/ai-reference/AI-MEDIA.md
@@ -1,6 +1,6 @@
 # Media & Live Video - EEN API Toolkit
 
-> **Version:** 0.3.34
+> **Version:** 0.3.35
 >
 > Complete reference for media retrieval, live streaming, and video playback.
 > Load this document when implementing video features.

--- a/docs/ai-reference/AI-SETUP.md
+++ b/docs/ai-reference/AI-SETUP.md
@@ -1,6 +1,6 @@
 # Vue 3 Application Setup - EEN API Toolkit
 
-> **Version:** 0.3.34
+> **Version:** 0.3.35
 >
 > Complete guide for setting up a Vue 3 application with the een-api-toolkit.
 > Load this document when creating a new project or troubleshooting setup issues.

--- a/docs/ai-reference/AI-USERS.md
+++ b/docs/ai-reference/AI-USERS.md
@@ -1,6 +1,6 @@
 # Users API - EEN API Toolkit
 
-> **Version:** 0.3.34
+> **Version:** 0.3.35
 >
 > Complete reference for user management.
 > Load this document when working with user data.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,8 +1,8 @@
-**EEN API Toolkit v0.3.34**
+**EEN API Toolkit v0.3.35**
 
 ***
 
-# EEN API Toolkit v0.3.34
+# EEN API Toolkit v0.3.35
 
 ## Interfaces
 

--- a/docs/api/functions/connectToEventSubscription.md
+++ b/docs/api/functions/connectToEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/createEventSubscription.md
+++ b/docs/api/functions/createEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/createLayout.md
+++ b/docs/api/functions/createLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteEventSubscription.md
+++ b/docs/api/functions/deleteEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteLayout.md
+++ b/docs/api/functions/deleteLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/formatTimestamp.md
+++ b/docs/api/functions/formatTimestamp.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAccessToken.md
+++ b/docs/api/functions/getAccessToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlert.md
+++ b/docs/api/functions/getAlert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAuthUrl.md
+++ b/docs/api/functions/getAuthUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridge.md
+++ b/docs/api/functions/getBridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridges.md
+++ b/docs/api/functions/getBridges.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCamera.md
+++ b/docs/api/functions/getCamera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameras.md
+++ b/docs/api/functions/getCameras.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/getClientId.md
+++ b/docs/api/functions/getClientId.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/getConfig.md
+++ b/docs/api/functions/getConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCurrentUser.md
+++ b/docs/api/functions/getCurrentUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEvent.md
+++ b/docs/api/functions/getEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventMetrics.md
+++ b/docs/api/functions/getEventMetrics.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventSubscription.md
+++ b/docs/api/functions/getEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayout.md
+++ b/docs/api/functions/getLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayouts.md
+++ b/docs/api/functions/getLayouts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLiveImage.md
+++ b/docs/api/functions/getLiveImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/getMediaSession.md
+++ b/docs/api/functions/getMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/getNotification.md
+++ b/docs/api/functions/getNotification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/getProxyUrl.md
+++ b/docs/api/functions/getProxyUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRecordedImage.md
+++ b/docs/api/functions/getRecordedImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRedirectUri.md
+++ b/docs/api/functions/getRedirectUri.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/getStorageStrategy.md
+++ b/docs/api/functions/getStorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUser.md
+++ b/docs/api/functions/getUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUsers.md
+++ b/docs/api/functions/getUsers.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/handleAuthCallback.md
+++ b/docs/api/functions/handleAuthCallback.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/initEenToolkit.md
+++ b/docs/api/functions/initEenToolkit.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/initMediaSession.md
+++ b/docs/api/functions/initMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertTypes.md
+++ b/docs/api/functions/listAlertTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlerts.md
+++ b/docs/api/functions/listAlerts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventFieldValues.md
+++ b/docs/api/functions/listEventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventSubscriptions.md
+++ b/docs/api/functions/listEventSubscriptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventTypes.md
+++ b/docs/api/functions/listEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEvents.md
+++ b/docs/api/functions/listEvents.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/listFeeds.md
+++ b/docs/api/functions/listFeeds.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/listMedia.md
+++ b/docs/api/functions/listMedia.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/listNotifications.md
+++ b/docs/api/functions/listNotifications.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/refreshToken.md
+++ b/docs/api/functions/refreshToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/revokeToken.md
+++ b/docs/api/functions/revokeToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/functions/updateLayout.md
+++ b/docs/api/functions/updateLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Alert.md
+++ b/docs/api/interfaces/Alert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertAction.md
+++ b/docs/api/interfaces/AlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertType.md
+++ b/docs/api/interfaces/AlertType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Bridge.md
+++ b/docs/api/interfaces/Bridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDeviceInfo.md
+++ b/docs/api/interfaces/BridgeDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDevicePosition.md
+++ b/docs/api/interfaces/BridgeDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeNetworkInfo.md
+++ b/docs/api/interfaces/BridgeNetworkInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Camera.md
+++ b/docs/api/interfaces/Camera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDeviceInfo.md
+++ b/docs/api/interfaces/CameraDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDevicePosition.md
+++ b/docs/api/interfaces/CameraDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRecordingModes.md
+++ b/docs/api/interfaces/CameraRecordingModes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRtspConnectionSettings.md
+++ b/docs/api/interfaces/CameraRtspConnectionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraShareDetails.md
+++ b/docs/api/interfaces/CameraShareDetails.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStatusCounts.md
+++ b/docs/api/interfaces/CameraStatusCounts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStreamUrls.md
+++ b/docs/api/interfaces/CameraStreamUrls.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateEventSubscriptionParams.md
+++ b/docs/api/interfaces/CreateEventSubscriptionParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateLayoutParams.md
+++ b/docs/api/interfaces/CreateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenError.md
+++ b/docs/api/interfaces/EenError.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenToolkitConfig.md
+++ b/docs/api/interfaces/EenToolkitConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Event.md
+++ b/docs/api/interfaces/Event.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventData.md
+++ b/docs/api/interfaces/EventData.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventFieldValues.md
+++ b/docs/api/interfaces/EventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventMetric.md
+++ b/docs/api/interfaces/EventMetric.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscription.md
+++ b/docs/api/interfaces/EventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionConfig.md
+++ b/docs/api/interfaces/EventSubscriptionConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionFilter.md
+++ b/docs/api/interfaces/EventSubscriptionFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventType.md
+++ b/docs/api/interfaces/EventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventTypeFilter.md
+++ b/docs/api/interfaces/EventTypeFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Feed.md
+++ b/docs/api/interfaces/Feed.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/FilterCreate.md
+++ b/docs/api/interfaces/FilterCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetAlertParams.md
+++ b/docs/api/interfaces/GetAlertParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetBridgeParams.md
+++ b/docs/api/interfaces/GetBridgeParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetCameraParams.md
+++ b/docs/api/interfaces/GetCameraParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventMetricsParams.md
+++ b/docs/api/interfaces/GetEventMetricsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventParams.md
+++ b/docs/api/interfaces/GetEventParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLayoutParams.md
+++ b/docs/api/interfaces/GetLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLiveImageParams.md
+++ b/docs/api/interfaces/GetLiveImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetRecordedImageParams.md
+++ b/docs/api/interfaces/GetRecordedImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetUserParams.md
+++ b/docs/api/interfaces/GetUserParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Layout.md
+++ b/docs/api/interfaces/Layout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPane.md
+++ b/docs/api/interfaces/LayoutPane.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPermissions.md
+++ b/docs/api/interfaces/LayoutPermissions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutSettings.md
+++ b/docs/api/interfaces/LayoutSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertTypesParams.md
+++ b/docs/api/interfaces/ListAlertTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertsParams.md
+++ b/docs/api/interfaces/ListAlertsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListBridgesParams.md
+++ b/docs/api/interfaces/ListBridgesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListCamerasParams.md
+++ b/docs/api/interfaces/ListCamerasParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventFieldValuesParams.md
+++ b/docs/api/interfaces/ListEventFieldValuesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventSubscriptionsParams.md
+++ b/docs/api/interfaces/ListEventSubscriptionsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventTypesParams.md
+++ b/docs/api/interfaces/ListEventTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventsParams.md
+++ b/docs/api/interfaces/ListEventsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsParams.md
+++ b/docs/api/interfaces/ListFeedsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsResult.md
+++ b/docs/api/interfaces/ListFeedsResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListLayoutsParams.md
+++ b/docs/api/interfaces/ListLayoutsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListMediaParams.md
+++ b/docs/api/interfaces/ListMediaParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListNotificationsParams.md
+++ b/docs/api/interfaces/ListNotificationsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListUsersParams.md
+++ b/docs/api/interfaces/ListUsersParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LiveImageResult.md
+++ b/docs/api/interfaces/LiveImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaInterval.md
+++ b/docs/api/interfaces/MediaInterval.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResponse.md
+++ b/docs/api/interfaces/MediaSessionResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResult.md
+++ b/docs/api/interfaces/MediaSessionResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Notification.md
+++ b/docs/api/interfaces/Notification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginatedResult.md
+++ b/docs/api/interfaces/PaginatedResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginationParams.md
+++ b/docs/api/interfaces/PaginationParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/RecordedImageResult.md
+++ b/docs/api/interfaces/RecordedImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnection.md
+++ b/docs/api/interfaces/SSEConnection.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnectionOptions.md
+++ b/docs/api/interfaces/SSEConnectionOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfig.md
+++ b/docs/api/interfaces/SSEDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfigCreate.md
+++ b/docs/api/interfaces/SSEDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEEvent.md
+++ b/docs/api/interfaces/SSEEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/TokenResponse.md
+++ b/docs/api/interfaces/TokenResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UpdateLayoutParams.md
+++ b/docs/api/interfaces/UpdateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/User.md
+++ b/docs/api/interfaces/User.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UserProfile.md
+++ b/docs/api/interfaces/UserProfile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfig.md
+++ b/docs/api/interfaces/WebhookDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfigCreate.md
+++ b/docs/api/interfaces/WebhookDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ActorType.md
+++ b/docs/api/type-aliases/ActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionStatus.md
+++ b/docs/api/type-aliases/AlertActionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertInclude.md
+++ b/docs/api/type-aliases/AlertInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertSort.md
+++ b/docs/api/type-aliases/AlertSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/BridgeStatus.md
+++ b/docs/api/type-aliases/BridgeStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraAspectRatio.md
+++ b/docs/api/type-aliases/CameraAspectRatio.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraStatus.md
+++ b/docs/api/type-aliases/CameraStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfig.md
+++ b/docs/api/type-aliases/DeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfigCreate.md
+++ b/docs/api/type-aliases/DeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ErrorCode.md
+++ b/docs/api/type-aliases/ErrorCode.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionDeliveryType.md
+++ b/docs/api/type-aliases/EventSubscriptionDeliveryType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionLifecycle.md
+++ b/docs/api/type-aliases/EventSubscriptionLifecycle.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedIncludeOption.md
+++ b/docs/api/type-aliases/FeedIncludeOption.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedMediaType.md
+++ b/docs/api/type-aliases/FeedMediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedStreamType.md
+++ b/docs/api/type-aliases/FeedStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/GetLayoutInclude.md
+++ b/docs/api/type-aliases/GetLayoutInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneSize.md
+++ b/docs/api/type-aliases/LayoutPaneSize.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneType.md
+++ b/docs/api/type-aliases/LayoutPaneType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsInclude.md
+++ b/docs/api/type-aliases/ListLayoutsInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsSort.md
+++ b/docs/api/type-aliases/ListLayoutsSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaStreamType.md
+++ b/docs/api/type-aliases/MediaStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaType.md
+++ b/docs/api/type-aliases/MediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricActorType.md
+++ b/docs/api/type-aliases/MetricActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricDataPoint.md
+++ b/docs/api/type-aliases/MetricDataPoint.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationCategory.md
+++ b/docs/api/type-aliases/NotificationCategory.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationStatus.md
+++ b/docs/api/type-aliases/NotificationStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/Result.md
+++ b/docs/api/type-aliases/Result.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/SSEConnectionStatus.md
+++ b/docs/api/type-aliases/SSEConnectionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/StorageStrategy.md
+++ b/docs/api/type-aliases/StorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
+++ b/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/docs/api/variables/useAuthStore.md
+++ b/docs/api/variables/useAuthStore.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.34**](../README.md)
+[**EEN API Toolkit v0.3.35**](../README.md)
 
 ***
 

--- a/examples/vue-alerts-metrics/package-lock.json
+++ b/examples/vue-alerts-metrics/package-lock.json
@@ -17,7 +17,7 @@
         "vue-router": "^4.2.0"
       },
       "devDependencies": {
-        "@playwright/test": "^1.57.0",
+        "@playwright/test": "1.58.0",
         "@vitejs/plugin-vue": "^6.0.0",
         "dotenv": "^17.2.3",
         "typescript": "~5.8.0",
@@ -26,12 +26,15 @@
       }
     },
     "../..": {
-      "version": "0.3.15",
+      "version": "0.3.34",
       "license": "MIT",
+      "bin": {
+        "een-setup-agents": "scripts/setup-agents.ts"
+      },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
         "@marp-team/marp-cli": "^4.2.3",
-        "@playwright/test": "^1.57.0",
+        "@playwright/test": "1.58.0",
         "@types/node": "^25.0.3",
         "@typescript-eslint/eslint-plugin": "^8.51.0",
         "@typescript-eslint/parser": "^8.51.0",
@@ -564,13 +567,13 @@
       "license": "MIT"
     },
     "node_modules/@playwright/test": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
-      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.0.tgz",
+      "integrity": "sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.57.0"
+        "playwright": "1.58.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1415,13 +1418,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.0.tgz",
+      "integrity": "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.57.0"
+        "playwright-core": "1.58.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1434,9 +1437,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.0.tgz",
+      "integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/examples/vue-alerts-metrics/package.json
+++ b/examples/vue-alerts-metrics/package.json
@@ -21,7 +21,7 @@
     "vue-router": "^4.2.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.57.0",
+    "@playwright/test": "1.58.0",
     "@vitejs/plugin-vue": "^6.0.0",
     "dotenv": "^17.2.3",
     "typescript": "~5.8.0",

--- a/examples/vue-bridges/package-lock.json
+++ b/examples/vue-bridges/package-lock.json
@@ -14,7 +14,7 @@
         "vue-router": "^4.2.0"
       },
       "devDependencies": {
-        "@playwright/test": "^1.57.0",
+        "@playwright/test": "1.58.0",
         "@vitejs/plugin-vue": "^6.0.0",
         "dotenv": "^17.2.3",
         "typescript": "~5.8.0",
@@ -23,10 +23,15 @@
       }
     },
     "../..": {
-      "version": "0.1.13",
+      "version": "0.3.34",
       "license": "MIT",
+      "bin": {
+        "een-setup-agents": "scripts/setup-agents.ts"
+      },
       "devDependencies": {
-        "@playwright/test": "^1.57.0",
+        "@eslint/js": "^9.39.2",
+        "@marp-team/marp-cli": "^4.2.3",
+        "@playwright/test": "1.58.0",
         "@types/node": "^25.0.3",
         "@typescript-eslint/eslint-plugin": "^8.51.0",
         "@typescript-eslint/parser": "^8.51.0",
@@ -47,13 +52,14 @@
         "vite-plugin-dts": "^4.5.4",
         "vitest": "^4.0.16",
         "vue": "^3.4.0",
+        "vue-eslint-parser": "^10.2.0",
         "vue-tsc": "^3.2.1"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "pinia": "^2.0.0 || ^3.0.0",
+        "pinia": "^3.0.0",
         "vue": "^3.3.0"
       }
     },
@@ -552,13 +558,13 @@
       "license": "MIT"
     },
     "node_modules/@playwright/test": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
-      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.0.tgz",
+      "integrity": "sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.57.0"
+        "playwright": "1.58.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1349,13 +1355,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.0.tgz",
+      "integrity": "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.57.0"
+        "playwright-core": "1.58.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1368,9 +1374,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.0.tgz",
+      "integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/examples/vue-bridges/package.json
+++ b/examples/vue-bridges/package.json
@@ -18,7 +18,7 @@
     "vue-router": "^4.2.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.57.0",
+    "@playwright/test": "1.58.0",
     "@vitejs/plugin-vue": "^6.0.0",
     "dotenv": "^17.2.3",
     "typescript": "~5.8.0",

--- a/examples/vue-cameras/package-lock.json
+++ b/examples/vue-cameras/package-lock.json
@@ -14,7 +14,7 @@
         "vue-router": "^4.2.0"
       },
       "devDependencies": {
-        "@playwright/test": "^1.57.0",
+        "@playwright/test": "1.58.0",
         "@vitejs/plugin-vue": "^6.0.0",
         "dotenv": "^17.2.3",
         "typescript": "~5.8.0",
@@ -23,10 +23,15 @@
       }
     },
     "../..": {
-      "version": "0.1.13",
+      "version": "0.3.34",
       "license": "MIT",
+      "bin": {
+        "een-setup-agents": "scripts/setup-agents.ts"
+      },
       "devDependencies": {
-        "@playwright/test": "^1.57.0",
+        "@eslint/js": "^9.39.2",
+        "@marp-team/marp-cli": "^4.2.3",
+        "@playwright/test": "1.58.0",
         "@types/node": "^25.0.3",
         "@typescript-eslint/eslint-plugin": "^8.51.0",
         "@typescript-eslint/parser": "^8.51.0",
@@ -47,13 +52,14 @@
         "vite-plugin-dts": "^4.5.4",
         "vitest": "^4.0.16",
         "vue": "^3.4.0",
+        "vue-eslint-parser": "^10.2.0",
         "vue-tsc": "^3.2.1"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "pinia": "^2.0.0 || ^3.0.0",
+        "pinia": "^3.0.0",
         "vue": "^3.3.0"
       }
     },
@@ -552,13 +558,13 @@
       "license": "MIT"
     },
     "node_modules/@playwright/test": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
-      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.0.tgz",
+      "integrity": "sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.57.0"
+        "playwright": "1.58.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1349,13 +1355,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.0.tgz",
+      "integrity": "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.57.0"
+        "playwright-core": "1.58.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1368,9 +1374,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.0.tgz",
+      "integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/examples/vue-cameras/package.json
+++ b/examples/vue-cameras/package.json
@@ -18,7 +18,7 @@
     "vue-router": "^4.2.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.57.0",
+    "@playwright/test": "1.58.0",
     "@vitejs/plugin-vue": "^6.0.0",
     "dotenv": "^17.2.3",
     "typescript": "~5.8.0",

--- a/examples/vue-event-subscriptions/package-lock.json
+++ b/examples/vue-event-subscriptions/package-lock.json
@@ -15,7 +15,7 @@
         "vue-router": "^4.2.0"
       },
       "devDependencies": {
-        "@playwright/test": "^1.57.0",
+        "@playwright/test": "1.58.0",
         "@vitejs/plugin-vue": "^6.0.0",
         "dotenv": "^17.2.3",
         "typescript": "~5.8.0",
@@ -24,12 +24,15 @@
       }
     },
     "../..": {
-      "version": "0.3.20",
+      "version": "0.3.34",
       "license": "MIT",
+      "bin": {
+        "een-setup-agents": "scripts/setup-agents.ts"
+      },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
         "@marp-team/marp-cli": "^4.2.3",
-        "@playwright/test": "^1.57.0",
+        "@playwright/test": "1.58.0",
         "@types/node": "^25.0.3",
         "@typescript-eslint/eslint-plugin": "^8.51.0",
         "@typescript-eslint/parser": "^8.51.0",
@@ -556,13 +559,13 @@
       "license": "MIT"
     },
     "node_modules/@playwright/test": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
-      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.0.tgz",
+      "integrity": "sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.57.0"
+        "playwright": "1.58.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1395,13 +1398,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.0.tgz",
+      "integrity": "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.57.0"
+        "playwright-core": "1.58.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1414,9 +1417,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.0.tgz",
+      "integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/examples/vue-event-subscriptions/package.json
+++ b/examples/vue-event-subscriptions/package.json
@@ -19,7 +19,7 @@
     "vue-router": "^4.2.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.57.0",
+    "@playwright/test": "1.58.0",
     "@vitejs/plugin-vue": "^6.0.0",
     "dotenv": "^17.2.3",
     "typescript": "~5.8.0",

--- a/examples/vue-events/package-lock.json
+++ b/examples/vue-events/package-lock.json
@@ -15,7 +15,7 @@
         "vue-router": "^4.2.0"
       },
       "devDependencies": {
-        "@playwright/test": "^1.57.0",
+        "@playwright/test": "1.58.0",
         "@vitejs/plugin-vue": "^6.0.0",
         "dotenv": "^17.2.3",
         "typescript": "~5.8.0",
@@ -24,12 +24,15 @@
       }
     },
     "../..": {
-      "version": "0.3.20",
+      "version": "0.3.34",
       "license": "MIT",
+      "bin": {
+        "een-setup-agents": "scripts/setup-agents.ts"
+      },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
         "@marp-team/marp-cli": "^4.2.3",
-        "@playwright/test": "^1.57.0",
+        "@playwright/test": "1.58.0",
         "@types/node": "^25.0.3",
         "@typescript-eslint/eslint-plugin": "^8.51.0",
         "@typescript-eslint/parser": "^8.51.0",
@@ -556,13 +559,13 @@
       "license": "MIT"
     },
     "node_modules/@playwright/test": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
-      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.0.tgz",
+      "integrity": "sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.57.0"
+        "playwright": "1.58.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1395,13 +1398,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.0.tgz",
+      "integrity": "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.57.0"
+        "playwright-core": "1.58.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1414,9 +1417,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.0.tgz",
+      "integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/examples/vue-events/package.json
+++ b/examples/vue-events/package.json
@@ -19,7 +19,7 @@
     "vue-router": "^4.2.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.57.0",
+    "@playwright/test": "1.58.0",
     "@vitejs/plugin-vue": "^6.0.0",
     "dotenv": "^17.2.3",
     "typescript": "~5.8.0",

--- a/examples/vue-feeds/package-lock.json
+++ b/examples/vue-feeds/package-lock.json
@@ -15,7 +15,7 @@
         "vue-router": "^4.2.0"
       },
       "devDependencies": {
-        "@playwright/test": "^1.57.0",
+        "@playwright/test": "1.58.0",
         "@vitejs/plugin-vue": "^6.0.0",
         "dotenv": "^17.2.3",
         "typescript": "~5.8.0",
@@ -24,10 +24,15 @@
       }
     },
     "../..": {
-      "version": "0.1.13",
+      "version": "0.3.34",
       "license": "MIT",
+      "bin": {
+        "een-setup-agents": "scripts/setup-agents.ts"
+      },
       "devDependencies": {
-        "@playwright/test": "^1.57.0",
+        "@eslint/js": "^9.39.2",
+        "@marp-team/marp-cli": "^4.2.3",
+        "@playwright/test": "1.58.0",
         "@types/node": "^25.0.3",
         "@typescript-eslint/eslint-plugin": "^8.51.0",
         "@typescript-eslint/parser": "^8.51.0",
@@ -48,13 +53,14 @@
         "vite-plugin-dts": "^4.5.4",
         "vitest": "^4.0.16",
         "vue": "^3.4.0",
+        "vue-eslint-parser": "^10.2.0",
         "vue-tsc": "^3.2.1"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "pinia": "^2.0.0 || ^3.0.0",
+        "pinia": "^3.0.0",
         "vue": "^3.3.0"
       }
     },
@@ -559,13 +565,13 @@
       "license": "MIT"
     },
     "node_modules/@playwright/test": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
-      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.0.tgz",
+      "integrity": "sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.57.0"
+        "playwright": "1.58.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1356,13 +1362,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.0.tgz",
+      "integrity": "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.57.0"
+        "playwright-core": "1.58.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1375,9 +1381,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.0.tgz",
+      "integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/examples/vue-feeds/package.json
+++ b/examples/vue-feeds/package.json
@@ -19,7 +19,7 @@
     "vue-router": "^4.2.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.57.0",
+    "@playwright/test": "1.58.0",
     "@vitejs/plugin-vue": "^6.0.0",
     "dotenv": "^17.2.3",
     "typescript": "~5.8.0",

--- a/examples/vue-layouts/package-lock.json
+++ b/examples/vue-layouts/package-lock.json
@@ -14,7 +14,7 @@
         "vue-router": "^4.2.0"
       },
       "devDependencies": {
-        "@playwright/test": "^1.57.0",
+        "@playwright/test": "1.58.0",
         "@vitejs/plugin-vue": "^6.0.0",
         "dotenv": "^17.2.3",
         "typescript": "~5.8.0",
@@ -23,7 +23,7 @@
       }
     },
     "../..": {
-      "version": "0.3.30",
+      "version": "0.3.34",
       "license": "MIT",
       "bin": {
         "een-setup-agents": "scripts/setup-agents.ts"
@@ -31,7 +31,7 @@
       "devDependencies": {
         "@eslint/js": "^9.39.2",
         "@marp-team/marp-cli": "^4.2.3",
-        "@playwright/test": "^1.57.0",
+        "@playwright/test": "1.58.0",
         "@types/node": "^25.0.3",
         "@typescript-eslint/eslint-plugin": "^8.51.0",
         "@typescript-eslint/parser": "^8.51.0",

--- a/examples/vue-layouts/package.json
+++ b/examples/vue-layouts/package.json
@@ -18,7 +18,7 @@
     "vue-router": "^4.2.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.57.0",
+    "@playwright/test": "1.58.0",
     "@vitejs/plugin-vue": "^6.0.0",
     "dotenv": "^17.2.3",
     "typescript": "~5.8.0",

--- a/examples/vue-media/package-lock.json
+++ b/examples/vue-media/package-lock.json
@@ -15,7 +15,7 @@
         "vue-router": "^4.2.0"
       },
       "devDependencies": {
-        "@playwright/test": "^1.57.0",
+        "@playwright/test": "1.58.0",
         "@vitejs/plugin-vue": "^6.0.0",
         "dotenv": "^17.2.3",
         "typescript": "~5.8.0",
@@ -24,11 +24,15 @@
       }
     },
     "../..": {
-      "version": "0.3.10",
+      "version": "0.3.34",
       "license": "MIT",
+      "bin": {
+        "een-setup-agents": "scripts/setup-agents.ts"
+      },
       "devDependencies": {
+        "@eslint/js": "^9.39.2",
         "@marp-team/marp-cli": "^4.2.3",
-        "@playwright/test": "^1.57.0",
+        "@playwright/test": "1.58.0",
         "@types/node": "^25.0.3",
         "@typescript-eslint/eslint-plugin": "^8.51.0",
         "@typescript-eslint/parser": "^8.51.0",
@@ -49,6 +53,7 @@
         "vite-plugin-dts": "^4.5.4",
         "vitest": "^4.0.16",
         "vue": "^3.4.0",
+        "vue-eslint-parser": "^10.2.0",
         "vue-tsc": "^3.2.1"
       },
       "engines": {
@@ -554,13 +559,13 @@
       "license": "MIT"
     },
     "node_modules/@playwright/test": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
-      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.0.tgz",
+      "integrity": "sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.57.0"
+        "playwright": "1.58.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1357,13 +1362,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.0.tgz",
+      "integrity": "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.57.0"
+        "playwright-core": "1.58.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1376,9 +1381,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.0.tgz",
+      "integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/examples/vue-media/package.json
+++ b/examples/vue-media/package.json
@@ -19,7 +19,7 @@
     "vue-router": "^4.2.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.57.0",
+    "@playwright/test": "1.58.0",
     "@vitejs/plugin-vue": "^6.0.0",
     "dotenv": "^17.2.3",
     "typescript": "~5.8.0",

--- a/examples/vue-users/package-lock.json
+++ b/examples/vue-users/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-api-toolkit-example",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit-example",
-      "version": "0.0.24",
+      "version": "0.0.25",
       "dependencies": {
         "een-api-toolkit": "file:../..",
         "pinia": "^3.0.4",
@@ -14,7 +14,7 @@
         "vue-router": "^4.2.0"
       },
       "devDependencies": {
-        "@playwright/test": "^1.57.0",
+        "@playwright/test": "1.58.0",
         "@vitejs/plugin-vue": "^6.0.0",
         "dotenv": "^17.2.3",
         "typescript": "~5.8.0",
@@ -23,11 +23,15 @@
       }
     },
     "../..": {
-      "version": "0.3.5",
+      "version": "0.3.34",
       "license": "MIT",
+      "bin": {
+        "een-setup-agents": "scripts/setup-agents.ts"
+      },
       "devDependencies": {
+        "@eslint/js": "^9.39.2",
         "@marp-team/marp-cli": "^4.2.3",
-        "@playwright/test": "^1.57.0",
+        "@playwright/test": "1.58.0",
         "@types/node": "^25.0.3",
         "@typescript-eslint/eslint-plugin": "^8.51.0",
         "@typescript-eslint/parser": "^8.51.0",
@@ -48,6 +52,7 @@
         "vite-plugin-dts": "^4.5.4",
         "vitest": "^4.0.16",
         "vue": "^3.4.0",
+        "vue-eslint-parser": "^10.2.0",
         "vue-tsc": "^3.2.1"
       },
       "engines": {
@@ -553,13 +558,13 @@
       "license": "MIT"
     },
     "node_modules/@playwright/test": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
-      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.0.tgz",
+      "integrity": "sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.57.0"
+        "playwright": "1.58.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1350,13 +1355,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.0.tgz",
+      "integrity": "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.57.0"
+        "playwright-core": "1.58.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1369,9 +1374,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.0.tgz",
+      "integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/examples/vue-users/package.json
+++ b/examples/vue-users/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit-example",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "private": true,
   "type": "module",
   "scripts": {
@@ -18,7 +18,7 @@
     "vue-router": "^4.2.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.57.0",
+    "@playwright/test": "1.58.0",
     "@vitejs/plugin-vue": "^6.0.0",
     "dotenv": "^17.2.3",
     "typescript": "~5.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,20 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.34",
+  "version": "0.3.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit",
-      "version": "0.3.34",
+      "version": "0.3.35",
       "license": "MIT",
+      "bin": {
+        "een-setup-agents": "scripts/setup-agents.ts"
+      },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
         "@marp-team/marp-cli": "^4.2.3",
-        "@playwright/test": "^1.57.0",
+        "@playwright/test": "1.58.0",
         "@types/node": "^25.0.3",
         "@typescript-eslint/eslint-plugin": "^8.51.0",
         "@typescript-eslint/parser": "^8.51.0",
@@ -1346,13 +1349,13 @@
       "license": "MIT"
     },
     "node_modules/@playwright/test": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
-      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.0.tgz",
+      "integrity": "sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.57.0"
+        "playwright": "1.58.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -5130,13 +5133,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.0.tgz",
+      "integrity": "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.57.0"
+        "playwright-core": "1.58.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -5149,9 +5152,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.0.tgz",
+      "integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.34",
+  "version": "0.3.35",
   "description": "EEN Video platform API v3.0 library for Vue 3",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.2",
     "@marp-team/marp-cli": "^4.2.3",
-    "@playwright/test": "^1.57.0",
+    "@playwright/test": "1.58.0",
     "@types/node": "^25.0.3",
     "@typescript-eslint/eslint-plugin": "^8.51.0",
     "@typescript-eslint/parser": "^8.51.0",


### PR DESCRIPTION
## Summary

- Pin Playwright to exact version 1.58.0 across all packages (root + 9 examples)
- Regenerate all package-lock.json files for consistency
- Update docs-accuracy-reviewer agent to check ALL example READMEs
- Fix een-devices-agent with correct CameraStatus/BridgeStatus values

## Why

CI workflow was failing due to Playwright version mismatch:
- Some examples had 1.57.0, others had 1.58.0
- Browser build versions differed (1200 vs 1208)
- Tests failed with "Executable doesn't exist" error

## Changes

| Package | Before | After |
|---------|--------|-------|
| Root | ^1.57.0 | 1.58.0 |
| All 9 examples | ^1.57.0 | 1.58.0 |

Version: **0.3.35**

## Test Results

- **Unit tests**: 378 passed
- **E2E tests**: 137 passed across 9 example apps
  - vue-alerts-metrics: 20 passed
  - vue-bridges: 13 passed
  - vue-cameras: 13 passed
  - vue-event-subscriptions: 15 passed
  - vue-events: 16 passed
  - vue-feeds: 12 passed
  - vue-layouts: 14 passed
  - vue-media: 20 passed
  - vue-users: 14 passed

🤖 Generated with [Claude Code](https://claude.ai/code)