### PR TITLE
fix: UTC timezone for datetime test and include examples in version bump

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -9,8 +9,9 @@
 #   - src/**/* and e2e/**/* (source and test files)
 #   - .claude/agents/**/* and .claude/skills/**/* (AI agents and skills)
 #   - docs/**/* (documentation included in npm package)
+#   - examples/**/* (example applications)
 #   - README.md (documentation included in npm package)
-if git diff --cached --name-only | grep -qE "^(src|e2e|\.claude/agents|\.claude/skills|docs)/|^README\.md$"; then
+if git diff --cached --name-only | grep -qE "^(src|e2e|\.claude/agents|\.claude/skills|docs|examples)/|^README\.md$"; then
     echo "Incrementing main package version..."
 
     # Increment patch version

--- a/docs/AI-CONTEXT.md
+++ b/docs/AI-CONTEXT.md
@@ -1,6 +1,6 @@
 # EEN API Toolkit - AI Reference
 
-> **Version:** 0.3.35
+> **Version:** 0.3.37
 >
 > This documentation is optimized for AI assistants. It provides focused, domain-specific
 > references to help you understand and use the een-api-toolkit efficiently.

--- a/docs/ai-reference/AI-AUTH.md
+++ b/docs/ai-reference/AI-AUTH.md
@@ -1,6 +1,6 @@
 # Authentication - EEN API Toolkit
 
-> **Version:** 0.3.35
+> **Version:** 0.3.37
 >
 > OAuth flow implementation, token management, and session handling.
 > Load this document when implementing login, logout, or auth guards.

--- a/docs/ai-reference/AI-DEVICES.md
+++ b/docs/ai-reference/AI-DEVICES.md
@@ -1,6 +1,6 @@
 # Cameras & Bridges API - EEN API Toolkit
 
-> **Version:** 0.3.35
+> **Version:** 0.3.37
 >
 > Complete reference for camera and bridge management.
 > Load this document when working with devices.

--- a/docs/ai-reference/AI-EVENTS.md
+++ b/docs/ai-reference/AI-EVENTS.md
@@ -1,6 +1,6 @@
 # Events, Alerts & Real-Time Streaming - EEN API Toolkit
 
-> **Version:** 0.3.35
+> **Version:** 0.3.37
 >
 > Complete reference for events, alerts, metrics, and SSE subscriptions.
 > Load this document when implementing event-driven features.

--- a/docs/ai-reference/AI-MEDIA.md
+++ b/docs/ai-reference/AI-MEDIA.md
@@ -1,6 +1,6 @@
 # Media & Live Video - EEN API Toolkit
 
-> **Version:** 0.3.35
+> **Version:** 0.3.37
 >
 > Complete reference for media retrieval, live streaming, and video playback.
 > Load this document when implementing video features.

--- a/docs/ai-reference/AI-SETUP.md
+++ b/docs/ai-reference/AI-SETUP.md
@@ -1,6 +1,6 @@
 # Vue 3 Application Setup - EEN API Toolkit
 
-> **Version:** 0.3.35
+> **Version:** 0.3.37
 >
 > Complete guide for setting up a Vue 3 application with the een-api-toolkit.
 > Load this document when creating a new project or troubleshooting setup issues.

--- a/docs/ai-reference/AI-USERS.md
+++ b/docs/ai-reference/AI-USERS.md
@@ -1,6 +1,6 @@
 # Users API - EEN API Toolkit
 
-> **Version:** 0.3.35
+> **Version:** 0.3.37
 >
 > Complete reference for user management.
 > Load this document when working with user data.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,8 +1,8 @@
-**EEN API Toolkit v0.3.35**
+**EEN API Toolkit v0.3.37**
 
 ***
 
-# EEN API Toolkit v0.3.35
+# EEN API Toolkit v0.3.37
 
 ## Interfaces
 

--- a/docs/api/functions/connectToEventSubscription.md
+++ b/docs/api/functions/connectToEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/createEventSubscription.md
+++ b/docs/api/functions/createEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/createLayout.md
+++ b/docs/api/functions/createLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteEventSubscription.md
+++ b/docs/api/functions/deleteEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteLayout.md
+++ b/docs/api/functions/deleteLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/formatTimestamp.md
+++ b/docs/api/functions/formatTimestamp.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAccessToken.md
+++ b/docs/api/functions/getAccessToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlert.md
+++ b/docs/api/functions/getAlert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAuthUrl.md
+++ b/docs/api/functions/getAuthUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridge.md
+++ b/docs/api/functions/getBridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridges.md
+++ b/docs/api/functions/getBridges.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCamera.md
+++ b/docs/api/functions/getCamera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameras.md
+++ b/docs/api/functions/getCameras.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/getClientId.md
+++ b/docs/api/functions/getClientId.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/getConfig.md
+++ b/docs/api/functions/getConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCurrentUser.md
+++ b/docs/api/functions/getCurrentUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEvent.md
+++ b/docs/api/functions/getEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventMetrics.md
+++ b/docs/api/functions/getEventMetrics.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventSubscription.md
+++ b/docs/api/functions/getEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayout.md
+++ b/docs/api/functions/getLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayouts.md
+++ b/docs/api/functions/getLayouts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLiveImage.md
+++ b/docs/api/functions/getLiveImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/getMediaSession.md
+++ b/docs/api/functions/getMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/getNotification.md
+++ b/docs/api/functions/getNotification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/getProxyUrl.md
+++ b/docs/api/functions/getProxyUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRecordedImage.md
+++ b/docs/api/functions/getRecordedImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRedirectUri.md
+++ b/docs/api/functions/getRedirectUri.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/getStorageStrategy.md
+++ b/docs/api/functions/getStorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUser.md
+++ b/docs/api/functions/getUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUsers.md
+++ b/docs/api/functions/getUsers.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/handleAuthCallback.md
+++ b/docs/api/functions/handleAuthCallback.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/initEenToolkit.md
+++ b/docs/api/functions/initEenToolkit.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/initMediaSession.md
+++ b/docs/api/functions/initMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertTypes.md
+++ b/docs/api/functions/listAlertTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlerts.md
+++ b/docs/api/functions/listAlerts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventFieldValues.md
+++ b/docs/api/functions/listEventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventSubscriptions.md
+++ b/docs/api/functions/listEventSubscriptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventTypes.md
+++ b/docs/api/functions/listEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEvents.md
+++ b/docs/api/functions/listEvents.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/listFeeds.md
+++ b/docs/api/functions/listFeeds.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/listMedia.md
+++ b/docs/api/functions/listMedia.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/listNotifications.md
+++ b/docs/api/functions/listNotifications.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/refreshToken.md
+++ b/docs/api/functions/refreshToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/revokeToken.md
+++ b/docs/api/functions/revokeToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/functions/updateLayout.md
+++ b/docs/api/functions/updateLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Alert.md
+++ b/docs/api/interfaces/Alert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertAction.md
+++ b/docs/api/interfaces/AlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertType.md
+++ b/docs/api/interfaces/AlertType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Bridge.md
+++ b/docs/api/interfaces/Bridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDeviceInfo.md
+++ b/docs/api/interfaces/BridgeDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDevicePosition.md
+++ b/docs/api/interfaces/BridgeDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeNetworkInfo.md
+++ b/docs/api/interfaces/BridgeNetworkInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Camera.md
+++ b/docs/api/interfaces/Camera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDeviceInfo.md
+++ b/docs/api/interfaces/CameraDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDevicePosition.md
+++ b/docs/api/interfaces/CameraDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRecordingModes.md
+++ b/docs/api/interfaces/CameraRecordingModes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRtspConnectionSettings.md
+++ b/docs/api/interfaces/CameraRtspConnectionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraShareDetails.md
+++ b/docs/api/interfaces/CameraShareDetails.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStatusCounts.md
+++ b/docs/api/interfaces/CameraStatusCounts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStreamUrls.md
+++ b/docs/api/interfaces/CameraStreamUrls.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateEventSubscriptionParams.md
+++ b/docs/api/interfaces/CreateEventSubscriptionParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateLayoutParams.md
+++ b/docs/api/interfaces/CreateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenError.md
+++ b/docs/api/interfaces/EenError.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenToolkitConfig.md
+++ b/docs/api/interfaces/EenToolkitConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Event.md
+++ b/docs/api/interfaces/Event.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventData.md
+++ b/docs/api/interfaces/EventData.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventFieldValues.md
+++ b/docs/api/interfaces/EventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventMetric.md
+++ b/docs/api/interfaces/EventMetric.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscription.md
+++ b/docs/api/interfaces/EventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionConfig.md
+++ b/docs/api/interfaces/EventSubscriptionConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionFilter.md
+++ b/docs/api/interfaces/EventSubscriptionFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventType.md
+++ b/docs/api/interfaces/EventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventTypeFilter.md
+++ b/docs/api/interfaces/EventTypeFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Feed.md
+++ b/docs/api/interfaces/Feed.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/FilterCreate.md
+++ b/docs/api/interfaces/FilterCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetAlertParams.md
+++ b/docs/api/interfaces/GetAlertParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetBridgeParams.md
+++ b/docs/api/interfaces/GetBridgeParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetCameraParams.md
+++ b/docs/api/interfaces/GetCameraParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventMetricsParams.md
+++ b/docs/api/interfaces/GetEventMetricsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventParams.md
+++ b/docs/api/interfaces/GetEventParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLayoutParams.md
+++ b/docs/api/interfaces/GetLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLiveImageParams.md
+++ b/docs/api/interfaces/GetLiveImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetRecordedImageParams.md
+++ b/docs/api/interfaces/GetRecordedImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetUserParams.md
+++ b/docs/api/interfaces/GetUserParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Layout.md
+++ b/docs/api/interfaces/Layout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPane.md
+++ b/docs/api/interfaces/LayoutPane.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPermissions.md
+++ b/docs/api/interfaces/LayoutPermissions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutSettings.md
+++ b/docs/api/interfaces/LayoutSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertTypesParams.md
+++ b/docs/api/interfaces/ListAlertTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertsParams.md
+++ b/docs/api/interfaces/ListAlertsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListBridgesParams.md
+++ b/docs/api/interfaces/ListBridgesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListCamerasParams.md
+++ b/docs/api/interfaces/ListCamerasParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventFieldValuesParams.md
+++ b/docs/api/interfaces/ListEventFieldValuesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventSubscriptionsParams.md
+++ b/docs/api/interfaces/ListEventSubscriptionsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventTypesParams.md
+++ b/docs/api/interfaces/ListEventTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventsParams.md
+++ b/docs/api/interfaces/ListEventsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsParams.md
+++ b/docs/api/interfaces/ListFeedsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsResult.md
+++ b/docs/api/interfaces/ListFeedsResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListLayoutsParams.md
+++ b/docs/api/interfaces/ListLayoutsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListMediaParams.md
+++ b/docs/api/interfaces/ListMediaParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListNotificationsParams.md
+++ b/docs/api/interfaces/ListNotificationsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListUsersParams.md
+++ b/docs/api/interfaces/ListUsersParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LiveImageResult.md
+++ b/docs/api/interfaces/LiveImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaInterval.md
+++ b/docs/api/interfaces/MediaInterval.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResponse.md
+++ b/docs/api/interfaces/MediaSessionResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResult.md
+++ b/docs/api/interfaces/MediaSessionResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Notification.md
+++ b/docs/api/interfaces/Notification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginatedResult.md
+++ b/docs/api/interfaces/PaginatedResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginationParams.md
+++ b/docs/api/interfaces/PaginationParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/RecordedImageResult.md
+++ b/docs/api/interfaces/RecordedImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnection.md
+++ b/docs/api/interfaces/SSEConnection.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnectionOptions.md
+++ b/docs/api/interfaces/SSEConnectionOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfig.md
+++ b/docs/api/interfaces/SSEDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfigCreate.md
+++ b/docs/api/interfaces/SSEDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEEvent.md
+++ b/docs/api/interfaces/SSEEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/TokenResponse.md
+++ b/docs/api/interfaces/TokenResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UpdateLayoutParams.md
+++ b/docs/api/interfaces/UpdateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/User.md
+++ b/docs/api/interfaces/User.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UserProfile.md
+++ b/docs/api/interfaces/UserProfile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfig.md
+++ b/docs/api/interfaces/WebhookDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfigCreate.md
+++ b/docs/api/interfaces/WebhookDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ActorType.md
+++ b/docs/api/type-aliases/ActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionStatus.md
+++ b/docs/api/type-aliases/AlertActionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertInclude.md
+++ b/docs/api/type-aliases/AlertInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertSort.md
+++ b/docs/api/type-aliases/AlertSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/BridgeStatus.md
+++ b/docs/api/type-aliases/BridgeStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraAspectRatio.md
+++ b/docs/api/type-aliases/CameraAspectRatio.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraStatus.md
+++ b/docs/api/type-aliases/CameraStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfig.md
+++ b/docs/api/type-aliases/DeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfigCreate.md
+++ b/docs/api/type-aliases/DeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ErrorCode.md
+++ b/docs/api/type-aliases/ErrorCode.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionDeliveryType.md
+++ b/docs/api/type-aliases/EventSubscriptionDeliveryType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionLifecycle.md
+++ b/docs/api/type-aliases/EventSubscriptionLifecycle.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedIncludeOption.md
+++ b/docs/api/type-aliases/FeedIncludeOption.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedMediaType.md
+++ b/docs/api/type-aliases/FeedMediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedStreamType.md
+++ b/docs/api/type-aliases/FeedStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/GetLayoutInclude.md
+++ b/docs/api/type-aliases/GetLayoutInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneSize.md
+++ b/docs/api/type-aliases/LayoutPaneSize.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneType.md
+++ b/docs/api/type-aliases/LayoutPaneType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsInclude.md
+++ b/docs/api/type-aliases/ListLayoutsInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsSort.md
+++ b/docs/api/type-aliases/ListLayoutsSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaStreamType.md
+++ b/docs/api/type-aliases/MediaStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaType.md
+++ b/docs/api/type-aliases/MediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricActorType.md
+++ b/docs/api/type-aliases/MetricActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricDataPoint.md
+++ b/docs/api/type-aliases/MetricDataPoint.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationCategory.md
+++ b/docs/api/type-aliases/NotificationCategory.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationStatus.md
+++ b/docs/api/type-aliases/NotificationStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/Result.md
+++ b/docs/api/type-aliases/Result.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/SSEConnectionStatus.md
+++ b/docs/api/type-aliases/SSEConnectionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/StorageStrategy.md
+++ b/docs/api/type-aliases/StorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
+++ b/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/docs/api/variables/useAuthStore.md
+++ b/docs/api/variables/useAuthStore.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.35**](../README.md)
+[**EEN API Toolkit v0.3.37**](../README.md)
 
 ***
 

--- a/examples/vue-media/e2e/auth.spec.ts
+++ b/examples/vue-media/e2e/auth.spec.ts
@@ -134,10 +134,6 @@ test.describe('Vue Media Example - Auth', () => {
     test.skip(!TEST_USER || !TEST_PASSWORD, 'Test credentials not available')
   }
 
-  function skipIfCI() {
-    test.skip(Boolean(process.env.CI), 'Skipped in CI - timezone-dependent test')
-  }
-
   test.beforeAll(async () => {
     proxyAccessible = await isProxyAccessible()
     if (!proxyAccessible) {
@@ -344,7 +340,26 @@ test.describe('Vue Media Example - Auth', () => {
   test('datetime selection persists between recorded and video pages', async ({ page }) => {
     skipIfNoProxy()
     skipIfNoCredentials()
-    skipIfCI() // Timezone differences between CI and local cause flaky failures
+
+    // Force browser to use UTC timezone for consistent behavior across CI and local environments
+    await page.addInitScript(() => {
+      const OriginalDate = Date
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(window as any).Date = class extends OriginalDate {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        constructor(...args: any[]) {
+          if (args.length === 0) {
+            super()
+          } else {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            super(...(args as [any]))
+          }
+        }
+        getTimezoneOffset() {
+          return 0 // UTC
+        }
+      }
+    })
 
     await performLogin(page, TEST_USER!, TEST_PASSWORD!)
     await expect(page.getByTestId('nav-recorded')).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.35",
+  "version": "0.3.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit",
-      "version": "0.3.35",
+      "version": "0.3.37",
       "license": "MIT",
       "bin": {
         "een-setup-agents": "scripts/setup-agents.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.35",
+  "version": "0.3.37",
   "description": "EEN Video platform API v3.0 library for Vue 3",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary
- Force UTC timezone in datetime persistence test for consistent CI/local behavior
- Include examples folder in Husky version bump trigger

## Changes
- `3641923` fix: Force UTC timezone in datetime persistence test for CI consistency
- `3a40255` chore: Include examples folder in version bump trigger
- `0a99fb8` chore: Bump version to 0.3.37

## Details

### UTC Timezone Fix
Instead of skipping the datetime persistence test in CI, the browser is now forced to use UTC timezone by overriding `Date.getTimezoneOffset()` via Playwright's `addInitScript`. This ensures consistent behavior across CI (UTC) and local development environments.

Addresses issue #76.

### Husky Update
Changes to `examples/**/*` now trigger a package version increment, ensuring example app updates are properly versioned.

## Version
`0.3.37`

🤖 Generated with [Claude Code](https://claude.ai/code)