### PR TITLE
feat: Session persistence with authStore.initialize() and comprehensive tests

### DIFF
--- a/.claude/agents/een-auth-agent.md
+++ b/.claude/agents/een-auth-agent.md
@@ -122,6 +122,32 @@ authStore.isAuthenticated // Computed: true if valid token exists
 authStore.isExpired      // Computed: true if token expired
 ```
 
+### authStore.initialize() - Session Restoration (CRITICAL)
+**Must be called in App.vue onMounted to restore sessions from storage.**
+
+Without this call, users must re-login after every page refresh, even with localStorage strategy:
+
+```vue
+<script setup lang="ts">
+import { onMounted, computed } from 'vue'
+import { useAuthStore } from 'een-api-toolkit'
+
+const authStore = useAuthStore()
+const isAuthenticated = computed(() => authStore.isAuthenticated)
+
+// CRITICAL: Restore session from storage on app mount
+onMounted(() => {
+  authStore.initialize()
+})
+</script>
+```
+
+What `initialize()` does:
+1. Loads token, expiration, session ID, base URL from storage
+2. If valid token exists: Sets up auto-refresh timer
+3. If expired token: Clears auth state (user must re-login)
+4. If no token: No action (user must login)
+
 ## Auth Guard Pattern
 
 **CRITICAL**: The OAuth callback check MUST come BEFORE the auth check in the global guard.
@@ -297,3 +323,5 @@ async function clearAuthState(page: Page): Promise<void> {
 | invalid_grant | Code expired or reused | Restart OAuth flow |
 | invalid_state | State mismatch | Clear storage, restart flow |
 | REFRESH_FAILED | Refresh token invalid | Redirect to login |
+| Session lost on refresh | Missing initialize() call | Add `authStore.initialize()` in App.vue onMounted |
+| Must login after refresh | Missing initialize() call | Add `authStore.initialize()` in App.vue onMounted |

--- a/.claude/agents/een-events-agent.md
+++ b/.claude/agents/een-events-agent.md
@@ -269,12 +269,20 @@ async function fetchNotifications() {
 
 ## SSE (Server-Sent Events) for Real-Time Updates
 
+### SSE Subscription Behavior
+
+**Important: TTL is read-only and server-determined**
+- SSE subscriptions have a **15-minute TTL** (900 seconds) set by the server
+- The `timeToLiveSeconds` value **cannot be customized** when creating a subscription
+- The `subscriptionConfig` (including `lifeCycle` and `timeToLiveSeconds`) is returned in the API response but is not a configurable input
+- SSE URLs are **single-use**: once disconnected, you must create a new subscription
+
 ### SSE Lifecycle
 
-1. **Create Subscription** - Get a subscription with SSE URL
+1. **Create Subscription** - Get a subscription with SSE URL (server sets 15-min TTL)
 2. **Connect to Stream** - Open EventSource connection
 3. **Handle Events** - Process events as they arrive
-4. **Cleanup** - Delete subscription when done
+4. **Cleanup** - Delete subscription when done (or it auto-expires after 15 min of inactivity)
 
 ### createEventSubscription()
 ```typescript

--- a/.claude/agents/een-setup-agent.md
+++ b/.claude/agents/een-setup-agent.md
@@ -74,6 +74,35 @@ app.use(router)
 app.mount('#app')
 ```
 
+### App.vue Session Restoration (CRITICAL)
+**Users will need to re-login after every page refresh unless you call `authStore.initialize()` in App.vue.**
+
+```vue
+<script setup lang="ts">
+import { onMounted, computed } from 'vue'
+import { useAuthStore } from 'een-api-toolkit'
+
+const authStore = useAuthStore()
+const isAuthenticated = computed(() => authStore.isAuthenticated)
+
+// CRITICAL: Initialize auth store from storage on app mount
+// This restores the session if a valid token exists in localStorage/sessionStorage
+onMounted(() => {
+  authStore.initialize()
+})
+</script>
+```
+
+Without `initialize()`:
+- Token is saved to localStorage after login ✓
+- On page refresh, Pinia store starts with empty state
+- `isAuthenticated` returns false → user must login again
+
+With `initialize()`:
+- Token is loaded from localStorage on app mount
+- `isAuthenticated` returns true → session is restored
+- User can continue without re-logging in
+
 ### vite.config.ts for EEN OAuth
 ```typescript
 import { defineConfig } from 'vite'
@@ -115,6 +144,7 @@ export default router
 - Pinia must be installed before initEenToolkit()
 - Never add trailing slashes to redirect URIs
 - Ensure VITE_PROXY_URL is set in .env file
+- **Always call `authStore.initialize()` in App.vue onMounted** for session persistence
 
 ## Common Errors and Solutions
 
@@ -124,3 +154,5 @@ export default router
 | "redirect_uri mismatch" | Wrong host/port | Use 127.0.0.1:3333 in vite.config.ts |
 | "Invalid redirect_uri" | Trailing slash | Remove trailing slash from redirect URI |
 | "CORS error" | Proxy not running | Start the OAuth proxy server |
+| Session lost on refresh | Missing initialize() call | Add `authStore.initialize()` in App.vue onMounted |
+| Must login after refresh | Missing initialize() call | Add `authStore.initialize()` in App.vue onMounted |

--- a/docs/AI-CONTEXT.md
+++ b/docs/AI-CONTEXT.md
@@ -1,6 +1,6 @@
 # EEN API Toolkit - AI Reference
 
-> **Version:** 0.3.39
+> **Version:** 0.3.40
 >
 > This documentation is optimized for AI assistants. It provides focused, domain-specific
 > references to help you understand and use the een-api-toolkit efficiently.

--- a/docs/AI-CONTEXT.md
+++ b/docs/AI-CONTEXT.md
@@ -1,6 +1,6 @@
 # EEN API Toolkit - AI Reference
 
-> **Version:** 0.3.40
+> **Version:** 0.3.41
 >
 > This documentation is optimized for AI assistants. It provides focused, domain-specific
 > references to help you understand and use the een-api-toolkit efficiently.

--- a/docs/AI-CONTEXT.md
+++ b/docs/AI-CONTEXT.md
@@ -1,6 +1,6 @@
 # EEN API Toolkit - AI Reference
 
-> **Version:** 0.3.38
+> **Version:** 0.3.39
 >
 > This documentation is optimized for AI assistants. It provides focused, domain-specific
 > references to help you understand and use the een-api-toolkit efficiently.

--- a/docs/AI-CONTEXT.md
+++ b/docs/AI-CONTEXT.md
@@ -1,6 +1,6 @@
 # EEN API Toolkit - AI Reference
 
-> **Version:** 0.3.41
+> **Version:** 0.3.42
 >
 > This documentation is optimized for AI assistants. It provides focused, domain-specific
 > references to help you understand and use the een-api-toolkit efficiently.

--- a/docs/AI-CONTEXT.md
+++ b/docs/AI-CONTEXT.md
@@ -1,6 +1,6 @@
 # EEN API Toolkit - AI Reference
 
-> **Version:** 0.3.42
+> **Version:** 0.3.43
 >
 > This documentation is optimized for AI assistants. It provides focused, domain-specific
 > references to help you understand and use the een-api-toolkit efficiently.

--- a/docs/ai-reference/AI-AUTH.md
+++ b/docs/ai-reference/AI-AUTH.md
@@ -1,6 +1,6 @@
 # Authentication - EEN API Toolkit
 
-> **Version:** 0.3.42
+> **Version:** 0.3.43
 >
 > OAuth flow implementation, token management, and session handling.
 > Load this document when implementing login, logout, or auth guards.

--- a/docs/ai-reference/AI-AUTH.md
+++ b/docs/ai-reference/AI-AUTH.md
@@ -1,6 +1,6 @@
 # Authentication - EEN API Toolkit
 
-> **Version:** 0.3.41
+> **Version:** 0.3.42
 >
 > OAuth flow implementation, token management, and session handling.
 > Load this document when implementing login, logout, or auth guards.

--- a/docs/ai-reference/AI-AUTH.md
+++ b/docs/ai-reference/AI-AUTH.md
@@ -1,6 +1,6 @@
 # Authentication - EEN API Toolkit
 
-> **Version:** 0.3.40
+> **Version:** 0.3.41
 >
 > OAuth flow implementation, token management, and session handling.
 > Load this document when implementing login, logout, or auth guards.
@@ -95,6 +95,47 @@ authStore.token            // Access token (or null)
 authStore.baseUrl          // EEN API base URL (e.g., https://c001.eagleeyenetworks.com)
 authStore.sessionId        // Session identifier
 ```
+
+---
+
+## Session Persistence (IMPORTANT)
+
+**To restore sessions from storage on page load, you must call `authStore.initialize()` in your App.vue.**
+
+Without this call, users will need to log in again after every page refresh, even with `localStorage` strategy.
+
+### App.vue Setup
+
+```vue
+<script setup lang="ts">
+import { onMounted, computed } from 'vue'
+import { useAuthStore } from 'een-api-toolkit'
+
+const authStore = useAuthStore()
+const isAuthenticated = computed(() => authStore.isAuthenticated)
+
+// CRITICAL: Initialize auth store from storage on app mount
+// This restores the session if a valid token exists in localStorage/sessionStorage
+onMounted(() => {
+  authStore.initialize()
+})
+</script>
+```
+
+### What initialize() Does
+
+1. Loads token, expiration, session ID, and base URL from configured storage
+2. If token exists and is **not expired**: Sets up auto-refresh timer
+3. If token exists but **is expired**: Clears auth state (user must re-login)
+4. If no token: No action (user must login)
+
+### Storage Strategy Behavior
+
+| Strategy | Persists Across Refresh? | Requires initialize()? |
+|----------|-------------------------|------------------------|
+| `localStorage` | Yes | Yes |
+| `sessionStorage` | Yes (within tab) | Yes |
+| `memory` | No | No (always requires re-login) |
 
 ---
 

--- a/docs/ai-reference/AI-AUTH.md
+++ b/docs/ai-reference/AI-AUTH.md
@@ -1,6 +1,6 @@
 # Authentication - EEN API Toolkit
 
-> **Version:** 0.3.38
+> **Version:** 0.3.39
 >
 > OAuth flow implementation, token management, and session handling.
 > Load this document when implementing login, logout, or auth guards.

--- a/docs/ai-reference/AI-AUTH.md
+++ b/docs/ai-reference/AI-AUTH.md
@@ -1,6 +1,6 @@
 # Authentication - EEN API Toolkit
 
-> **Version:** 0.3.39
+> **Version:** 0.3.40
 >
 > OAuth flow implementation, token management, and session handling.
 > Load this document when implementing login, logout, or auth guards.

--- a/docs/ai-reference/AI-DEVICES.md
+++ b/docs/ai-reference/AI-DEVICES.md
@@ -1,6 +1,6 @@
 # Cameras & Bridges API - EEN API Toolkit
 
-> **Version:** 0.3.38
+> **Version:** 0.3.39
 >
 > Complete reference for camera and bridge management.
 > Load this document when working with devices.

--- a/docs/ai-reference/AI-DEVICES.md
+++ b/docs/ai-reference/AI-DEVICES.md
@@ -1,6 +1,6 @@
 # Cameras & Bridges API - EEN API Toolkit
 
-> **Version:** 0.3.40
+> **Version:** 0.3.41
 >
 > Complete reference for camera and bridge management.
 > Load this document when working with devices.

--- a/docs/ai-reference/AI-DEVICES.md
+++ b/docs/ai-reference/AI-DEVICES.md
@@ -1,6 +1,6 @@
 # Cameras & Bridges API - EEN API Toolkit
 
-> **Version:** 0.3.39
+> **Version:** 0.3.40
 >
 > Complete reference for camera and bridge management.
 > Load this document when working with devices.

--- a/docs/ai-reference/AI-DEVICES.md
+++ b/docs/ai-reference/AI-DEVICES.md
@@ -1,6 +1,6 @@
 # Cameras & Bridges API - EEN API Toolkit
 
-> **Version:** 0.3.41
+> **Version:** 0.3.42
 >
 > Complete reference for camera and bridge management.
 > Load this document when working with devices.

--- a/docs/ai-reference/AI-DEVICES.md
+++ b/docs/ai-reference/AI-DEVICES.md
@@ -1,6 +1,6 @@
 # Cameras & Bridges API - EEN API Toolkit
 
-> **Version:** 0.3.42
+> **Version:** 0.3.43
 >
 > Complete reference for camera and bridge management.
 > Load this document when working with devices.

--- a/docs/ai-reference/AI-EVENTS.md
+++ b/docs/ai-reference/AI-EVENTS.md
@@ -1,6 +1,6 @@
 # Events, Alerts & Real-Time Streaming - EEN API Toolkit
 
-> **Version:** 0.3.38
+> **Version:** 0.3.39
 >
 > Complete reference for events, alerts, metrics, and SSE subscriptions.
 > Load this document when implementing event-driven features.
@@ -1632,7 +1632,7 @@ watch(selectedSubscriptionId, (newId) => {
       <ul class="warning-list">
         <li>SSE URLs are single-use. Once disconnected, the subscription cannot be reconnected.</li>
         <li>To receive events again after disconnecting, create a new subscription.</li>
-        <li>Subscriptions have a 15-minute TTL and expire if not connected.</li>
+        <li>SSE subscriptions have a server-determined 15-minute TTL (not configurable) and expire if not connected.</li>
       </ul>
     </div>
 

--- a/docs/ai-reference/AI-EVENTS.md
+++ b/docs/ai-reference/AI-EVENTS.md
@@ -1,6 +1,6 @@
 # Events, Alerts & Real-Time Streaming - EEN API Toolkit
 
-> **Version:** 0.3.42
+> **Version:** 0.3.43
 >
 > Complete reference for events, alerts, metrics, and SSE subscriptions.
 > Load this document when implementing event-driven features.

--- a/docs/ai-reference/AI-EVENTS.md
+++ b/docs/ai-reference/AI-EVENTS.md
@@ -1,6 +1,6 @@
 # Events, Alerts & Real-Time Streaming - EEN API Toolkit
 
-> **Version:** 0.3.40
+> **Version:** 0.3.41
 >
 > Complete reference for events, alerts, metrics, and SSE subscriptions.
 > Load this document when implementing event-driven features.

--- a/docs/ai-reference/AI-EVENTS.md
+++ b/docs/ai-reference/AI-EVENTS.md
@@ -1,6 +1,6 @@
 # Events, Alerts & Real-Time Streaming - EEN API Toolkit
 
-> **Version:** 0.3.41
+> **Version:** 0.3.42
 >
 > Complete reference for events, alerts, metrics, and SSE subscriptions.
 > Load this document when implementing event-driven features.

--- a/docs/ai-reference/AI-EVENTS.md
+++ b/docs/ai-reference/AI-EVENTS.md
@@ -1,6 +1,6 @@
 # Events, Alerts & Real-Time Streaming - EEN API Toolkit
 
-> **Version:** 0.3.39
+> **Version:** 0.3.40
 >
 > Complete reference for events, alerts, metrics, and SSE subscriptions.
 > Load this document when implementing event-driven features.

--- a/docs/ai-reference/AI-MEDIA.md
+++ b/docs/ai-reference/AI-MEDIA.md
@@ -1,6 +1,6 @@
 # Media & Live Video - EEN API Toolkit
 
-> **Version:** 0.3.39
+> **Version:** 0.3.40
 >
 > Complete reference for media retrieval, live streaming, and video playback.
 > Load this document when implementing video features.

--- a/docs/ai-reference/AI-MEDIA.md
+++ b/docs/ai-reference/AI-MEDIA.md
@@ -1,6 +1,6 @@
 # Media & Live Video - EEN API Toolkit
 
-> **Version:** 0.3.41
+> **Version:** 0.3.42
 >
 > Complete reference for media retrieval, live streaming, and video playback.
 > Load this document when implementing video features.

--- a/docs/ai-reference/AI-MEDIA.md
+++ b/docs/ai-reference/AI-MEDIA.md
@@ -1,6 +1,6 @@
 # Media & Live Video - EEN API Toolkit
 
-> **Version:** 0.3.42
+> **Version:** 0.3.43
 >
 > Complete reference for media retrieval, live streaming, and video playback.
 > Load this document when implementing video features.

--- a/docs/ai-reference/AI-MEDIA.md
+++ b/docs/ai-reference/AI-MEDIA.md
@@ -1,6 +1,6 @@
 # Media & Live Video - EEN API Toolkit
 
-> **Version:** 0.3.40
+> **Version:** 0.3.41
 >
 > Complete reference for media retrieval, live streaming, and video playback.
 > Load this document when implementing video features.

--- a/docs/ai-reference/AI-MEDIA.md
+++ b/docs/ai-reference/AI-MEDIA.md
@@ -1,6 +1,6 @@
 # Media & Live Video - EEN API Toolkit
 
-> **Version:** 0.3.38
+> **Version:** 0.3.39
 >
 > Complete reference for media retrieval, live streaming, and video playback.
 > Load this document when implementing video features.

--- a/docs/ai-reference/AI-SETUP.md
+++ b/docs/ai-reference/AI-SETUP.md
@@ -1,6 +1,6 @@
 # Vue 3 Application Setup - EEN API Toolkit
 
-> **Version:** 0.3.40
+> **Version:** 0.3.41
 >
 > Complete guide for setting up a Vue 3 application with the een-api-toolkit.
 > Load this document when creating a new project or troubleshooting setup issues.

--- a/docs/ai-reference/AI-SETUP.md
+++ b/docs/ai-reference/AI-SETUP.md
@@ -1,6 +1,6 @@
 # Vue 3 Application Setup - EEN API Toolkit
 
-> **Version:** 0.3.42
+> **Version:** 0.3.43
 >
 > Complete guide for setting up a Vue 3 application with the een-api-toolkit.
 > Load this document when creating a new project or troubleshooting setup issues.

--- a/docs/ai-reference/AI-SETUP.md
+++ b/docs/ai-reference/AI-SETUP.md
@@ -1,6 +1,6 @@
 # Vue 3 Application Setup - EEN API Toolkit
 
-> **Version:** 0.3.38
+> **Version:** 0.3.39
 >
 > Complete guide for setting up a Vue 3 application with the een-api-toolkit.
 > Load this document when creating a new project or troubleshooting setup issues.

--- a/docs/ai-reference/AI-SETUP.md
+++ b/docs/ai-reference/AI-SETUP.md
@@ -1,6 +1,6 @@
 # Vue 3 Application Setup - EEN API Toolkit
 
-> **Version:** 0.3.41
+> **Version:** 0.3.42
 >
 > Complete guide for setting up a Vue 3 application with the een-api-toolkit.
 > Load this document when creating a new project or troubleshooting setup issues.

--- a/docs/ai-reference/AI-SETUP.md
+++ b/docs/ai-reference/AI-SETUP.md
@@ -1,6 +1,6 @@
 # Vue 3 Application Setup - EEN API Toolkit
 
-> **Version:** 0.3.39
+> **Version:** 0.3.40
 >
 > Complete guide for setting up a Vue 3 application with the een-api-toolkit.
 > Load this document when creating a new project or troubleshooting setup issues.

--- a/docs/ai-reference/AI-USERS.md
+++ b/docs/ai-reference/AI-USERS.md
@@ -1,6 +1,6 @@
 # Users API - EEN API Toolkit
 
-> **Version:** 0.3.40
+> **Version:** 0.3.41
 >
 > Complete reference for user management.
 > Load this document when working with user data.

--- a/docs/ai-reference/AI-USERS.md
+++ b/docs/ai-reference/AI-USERS.md
@@ -1,6 +1,6 @@
 # Users API - EEN API Toolkit
 
-> **Version:** 0.3.38
+> **Version:** 0.3.39
 >
 > Complete reference for user management.
 > Load this document when working with user data.

--- a/docs/ai-reference/AI-USERS.md
+++ b/docs/ai-reference/AI-USERS.md
@@ -1,6 +1,6 @@
 # Users API - EEN API Toolkit
 
-> **Version:** 0.3.41
+> **Version:** 0.3.42
 >
 > Complete reference for user management.
 > Load this document when working with user data.

--- a/docs/ai-reference/AI-USERS.md
+++ b/docs/ai-reference/AI-USERS.md
@@ -1,6 +1,6 @@
 # Users API - EEN API Toolkit
 
-> **Version:** 0.3.42
+> **Version:** 0.3.43
 >
 > Complete reference for user management.
 > Load this document when working with user data.

--- a/docs/ai-reference/AI-USERS.md
+++ b/docs/ai-reference/AI-USERS.md
@@ -1,6 +1,6 @@
 # Users API - EEN API Toolkit
 
-> **Version:** 0.3.39
+> **Version:** 0.3.40
 >
 > Complete reference for user management.
 > Load this document when working with user data.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,8 +1,8 @@
-**EEN API Toolkit v0.3.38**
+**EEN API Toolkit v0.3.39**
 
 ***
 
-# EEN API Toolkit v0.3.38
+# EEN API Toolkit v0.3.39
 
 ## Interfaces
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,8 +1,8 @@
-**EEN API Toolkit v0.3.42**
+**EEN API Toolkit v0.3.43**
 
 ***
 
-# EEN API Toolkit v0.3.42
+# EEN API Toolkit v0.3.43
 
 ## Interfaces
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,8 +1,8 @@
-**EEN API Toolkit v0.3.40**
+**EEN API Toolkit v0.3.41**
 
 ***
 
-# EEN API Toolkit v0.3.40
+# EEN API Toolkit v0.3.41
 
 ## Interfaces
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,8 +1,8 @@
-**EEN API Toolkit v0.3.39**
+**EEN API Toolkit v0.3.40**
 
 ***
 
-# EEN API Toolkit v0.3.39
+# EEN API Toolkit v0.3.40
 
 ## Interfaces
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,8 +1,8 @@
-**EEN API Toolkit v0.3.41**
+**EEN API Toolkit v0.3.42**
 
 ***
 
-# EEN API Toolkit v0.3.41
+# EEN API Toolkit v0.3.42
 
 ## Interfaces
 

--- a/docs/api/functions/connectToEventSubscription.md
+++ b/docs/api/functions/connectToEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/connectToEventSubscription.md
+++ b/docs/api/functions/connectToEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/connectToEventSubscription.md
+++ b/docs/api/functions/connectToEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/connectToEventSubscription.md
+++ b/docs/api/functions/connectToEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/connectToEventSubscription.md
+++ b/docs/api/functions/connectToEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/createEventSubscription.md
+++ b/docs/api/functions/createEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/createEventSubscription.md
+++ b/docs/api/functions/createEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/createEventSubscription.md
+++ b/docs/api/functions/createEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/createEventSubscription.md
+++ b/docs/api/functions/createEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/createEventSubscription.md
+++ b/docs/api/functions/createEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/createLayout.md
+++ b/docs/api/functions/createLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/createLayout.md
+++ b/docs/api/functions/createLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/createLayout.md
+++ b/docs/api/functions/createLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/createLayout.md
+++ b/docs/api/functions/createLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/createLayout.md
+++ b/docs/api/functions/createLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteEventSubscription.md
+++ b/docs/api/functions/deleteEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteEventSubscription.md
+++ b/docs/api/functions/deleteEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteEventSubscription.md
+++ b/docs/api/functions/deleteEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteEventSubscription.md
+++ b/docs/api/functions/deleteEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteEventSubscription.md
+++ b/docs/api/functions/deleteEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteLayout.md
+++ b/docs/api/functions/deleteLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteLayout.md
+++ b/docs/api/functions/deleteLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteLayout.md
+++ b/docs/api/functions/deleteLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteLayout.md
+++ b/docs/api/functions/deleteLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteLayout.md
+++ b/docs/api/functions/deleteLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/formatTimestamp.md
+++ b/docs/api/functions/formatTimestamp.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/formatTimestamp.md
+++ b/docs/api/functions/formatTimestamp.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/formatTimestamp.md
+++ b/docs/api/functions/formatTimestamp.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/formatTimestamp.md
+++ b/docs/api/functions/formatTimestamp.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/formatTimestamp.md
+++ b/docs/api/functions/formatTimestamp.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAccessToken.md
+++ b/docs/api/functions/getAccessToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAccessToken.md
+++ b/docs/api/functions/getAccessToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAccessToken.md
+++ b/docs/api/functions/getAccessToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAccessToken.md
+++ b/docs/api/functions/getAccessToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAccessToken.md
+++ b/docs/api/functions/getAccessToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlert.md
+++ b/docs/api/functions/getAlert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlert.md
+++ b/docs/api/functions/getAlert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlert.md
+++ b/docs/api/functions/getAlert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlert.md
+++ b/docs/api/functions/getAlert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlert.md
+++ b/docs/api/functions/getAlert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAuthUrl.md
+++ b/docs/api/functions/getAuthUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAuthUrl.md
+++ b/docs/api/functions/getAuthUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAuthUrl.md
+++ b/docs/api/functions/getAuthUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAuthUrl.md
+++ b/docs/api/functions/getAuthUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAuthUrl.md
+++ b/docs/api/functions/getAuthUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridge.md
+++ b/docs/api/functions/getBridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridge.md
+++ b/docs/api/functions/getBridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridge.md
+++ b/docs/api/functions/getBridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridge.md
+++ b/docs/api/functions/getBridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridge.md
+++ b/docs/api/functions/getBridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridges.md
+++ b/docs/api/functions/getBridges.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridges.md
+++ b/docs/api/functions/getBridges.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridges.md
+++ b/docs/api/functions/getBridges.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridges.md
+++ b/docs/api/functions/getBridges.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridges.md
+++ b/docs/api/functions/getBridges.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCamera.md
+++ b/docs/api/functions/getCamera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCamera.md
+++ b/docs/api/functions/getCamera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCamera.md
+++ b/docs/api/functions/getCamera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCamera.md
+++ b/docs/api/functions/getCamera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCamera.md
+++ b/docs/api/functions/getCamera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameras.md
+++ b/docs/api/functions/getCameras.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameras.md
+++ b/docs/api/functions/getCameras.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameras.md
+++ b/docs/api/functions/getCameras.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameras.md
+++ b/docs/api/functions/getCameras.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameras.md
+++ b/docs/api/functions/getCameras.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/getClientId.md
+++ b/docs/api/functions/getClientId.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/getClientId.md
+++ b/docs/api/functions/getClientId.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/getClientId.md
+++ b/docs/api/functions/getClientId.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/getClientId.md
+++ b/docs/api/functions/getClientId.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/getClientId.md
+++ b/docs/api/functions/getClientId.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/getConfig.md
+++ b/docs/api/functions/getConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/getConfig.md
+++ b/docs/api/functions/getConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/getConfig.md
+++ b/docs/api/functions/getConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/getConfig.md
+++ b/docs/api/functions/getConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/getConfig.md
+++ b/docs/api/functions/getConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCurrentUser.md
+++ b/docs/api/functions/getCurrentUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCurrentUser.md
+++ b/docs/api/functions/getCurrentUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCurrentUser.md
+++ b/docs/api/functions/getCurrentUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCurrentUser.md
+++ b/docs/api/functions/getCurrentUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCurrentUser.md
+++ b/docs/api/functions/getCurrentUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEvent.md
+++ b/docs/api/functions/getEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEvent.md
+++ b/docs/api/functions/getEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEvent.md
+++ b/docs/api/functions/getEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEvent.md
+++ b/docs/api/functions/getEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEvent.md
+++ b/docs/api/functions/getEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventMetrics.md
+++ b/docs/api/functions/getEventMetrics.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventMetrics.md
+++ b/docs/api/functions/getEventMetrics.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventMetrics.md
+++ b/docs/api/functions/getEventMetrics.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventMetrics.md
+++ b/docs/api/functions/getEventMetrics.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventMetrics.md
+++ b/docs/api/functions/getEventMetrics.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventSubscription.md
+++ b/docs/api/functions/getEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventSubscription.md
+++ b/docs/api/functions/getEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventSubscription.md
+++ b/docs/api/functions/getEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventSubscription.md
+++ b/docs/api/functions/getEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventSubscription.md
+++ b/docs/api/functions/getEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayout.md
+++ b/docs/api/functions/getLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayout.md
+++ b/docs/api/functions/getLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayout.md
+++ b/docs/api/functions/getLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayout.md
+++ b/docs/api/functions/getLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayout.md
+++ b/docs/api/functions/getLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayouts.md
+++ b/docs/api/functions/getLayouts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayouts.md
+++ b/docs/api/functions/getLayouts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayouts.md
+++ b/docs/api/functions/getLayouts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayouts.md
+++ b/docs/api/functions/getLayouts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayouts.md
+++ b/docs/api/functions/getLayouts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLiveImage.md
+++ b/docs/api/functions/getLiveImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLiveImage.md
+++ b/docs/api/functions/getLiveImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLiveImage.md
+++ b/docs/api/functions/getLiveImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLiveImage.md
+++ b/docs/api/functions/getLiveImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLiveImage.md
+++ b/docs/api/functions/getLiveImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/getMediaSession.md
+++ b/docs/api/functions/getMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/getMediaSession.md
+++ b/docs/api/functions/getMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/getMediaSession.md
+++ b/docs/api/functions/getMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/getMediaSession.md
+++ b/docs/api/functions/getMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/getMediaSession.md
+++ b/docs/api/functions/getMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/getNotification.md
+++ b/docs/api/functions/getNotification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/getNotification.md
+++ b/docs/api/functions/getNotification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/getNotification.md
+++ b/docs/api/functions/getNotification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/getNotification.md
+++ b/docs/api/functions/getNotification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/getNotification.md
+++ b/docs/api/functions/getNotification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/getProxyUrl.md
+++ b/docs/api/functions/getProxyUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/getProxyUrl.md
+++ b/docs/api/functions/getProxyUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/getProxyUrl.md
+++ b/docs/api/functions/getProxyUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/getProxyUrl.md
+++ b/docs/api/functions/getProxyUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/getProxyUrl.md
+++ b/docs/api/functions/getProxyUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRecordedImage.md
+++ b/docs/api/functions/getRecordedImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRecordedImage.md
+++ b/docs/api/functions/getRecordedImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRecordedImage.md
+++ b/docs/api/functions/getRecordedImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRecordedImage.md
+++ b/docs/api/functions/getRecordedImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRecordedImage.md
+++ b/docs/api/functions/getRecordedImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRedirectUri.md
+++ b/docs/api/functions/getRedirectUri.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRedirectUri.md
+++ b/docs/api/functions/getRedirectUri.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRedirectUri.md
+++ b/docs/api/functions/getRedirectUri.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRedirectUri.md
+++ b/docs/api/functions/getRedirectUri.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRedirectUri.md
+++ b/docs/api/functions/getRedirectUri.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/getStorageStrategy.md
+++ b/docs/api/functions/getStorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/getStorageStrategy.md
+++ b/docs/api/functions/getStorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/getStorageStrategy.md
+++ b/docs/api/functions/getStorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/getStorageStrategy.md
+++ b/docs/api/functions/getStorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/getStorageStrategy.md
+++ b/docs/api/functions/getStorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUser.md
+++ b/docs/api/functions/getUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUser.md
+++ b/docs/api/functions/getUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUser.md
+++ b/docs/api/functions/getUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUser.md
+++ b/docs/api/functions/getUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUser.md
+++ b/docs/api/functions/getUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUsers.md
+++ b/docs/api/functions/getUsers.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUsers.md
+++ b/docs/api/functions/getUsers.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUsers.md
+++ b/docs/api/functions/getUsers.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUsers.md
+++ b/docs/api/functions/getUsers.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUsers.md
+++ b/docs/api/functions/getUsers.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/handleAuthCallback.md
+++ b/docs/api/functions/handleAuthCallback.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/handleAuthCallback.md
+++ b/docs/api/functions/handleAuthCallback.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/handleAuthCallback.md
+++ b/docs/api/functions/handleAuthCallback.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/handleAuthCallback.md
+++ b/docs/api/functions/handleAuthCallback.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/handleAuthCallback.md
+++ b/docs/api/functions/handleAuthCallback.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/initEenToolkit.md
+++ b/docs/api/functions/initEenToolkit.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/initEenToolkit.md
+++ b/docs/api/functions/initEenToolkit.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/initEenToolkit.md
+++ b/docs/api/functions/initEenToolkit.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/initEenToolkit.md
+++ b/docs/api/functions/initEenToolkit.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/initEenToolkit.md
+++ b/docs/api/functions/initEenToolkit.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/initMediaSession.md
+++ b/docs/api/functions/initMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/initMediaSession.md
+++ b/docs/api/functions/initMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/initMediaSession.md
+++ b/docs/api/functions/initMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/initMediaSession.md
+++ b/docs/api/functions/initMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/initMediaSession.md
+++ b/docs/api/functions/initMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertTypes.md
+++ b/docs/api/functions/listAlertTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertTypes.md
+++ b/docs/api/functions/listAlertTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertTypes.md
+++ b/docs/api/functions/listAlertTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertTypes.md
+++ b/docs/api/functions/listAlertTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertTypes.md
+++ b/docs/api/functions/listAlertTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlerts.md
+++ b/docs/api/functions/listAlerts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlerts.md
+++ b/docs/api/functions/listAlerts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlerts.md
+++ b/docs/api/functions/listAlerts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlerts.md
+++ b/docs/api/functions/listAlerts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlerts.md
+++ b/docs/api/functions/listAlerts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventFieldValues.md
+++ b/docs/api/functions/listEventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventFieldValues.md
+++ b/docs/api/functions/listEventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventFieldValues.md
+++ b/docs/api/functions/listEventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventFieldValues.md
+++ b/docs/api/functions/listEventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventFieldValues.md
+++ b/docs/api/functions/listEventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventSubscriptions.md
+++ b/docs/api/functions/listEventSubscriptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventSubscriptions.md
+++ b/docs/api/functions/listEventSubscriptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventSubscriptions.md
+++ b/docs/api/functions/listEventSubscriptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventSubscriptions.md
+++ b/docs/api/functions/listEventSubscriptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventSubscriptions.md
+++ b/docs/api/functions/listEventSubscriptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventTypes.md
+++ b/docs/api/functions/listEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventTypes.md
+++ b/docs/api/functions/listEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventTypes.md
+++ b/docs/api/functions/listEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventTypes.md
+++ b/docs/api/functions/listEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventTypes.md
+++ b/docs/api/functions/listEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEvents.md
+++ b/docs/api/functions/listEvents.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEvents.md
+++ b/docs/api/functions/listEvents.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEvents.md
+++ b/docs/api/functions/listEvents.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEvents.md
+++ b/docs/api/functions/listEvents.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEvents.md
+++ b/docs/api/functions/listEvents.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/listFeeds.md
+++ b/docs/api/functions/listFeeds.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/listFeeds.md
+++ b/docs/api/functions/listFeeds.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/listFeeds.md
+++ b/docs/api/functions/listFeeds.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/listFeeds.md
+++ b/docs/api/functions/listFeeds.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/listFeeds.md
+++ b/docs/api/functions/listFeeds.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/listMedia.md
+++ b/docs/api/functions/listMedia.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/listMedia.md
+++ b/docs/api/functions/listMedia.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/listMedia.md
+++ b/docs/api/functions/listMedia.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/listMedia.md
+++ b/docs/api/functions/listMedia.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/listMedia.md
+++ b/docs/api/functions/listMedia.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/listNotifications.md
+++ b/docs/api/functions/listNotifications.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/listNotifications.md
+++ b/docs/api/functions/listNotifications.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/listNotifications.md
+++ b/docs/api/functions/listNotifications.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/listNotifications.md
+++ b/docs/api/functions/listNotifications.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/listNotifications.md
+++ b/docs/api/functions/listNotifications.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/refreshToken.md
+++ b/docs/api/functions/refreshToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/refreshToken.md
+++ b/docs/api/functions/refreshToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/refreshToken.md
+++ b/docs/api/functions/refreshToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/refreshToken.md
+++ b/docs/api/functions/refreshToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/refreshToken.md
+++ b/docs/api/functions/refreshToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/revokeToken.md
+++ b/docs/api/functions/revokeToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/revokeToken.md
+++ b/docs/api/functions/revokeToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/revokeToken.md
+++ b/docs/api/functions/revokeToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/revokeToken.md
+++ b/docs/api/functions/revokeToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/revokeToken.md
+++ b/docs/api/functions/revokeToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/functions/updateLayout.md
+++ b/docs/api/functions/updateLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/functions/updateLayout.md
+++ b/docs/api/functions/updateLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/functions/updateLayout.md
+++ b/docs/api/functions/updateLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/functions/updateLayout.md
+++ b/docs/api/functions/updateLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/functions/updateLayout.md
+++ b/docs/api/functions/updateLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Alert.md
+++ b/docs/api/interfaces/Alert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Alert.md
+++ b/docs/api/interfaces/Alert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Alert.md
+++ b/docs/api/interfaces/Alert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Alert.md
+++ b/docs/api/interfaces/Alert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Alert.md
+++ b/docs/api/interfaces/Alert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertAction.md
+++ b/docs/api/interfaces/AlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertAction.md
+++ b/docs/api/interfaces/AlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertAction.md
+++ b/docs/api/interfaces/AlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertAction.md
+++ b/docs/api/interfaces/AlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertAction.md
+++ b/docs/api/interfaces/AlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertType.md
+++ b/docs/api/interfaces/AlertType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertType.md
+++ b/docs/api/interfaces/AlertType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertType.md
+++ b/docs/api/interfaces/AlertType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertType.md
+++ b/docs/api/interfaces/AlertType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertType.md
+++ b/docs/api/interfaces/AlertType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Bridge.md
+++ b/docs/api/interfaces/Bridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Bridge.md
+++ b/docs/api/interfaces/Bridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Bridge.md
+++ b/docs/api/interfaces/Bridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Bridge.md
+++ b/docs/api/interfaces/Bridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Bridge.md
+++ b/docs/api/interfaces/Bridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDeviceInfo.md
+++ b/docs/api/interfaces/BridgeDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDeviceInfo.md
+++ b/docs/api/interfaces/BridgeDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDeviceInfo.md
+++ b/docs/api/interfaces/BridgeDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDeviceInfo.md
+++ b/docs/api/interfaces/BridgeDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDeviceInfo.md
+++ b/docs/api/interfaces/BridgeDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDevicePosition.md
+++ b/docs/api/interfaces/BridgeDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDevicePosition.md
+++ b/docs/api/interfaces/BridgeDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDevicePosition.md
+++ b/docs/api/interfaces/BridgeDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDevicePosition.md
+++ b/docs/api/interfaces/BridgeDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDevicePosition.md
+++ b/docs/api/interfaces/BridgeDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeNetworkInfo.md
+++ b/docs/api/interfaces/BridgeNetworkInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeNetworkInfo.md
+++ b/docs/api/interfaces/BridgeNetworkInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeNetworkInfo.md
+++ b/docs/api/interfaces/BridgeNetworkInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeNetworkInfo.md
+++ b/docs/api/interfaces/BridgeNetworkInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeNetworkInfo.md
+++ b/docs/api/interfaces/BridgeNetworkInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Camera.md
+++ b/docs/api/interfaces/Camera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Camera.md
+++ b/docs/api/interfaces/Camera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Camera.md
+++ b/docs/api/interfaces/Camera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Camera.md
+++ b/docs/api/interfaces/Camera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Camera.md
+++ b/docs/api/interfaces/Camera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDeviceInfo.md
+++ b/docs/api/interfaces/CameraDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDeviceInfo.md
+++ b/docs/api/interfaces/CameraDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDeviceInfo.md
+++ b/docs/api/interfaces/CameraDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDeviceInfo.md
+++ b/docs/api/interfaces/CameraDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDeviceInfo.md
+++ b/docs/api/interfaces/CameraDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDevicePosition.md
+++ b/docs/api/interfaces/CameraDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDevicePosition.md
+++ b/docs/api/interfaces/CameraDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDevicePosition.md
+++ b/docs/api/interfaces/CameraDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDevicePosition.md
+++ b/docs/api/interfaces/CameraDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDevicePosition.md
+++ b/docs/api/interfaces/CameraDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRecordingModes.md
+++ b/docs/api/interfaces/CameraRecordingModes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRecordingModes.md
+++ b/docs/api/interfaces/CameraRecordingModes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRecordingModes.md
+++ b/docs/api/interfaces/CameraRecordingModes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRecordingModes.md
+++ b/docs/api/interfaces/CameraRecordingModes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRecordingModes.md
+++ b/docs/api/interfaces/CameraRecordingModes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRtspConnectionSettings.md
+++ b/docs/api/interfaces/CameraRtspConnectionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRtspConnectionSettings.md
+++ b/docs/api/interfaces/CameraRtspConnectionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRtspConnectionSettings.md
+++ b/docs/api/interfaces/CameraRtspConnectionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRtspConnectionSettings.md
+++ b/docs/api/interfaces/CameraRtspConnectionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRtspConnectionSettings.md
+++ b/docs/api/interfaces/CameraRtspConnectionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraShareDetails.md
+++ b/docs/api/interfaces/CameraShareDetails.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraShareDetails.md
+++ b/docs/api/interfaces/CameraShareDetails.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraShareDetails.md
+++ b/docs/api/interfaces/CameraShareDetails.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraShareDetails.md
+++ b/docs/api/interfaces/CameraShareDetails.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraShareDetails.md
+++ b/docs/api/interfaces/CameraShareDetails.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStatusCounts.md
+++ b/docs/api/interfaces/CameraStatusCounts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStatusCounts.md
+++ b/docs/api/interfaces/CameraStatusCounts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStatusCounts.md
+++ b/docs/api/interfaces/CameraStatusCounts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStatusCounts.md
+++ b/docs/api/interfaces/CameraStatusCounts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStatusCounts.md
+++ b/docs/api/interfaces/CameraStatusCounts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStreamUrls.md
+++ b/docs/api/interfaces/CameraStreamUrls.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStreamUrls.md
+++ b/docs/api/interfaces/CameraStreamUrls.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStreamUrls.md
+++ b/docs/api/interfaces/CameraStreamUrls.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStreamUrls.md
+++ b/docs/api/interfaces/CameraStreamUrls.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStreamUrls.md
+++ b/docs/api/interfaces/CameraStreamUrls.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateEventSubscriptionParams.md
+++ b/docs/api/interfaces/CreateEventSubscriptionParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateEventSubscriptionParams.md
+++ b/docs/api/interfaces/CreateEventSubscriptionParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateEventSubscriptionParams.md
+++ b/docs/api/interfaces/CreateEventSubscriptionParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateEventSubscriptionParams.md
+++ b/docs/api/interfaces/CreateEventSubscriptionParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateEventSubscriptionParams.md
+++ b/docs/api/interfaces/CreateEventSubscriptionParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateLayoutParams.md
+++ b/docs/api/interfaces/CreateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateLayoutParams.md
+++ b/docs/api/interfaces/CreateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateLayoutParams.md
+++ b/docs/api/interfaces/CreateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateLayoutParams.md
+++ b/docs/api/interfaces/CreateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateLayoutParams.md
+++ b/docs/api/interfaces/CreateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenError.md
+++ b/docs/api/interfaces/EenError.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenError.md
+++ b/docs/api/interfaces/EenError.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenError.md
+++ b/docs/api/interfaces/EenError.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenError.md
+++ b/docs/api/interfaces/EenError.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenError.md
+++ b/docs/api/interfaces/EenError.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenToolkitConfig.md
+++ b/docs/api/interfaces/EenToolkitConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenToolkitConfig.md
+++ b/docs/api/interfaces/EenToolkitConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenToolkitConfig.md
+++ b/docs/api/interfaces/EenToolkitConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenToolkitConfig.md
+++ b/docs/api/interfaces/EenToolkitConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenToolkitConfig.md
+++ b/docs/api/interfaces/EenToolkitConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Event.md
+++ b/docs/api/interfaces/Event.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Event.md
+++ b/docs/api/interfaces/Event.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Event.md
+++ b/docs/api/interfaces/Event.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Event.md
+++ b/docs/api/interfaces/Event.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Event.md
+++ b/docs/api/interfaces/Event.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventData.md
+++ b/docs/api/interfaces/EventData.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventData.md
+++ b/docs/api/interfaces/EventData.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventData.md
+++ b/docs/api/interfaces/EventData.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventData.md
+++ b/docs/api/interfaces/EventData.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventData.md
+++ b/docs/api/interfaces/EventData.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventFieldValues.md
+++ b/docs/api/interfaces/EventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventFieldValues.md
+++ b/docs/api/interfaces/EventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventFieldValues.md
+++ b/docs/api/interfaces/EventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventFieldValues.md
+++ b/docs/api/interfaces/EventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventFieldValues.md
+++ b/docs/api/interfaces/EventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventMetric.md
+++ b/docs/api/interfaces/EventMetric.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventMetric.md
+++ b/docs/api/interfaces/EventMetric.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventMetric.md
+++ b/docs/api/interfaces/EventMetric.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventMetric.md
+++ b/docs/api/interfaces/EventMetric.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventMetric.md
+++ b/docs/api/interfaces/EventMetric.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscription.md
+++ b/docs/api/interfaces/EventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscription.md
+++ b/docs/api/interfaces/EventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscription.md
+++ b/docs/api/interfaces/EventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscription.md
+++ b/docs/api/interfaces/EventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscription.md
+++ b/docs/api/interfaces/EventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionConfig.md
+++ b/docs/api/interfaces/EventSubscriptionConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionConfig.md
+++ b/docs/api/interfaces/EventSubscriptionConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionConfig.md
+++ b/docs/api/interfaces/EventSubscriptionConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionConfig.md
+++ b/docs/api/interfaces/EventSubscriptionConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionConfig.md
+++ b/docs/api/interfaces/EventSubscriptionConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionFilter.md
+++ b/docs/api/interfaces/EventSubscriptionFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionFilter.md
+++ b/docs/api/interfaces/EventSubscriptionFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionFilter.md
+++ b/docs/api/interfaces/EventSubscriptionFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionFilter.md
+++ b/docs/api/interfaces/EventSubscriptionFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionFilter.md
+++ b/docs/api/interfaces/EventSubscriptionFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventType.md
+++ b/docs/api/interfaces/EventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventType.md
+++ b/docs/api/interfaces/EventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventType.md
+++ b/docs/api/interfaces/EventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventType.md
+++ b/docs/api/interfaces/EventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventType.md
+++ b/docs/api/interfaces/EventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventTypeFilter.md
+++ b/docs/api/interfaces/EventTypeFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventTypeFilter.md
+++ b/docs/api/interfaces/EventTypeFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventTypeFilter.md
+++ b/docs/api/interfaces/EventTypeFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventTypeFilter.md
+++ b/docs/api/interfaces/EventTypeFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventTypeFilter.md
+++ b/docs/api/interfaces/EventTypeFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Feed.md
+++ b/docs/api/interfaces/Feed.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Feed.md
+++ b/docs/api/interfaces/Feed.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Feed.md
+++ b/docs/api/interfaces/Feed.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Feed.md
+++ b/docs/api/interfaces/Feed.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Feed.md
+++ b/docs/api/interfaces/Feed.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/FilterCreate.md
+++ b/docs/api/interfaces/FilterCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/FilterCreate.md
+++ b/docs/api/interfaces/FilterCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/FilterCreate.md
+++ b/docs/api/interfaces/FilterCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/FilterCreate.md
+++ b/docs/api/interfaces/FilterCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/FilterCreate.md
+++ b/docs/api/interfaces/FilterCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetAlertParams.md
+++ b/docs/api/interfaces/GetAlertParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetAlertParams.md
+++ b/docs/api/interfaces/GetAlertParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetAlertParams.md
+++ b/docs/api/interfaces/GetAlertParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetAlertParams.md
+++ b/docs/api/interfaces/GetAlertParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetAlertParams.md
+++ b/docs/api/interfaces/GetAlertParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetBridgeParams.md
+++ b/docs/api/interfaces/GetBridgeParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetBridgeParams.md
+++ b/docs/api/interfaces/GetBridgeParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetBridgeParams.md
+++ b/docs/api/interfaces/GetBridgeParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetBridgeParams.md
+++ b/docs/api/interfaces/GetBridgeParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetBridgeParams.md
+++ b/docs/api/interfaces/GetBridgeParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetCameraParams.md
+++ b/docs/api/interfaces/GetCameraParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetCameraParams.md
+++ b/docs/api/interfaces/GetCameraParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetCameraParams.md
+++ b/docs/api/interfaces/GetCameraParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetCameraParams.md
+++ b/docs/api/interfaces/GetCameraParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetCameraParams.md
+++ b/docs/api/interfaces/GetCameraParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventMetricsParams.md
+++ b/docs/api/interfaces/GetEventMetricsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventMetricsParams.md
+++ b/docs/api/interfaces/GetEventMetricsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventMetricsParams.md
+++ b/docs/api/interfaces/GetEventMetricsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventMetricsParams.md
+++ b/docs/api/interfaces/GetEventMetricsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventMetricsParams.md
+++ b/docs/api/interfaces/GetEventMetricsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventParams.md
+++ b/docs/api/interfaces/GetEventParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventParams.md
+++ b/docs/api/interfaces/GetEventParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventParams.md
+++ b/docs/api/interfaces/GetEventParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventParams.md
+++ b/docs/api/interfaces/GetEventParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventParams.md
+++ b/docs/api/interfaces/GetEventParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLayoutParams.md
+++ b/docs/api/interfaces/GetLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLayoutParams.md
+++ b/docs/api/interfaces/GetLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLayoutParams.md
+++ b/docs/api/interfaces/GetLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLayoutParams.md
+++ b/docs/api/interfaces/GetLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLayoutParams.md
+++ b/docs/api/interfaces/GetLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLiveImageParams.md
+++ b/docs/api/interfaces/GetLiveImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLiveImageParams.md
+++ b/docs/api/interfaces/GetLiveImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLiveImageParams.md
+++ b/docs/api/interfaces/GetLiveImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLiveImageParams.md
+++ b/docs/api/interfaces/GetLiveImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLiveImageParams.md
+++ b/docs/api/interfaces/GetLiveImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetRecordedImageParams.md
+++ b/docs/api/interfaces/GetRecordedImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetRecordedImageParams.md
+++ b/docs/api/interfaces/GetRecordedImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetRecordedImageParams.md
+++ b/docs/api/interfaces/GetRecordedImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetRecordedImageParams.md
+++ b/docs/api/interfaces/GetRecordedImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetRecordedImageParams.md
+++ b/docs/api/interfaces/GetRecordedImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetUserParams.md
+++ b/docs/api/interfaces/GetUserParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetUserParams.md
+++ b/docs/api/interfaces/GetUserParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetUserParams.md
+++ b/docs/api/interfaces/GetUserParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetUserParams.md
+++ b/docs/api/interfaces/GetUserParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetUserParams.md
+++ b/docs/api/interfaces/GetUserParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Layout.md
+++ b/docs/api/interfaces/Layout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Layout.md
+++ b/docs/api/interfaces/Layout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Layout.md
+++ b/docs/api/interfaces/Layout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Layout.md
+++ b/docs/api/interfaces/Layout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Layout.md
+++ b/docs/api/interfaces/Layout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPane.md
+++ b/docs/api/interfaces/LayoutPane.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPane.md
+++ b/docs/api/interfaces/LayoutPane.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPane.md
+++ b/docs/api/interfaces/LayoutPane.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPane.md
+++ b/docs/api/interfaces/LayoutPane.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPane.md
+++ b/docs/api/interfaces/LayoutPane.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPermissions.md
+++ b/docs/api/interfaces/LayoutPermissions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPermissions.md
+++ b/docs/api/interfaces/LayoutPermissions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPermissions.md
+++ b/docs/api/interfaces/LayoutPermissions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPermissions.md
+++ b/docs/api/interfaces/LayoutPermissions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPermissions.md
+++ b/docs/api/interfaces/LayoutPermissions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutSettings.md
+++ b/docs/api/interfaces/LayoutSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutSettings.md
+++ b/docs/api/interfaces/LayoutSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutSettings.md
+++ b/docs/api/interfaces/LayoutSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutSettings.md
+++ b/docs/api/interfaces/LayoutSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutSettings.md
+++ b/docs/api/interfaces/LayoutSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertTypesParams.md
+++ b/docs/api/interfaces/ListAlertTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertTypesParams.md
+++ b/docs/api/interfaces/ListAlertTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertTypesParams.md
+++ b/docs/api/interfaces/ListAlertTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertTypesParams.md
+++ b/docs/api/interfaces/ListAlertTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertTypesParams.md
+++ b/docs/api/interfaces/ListAlertTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertsParams.md
+++ b/docs/api/interfaces/ListAlertsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertsParams.md
+++ b/docs/api/interfaces/ListAlertsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertsParams.md
+++ b/docs/api/interfaces/ListAlertsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertsParams.md
+++ b/docs/api/interfaces/ListAlertsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertsParams.md
+++ b/docs/api/interfaces/ListAlertsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListBridgesParams.md
+++ b/docs/api/interfaces/ListBridgesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListBridgesParams.md
+++ b/docs/api/interfaces/ListBridgesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListBridgesParams.md
+++ b/docs/api/interfaces/ListBridgesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListBridgesParams.md
+++ b/docs/api/interfaces/ListBridgesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListBridgesParams.md
+++ b/docs/api/interfaces/ListBridgesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListCamerasParams.md
+++ b/docs/api/interfaces/ListCamerasParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListCamerasParams.md
+++ b/docs/api/interfaces/ListCamerasParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListCamerasParams.md
+++ b/docs/api/interfaces/ListCamerasParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListCamerasParams.md
+++ b/docs/api/interfaces/ListCamerasParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListCamerasParams.md
+++ b/docs/api/interfaces/ListCamerasParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventFieldValuesParams.md
+++ b/docs/api/interfaces/ListEventFieldValuesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventFieldValuesParams.md
+++ b/docs/api/interfaces/ListEventFieldValuesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventFieldValuesParams.md
+++ b/docs/api/interfaces/ListEventFieldValuesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventFieldValuesParams.md
+++ b/docs/api/interfaces/ListEventFieldValuesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventFieldValuesParams.md
+++ b/docs/api/interfaces/ListEventFieldValuesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventSubscriptionsParams.md
+++ b/docs/api/interfaces/ListEventSubscriptionsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventSubscriptionsParams.md
+++ b/docs/api/interfaces/ListEventSubscriptionsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventSubscriptionsParams.md
+++ b/docs/api/interfaces/ListEventSubscriptionsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventSubscriptionsParams.md
+++ b/docs/api/interfaces/ListEventSubscriptionsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventSubscriptionsParams.md
+++ b/docs/api/interfaces/ListEventSubscriptionsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventTypesParams.md
+++ b/docs/api/interfaces/ListEventTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventTypesParams.md
+++ b/docs/api/interfaces/ListEventTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventTypesParams.md
+++ b/docs/api/interfaces/ListEventTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventTypesParams.md
+++ b/docs/api/interfaces/ListEventTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventTypesParams.md
+++ b/docs/api/interfaces/ListEventTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventsParams.md
+++ b/docs/api/interfaces/ListEventsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventsParams.md
+++ b/docs/api/interfaces/ListEventsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventsParams.md
+++ b/docs/api/interfaces/ListEventsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventsParams.md
+++ b/docs/api/interfaces/ListEventsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventsParams.md
+++ b/docs/api/interfaces/ListEventsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsParams.md
+++ b/docs/api/interfaces/ListFeedsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsParams.md
+++ b/docs/api/interfaces/ListFeedsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsParams.md
+++ b/docs/api/interfaces/ListFeedsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsParams.md
+++ b/docs/api/interfaces/ListFeedsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsParams.md
+++ b/docs/api/interfaces/ListFeedsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsResult.md
+++ b/docs/api/interfaces/ListFeedsResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsResult.md
+++ b/docs/api/interfaces/ListFeedsResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsResult.md
+++ b/docs/api/interfaces/ListFeedsResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsResult.md
+++ b/docs/api/interfaces/ListFeedsResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsResult.md
+++ b/docs/api/interfaces/ListFeedsResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListLayoutsParams.md
+++ b/docs/api/interfaces/ListLayoutsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListLayoutsParams.md
+++ b/docs/api/interfaces/ListLayoutsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListLayoutsParams.md
+++ b/docs/api/interfaces/ListLayoutsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListLayoutsParams.md
+++ b/docs/api/interfaces/ListLayoutsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListLayoutsParams.md
+++ b/docs/api/interfaces/ListLayoutsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListMediaParams.md
+++ b/docs/api/interfaces/ListMediaParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListMediaParams.md
+++ b/docs/api/interfaces/ListMediaParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListMediaParams.md
+++ b/docs/api/interfaces/ListMediaParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListMediaParams.md
+++ b/docs/api/interfaces/ListMediaParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListMediaParams.md
+++ b/docs/api/interfaces/ListMediaParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListNotificationsParams.md
+++ b/docs/api/interfaces/ListNotificationsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListNotificationsParams.md
+++ b/docs/api/interfaces/ListNotificationsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListNotificationsParams.md
+++ b/docs/api/interfaces/ListNotificationsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListNotificationsParams.md
+++ b/docs/api/interfaces/ListNotificationsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListNotificationsParams.md
+++ b/docs/api/interfaces/ListNotificationsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListUsersParams.md
+++ b/docs/api/interfaces/ListUsersParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListUsersParams.md
+++ b/docs/api/interfaces/ListUsersParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListUsersParams.md
+++ b/docs/api/interfaces/ListUsersParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListUsersParams.md
+++ b/docs/api/interfaces/ListUsersParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListUsersParams.md
+++ b/docs/api/interfaces/ListUsersParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LiveImageResult.md
+++ b/docs/api/interfaces/LiveImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LiveImageResult.md
+++ b/docs/api/interfaces/LiveImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LiveImageResult.md
+++ b/docs/api/interfaces/LiveImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LiveImageResult.md
+++ b/docs/api/interfaces/LiveImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LiveImageResult.md
+++ b/docs/api/interfaces/LiveImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaInterval.md
+++ b/docs/api/interfaces/MediaInterval.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaInterval.md
+++ b/docs/api/interfaces/MediaInterval.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaInterval.md
+++ b/docs/api/interfaces/MediaInterval.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaInterval.md
+++ b/docs/api/interfaces/MediaInterval.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaInterval.md
+++ b/docs/api/interfaces/MediaInterval.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResponse.md
+++ b/docs/api/interfaces/MediaSessionResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResponse.md
+++ b/docs/api/interfaces/MediaSessionResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResponse.md
+++ b/docs/api/interfaces/MediaSessionResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResponse.md
+++ b/docs/api/interfaces/MediaSessionResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResponse.md
+++ b/docs/api/interfaces/MediaSessionResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResult.md
+++ b/docs/api/interfaces/MediaSessionResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResult.md
+++ b/docs/api/interfaces/MediaSessionResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResult.md
+++ b/docs/api/interfaces/MediaSessionResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResult.md
+++ b/docs/api/interfaces/MediaSessionResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResult.md
+++ b/docs/api/interfaces/MediaSessionResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Notification.md
+++ b/docs/api/interfaces/Notification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Notification.md
+++ b/docs/api/interfaces/Notification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Notification.md
+++ b/docs/api/interfaces/Notification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Notification.md
+++ b/docs/api/interfaces/Notification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Notification.md
+++ b/docs/api/interfaces/Notification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginatedResult.md
+++ b/docs/api/interfaces/PaginatedResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginatedResult.md
+++ b/docs/api/interfaces/PaginatedResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginatedResult.md
+++ b/docs/api/interfaces/PaginatedResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginatedResult.md
+++ b/docs/api/interfaces/PaginatedResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginatedResult.md
+++ b/docs/api/interfaces/PaginatedResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginationParams.md
+++ b/docs/api/interfaces/PaginationParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginationParams.md
+++ b/docs/api/interfaces/PaginationParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginationParams.md
+++ b/docs/api/interfaces/PaginationParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginationParams.md
+++ b/docs/api/interfaces/PaginationParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginationParams.md
+++ b/docs/api/interfaces/PaginationParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/RecordedImageResult.md
+++ b/docs/api/interfaces/RecordedImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/RecordedImageResult.md
+++ b/docs/api/interfaces/RecordedImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/RecordedImageResult.md
+++ b/docs/api/interfaces/RecordedImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/RecordedImageResult.md
+++ b/docs/api/interfaces/RecordedImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/RecordedImageResult.md
+++ b/docs/api/interfaces/RecordedImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnection.md
+++ b/docs/api/interfaces/SSEConnection.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnection.md
+++ b/docs/api/interfaces/SSEConnection.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnection.md
+++ b/docs/api/interfaces/SSEConnection.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnection.md
+++ b/docs/api/interfaces/SSEConnection.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnection.md
+++ b/docs/api/interfaces/SSEConnection.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnectionOptions.md
+++ b/docs/api/interfaces/SSEConnectionOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnectionOptions.md
+++ b/docs/api/interfaces/SSEConnectionOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnectionOptions.md
+++ b/docs/api/interfaces/SSEConnectionOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnectionOptions.md
+++ b/docs/api/interfaces/SSEConnectionOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnectionOptions.md
+++ b/docs/api/interfaces/SSEConnectionOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfig.md
+++ b/docs/api/interfaces/SSEDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfig.md
+++ b/docs/api/interfaces/SSEDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfig.md
+++ b/docs/api/interfaces/SSEDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfig.md
+++ b/docs/api/interfaces/SSEDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfig.md
+++ b/docs/api/interfaces/SSEDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfigCreate.md
+++ b/docs/api/interfaces/SSEDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfigCreate.md
+++ b/docs/api/interfaces/SSEDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfigCreate.md
+++ b/docs/api/interfaces/SSEDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfigCreate.md
+++ b/docs/api/interfaces/SSEDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfigCreate.md
+++ b/docs/api/interfaces/SSEDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEEvent.md
+++ b/docs/api/interfaces/SSEEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEEvent.md
+++ b/docs/api/interfaces/SSEEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEEvent.md
+++ b/docs/api/interfaces/SSEEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEEvent.md
+++ b/docs/api/interfaces/SSEEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEEvent.md
+++ b/docs/api/interfaces/SSEEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/TokenResponse.md
+++ b/docs/api/interfaces/TokenResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/TokenResponse.md
+++ b/docs/api/interfaces/TokenResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/TokenResponse.md
+++ b/docs/api/interfaces/TokenResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/TokenResponse.md
+++ b/docs/api/interfaces/TokenResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/TokenResponse.md
+++ b/docs/api/interfaces/TokenResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UpdateLayoutParams.md
+++ b/docs/api/interfaces/UpdateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UpdateLayoutParams.md
+++ b/docs/api/interfaces/UpdateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UpdateLayoutParams.md
+++ b/docs/api/interfaces/UpdateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UpdateLayoutParams.md
+++ b/docs/api/interfaces/UpdateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UpdateLayoutParams.md
+++ b/docs/api/interfaces/UpdateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/User.md
+++ b/docs/api/interfaces/User.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/User.md
+++ b/docs/api/interfaces/User.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/User.md
+++ b/docs/api/interfaces/User.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/User.md
+++ b/docs/api/interfaces/User.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/User.md
+++ b/docs/api/interfaces/User.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UserProfile.md
+++ b/docs/api/interfaces/UserProfile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UserProfile.md
+++ b/docs/api/interfaces/UserProfile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UserProfile.md
+++ b/docs/api/interfaces/UserProfile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UserProfile.md
+++ b/docs/api/interfaces/UserProfile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UserProfile.md
+++ b/docs/api/interfaces/UserProfile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfig.md
+++ b/docs/api/interfaces/WebhookDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfig.md
+++ b/docs/api/interfaces/WebhookDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfig.md
+++ b/docs/api/interfaces/WebhookDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfig.md
+++ b/docs/api/interfaces/WebhookDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfig.md
+++ b/docs/api/interfaces/WebhookDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfigCreate.md
+++ b/docs/api/interfaces/WebhookDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfigCreate.md
+++ b/docs/api/interfaces/WebhookDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfigCreate.md
+++ b/docs/api/interfaces/WebhookDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfigCreate.md
+++ b/docs/api/interfaces/WebhookDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfigCreate.md
+++ b/docs/api/interfaces/WebhookDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ActorType.md
+++ b/docs/api/type-aliases/ActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ActorType.md
+++ b/docs/api/type-aliases/ActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ActorType.md
+++ b/docs/api/type-aliases/ActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ActorType.md
+++ b/docs/api/type-aliases/ActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ActorType.md
+++ b/docs/api/type-aliases/ActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionStatus.md
+++ b/docs/api/type-aliases/AlertActionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionStatus.md
+++ b/docs/api/type-aliases/AlertActionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionStatus.md
+++ b/docs/api/type-aliases/AlertActionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionStatus.md
+++ b/docs/api/type-aliases/AlertActionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionStatus.md
+++ b/docs/api/type-aliases/AlertActionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertInclude.md
+++ b/docs/api/type-aliases/AlertInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertInclude.md
+++ b/docs/api/type-aliases/AlertInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertInclude.md
+++ b/docs/api/type-aliases/AlertInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertInclude.md
+++ b/docs/api/type-aliases/AlertInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertInclude.md
+++ b/docs/api/type-aliases/AlertInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertSort.md
+++ b/docs/api/type-aliases/AlertSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertSort.md
+++ b/docs/api/type-aliases/AlertSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertSort.md
+++ b/docs/api/type-aliases/AlertSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertSort.md
+++ b/docs/api/type-aliases/AlertSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertSort.md
+++ b/docs/api/type-aliases/AlertSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/BridgeStatus.md
+++ b/docs/api/type-aliases/BridgeStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/BridgeStatus.md
+++ b/docs/api/type-aliases/BridgeStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/BridgeStatus.md
+++ b/docs/api/type-aliases/BridgeStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/BridgeStatus.md
+++ b/docs/api/type-aliases/BridgeStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/BridgeStatus.md
+++ b/docs/api/type-aliases/BridgeStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraAspectRatio.md
+++ b/docs/api/type-aliases/CameraAspectRatio.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraAspectRatio.md
+++ b/docs/api/type-aliases/CameraAspectRatio.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraAspectRatio.md
+++ b/docs/api/type-aliases/CameraAspectRatio.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraAspectRatio.md
+++ b/docs/api/type-aliases/CameraAspectRatio.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraAspectRatio.md
+++ b/docs/api/type-aliases/CameraAspectRatio.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraStatus.md
+++ b/docs/api/type-aliases/CameraStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraStatus.md
+++ b/docs/api/type-aliases/CameraStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraStatus.md
+++ b/docs/api/type-aliases/CameraStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraStatus.md
+++ b/docs/api/type-aliases/CameraStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraStatus.md
+++ b/docs/api/type-aliases/CameraStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfig.md
+++ b/docs/api/type-aliases/DeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfig.md
+++ b/docs/api/type-aliases/DeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfig.md
+++ b/docs/api/type-aliases/DeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfig.md
+++ b/docs/api/type-aliases/DeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfig.md
+++ b/docs/api/type-aliases/DeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfigCreate.md
+++ b/docs/api/type-aliases/DeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfigCreate.md
+++ b/docs/api/type-aliases/DeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfigCreate.md
+++ b/docs/api/type-aliases/DeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfigCreate.md
+++ b/docs/api/type-aliases/DeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfigCreate.md
+++ b/docs/api/type-aliases/DeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ErrorCode.md
+++ b/docs/api/type-aliases/ErrorCode.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ErrorCode.md
+++ b/docs/api/type-aliases/ErrorCode.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ErrorCode.md
+++ b/docs/api/type-aliases/ErrorCode.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ErrorCode.md
+++ b/docs/api/type-aliases/ErrorCode.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ErrorCode.md
+++ b/docs/api/type-aliases/ErrorCode.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionDeliveryType.md
+++ b/docs/api/type-aliases/EventSubscriptionDeliveryType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionDeliveryType.md
+++ b/docs/api/type-aliases/EventSubscriptionDeliveryType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionDeliveryType.md
+++ b/docs/api/type-aliases/EventSubscriptionDeliveryType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionDeliveryType.md
+++ b/docs/api/type-aliases/EventSubscriptionDeliveryType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionDeliveryType.md
+++ b/docs/api/type-aliases/EventSubscriptionDeliveryType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionLifecycle.md
+++ b/docs/api/type-aliases/EventSubscriptionLifecycle.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionLifecycle.md
+++ b/docs/api/type-aliases/EventSubscriptionLifecycle.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionLifecycle.md
+++ b/docs/api/type-aliases/EventSubscriptionLifecycle.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionLifecycle.md
+++ b/docs/api/type-aliases/EventSubscriptionLifecycle.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionLifecycle.md
+++ b/docs/api/type-aliases/EventSubscriptionLifecycle.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedIncludeOption.md
+++ b/docs/api/type-aliases/FeedIncludeOption.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedIncludeOption.md
+++ b/docs/api/type-aliases/FeedIncludeOption.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedIncludeOption.md
+++ b/docs/api/type-aliases/FeedIncludeOption.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedIncludeOption.md
+++ b/docs/api/type-aliases/FeedIncludeOption.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedIncludeOption.md
+++ b/docs/api/type-aliases/FeedIncludeOption.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedMediaType.md
+++ b/docs/api/type-aliases/FeedMediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedMediaType.md
+++ b/docs/api/type-aliases/FeedMediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedMediaType.md
+++ b/docs/api/type-aliases/FeedMediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedMediaType.md
+++ b/docs/api/type-aliases/FeedMediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedMediaType.md
+++ b/docs/api/type-aliases/FeedMediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedStreamType.md
+++ b/docs/api/type-aliases/FeedStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedStreamType.md
+++ b/docs/api/type-aliases/FeedStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedStreamType.md
+++ b/docs/api/type-aliases/FeedStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedStreamType.md
+++ b/docs/api/type-aliases/FeedStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedStreamType.md
+++ b/docs/api/type-aliases/FeedStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/GetLayoutInclude.md
+++ b/docs/api/type-aliases/GetLayoutInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/GetLayoutInclude.md
+++ b/docs/api/type-aliases/GetLayoutInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/GetLayoutInclude.md
+++ b/docs/api/type-aliases/GetLayoutInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/GetLayoutInclude.md
+++ b/docs/api/type-aliases/GetLayoutInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/GetLayoutInclude.md
+++ b/docs/api/type-aliases/GetLayoutInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneSize.md
+++ b/docs/api/type-aliases/LayoutPaneSize.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneSize.md
+++ b/docs/api/type-aliases/LayoutPaneSize.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneSize.md
+++ b/docs/api/type-aliases/LayoutPaneSize.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneSize.md
+++ b/docs/api/type-aliases/LayoutPaneSize.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneSize.md
+++ b/docs/api/type-aliases/LayoutPaneSize.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneType.md
+++ b/docs/api/type-aliases/LayoutPaneType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneType.md
+++ b/docs/api/type-aliases/LayoutPaneType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneType.md
+++ b/docs/api/type-aliases/LayoutPaneType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneType.md
+++ b/docs/api/type-aliases/LayoutPaneType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneType.md
+++ b/docs/api/type-aliases/LayoutPaneType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsInclude.md
+++ b/docs/api/type-aliases/ListLayoutsInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsInclude.md
+++ b/docs/api/type-aliases/ListLayoutsInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsInclude.md
+++ b/docs/api/type-aliases/ListLayoutsInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsInclude.md
+++ b/docs/api/type-aliases/ListLayoutsInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsInclude.md
+++ b/docs/api/type-aliases/ListLayoutsInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsSort.md
+++ b/docs/api/type-aliases/ListLayoutsSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsSort.md
+++ b/docs/api/type-aliases/ListLayoutsSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsSort.md
+++ b/docs/api/type-aliases/ListLayoutsSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsSort.md
+++ b/docs/api/type-aliases/ListLayoutsSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsSort.md
+++ b/docs/api/type-aliases/ListLayoutsSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaStreamType.md
+++ b/docs/api/type-aliases/MediaStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaStreamType.md
+++ b/docs/api/type-aliases/MediaStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaStreamType.md
+++ b/docs/api/type-aliases/MediaStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaStreamType.md
+++ b/docs/api/type-aliases/MediaStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaStreamType.md
+++ b/docs/api/type-aliases/MediaStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaType.md
+++ b/docs/api/type-aliases/MediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaType.md
+++ b/docs/api/type-aliases/MediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaType.md
+++ b/docs/api/type-aliases/MediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaType.md
+++ b/docs/api/type-aliases/MediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaType.md
+++ b/docs/api/type-aliases/MediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricActorType.md
+++ b/docs/api/type-aliases/MetricActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricActorType.md
+++ b/docs/api/type-aliases/MetricActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricActorType.md
+++ b/docs/api/type-aliases/MetricActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricActorType.md
+++ b/docs/api/type-aliases/MetricActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricActorType.md
+++ b/docs/api/type-aliases/MetricActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricDataPoint.md
+++ b/docs/api/type-aliases/MetricDataPoint.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricDataPoint.md
+++ b/docs/api/type-aliases/MetricDataPoint.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricDataPoint.md
+++ b/docs/api/type-aliases/MetricDataPoint.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricDataPoint.md
+++ b/docs/api/type-aliases/MetricDataPoint.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricDataPoint.md
+++ b/docs/api/type-aliases/MetricDataPoint.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationCategory.md
+++ b/docs/api/type-aliases/NotificationCategory.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationCategory.md
+++ b/docs/api/type-aliases/NotificationCategory.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationCategory.md
+++ b/docs/api/type-aliases/NotificationCategory.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationCategory.md
+++ b/docs/api/type-aliases/NotificationCategory.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationCategory.md
+++ b/docs/api/type-aliases/NotificationCategory.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationStatus.md
+++ b/docs/api/type-aliases/NotificationStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationStatus.md
+++ b/docs/api/type-aliases/NotificationStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationStatus.md
+++ b/docs/api/type-aliases/NotificationStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationStatus.md
+++ b/docs/api/type-aliases/NotificationStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationStatus.md
+++ b/docs/api/type-aliases/NotificationStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/Result.md
+++ b/docs/api/type-aliases/Result.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/Result.md
+++ b/docs/api/type-aliases/Result.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/Result.md
+++ b/docs/api/type-aliases/Result.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/Result.md
+++ b/docs/api/type-aliases/Result.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/Result.md
+++ b/docs/api/type-aliases/Result.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/SSEConnectionStatus.md
+++ b/docs/api/type-aliases/SSEConnectionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/SSEConnectionStatus.md
+++ b/docs/api/type-aliases/SSEConnectionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/SSEConnectionStatus.md
+++ b/docs/api/type-aliases/SSEConnectionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/SSEConnectionStatus.md
+++ b/docs/api/type-aliases/SSEConnectionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/SSEConnectionStatus.md
+++ b/docs/api/type-aliases/SSEConnectionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/StorageStrategy.md
+++ b/docs/api/type-aliases/StorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/StorageStrategy.md
+++ b/docs/api/type-aliases/StorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/StorageStrategy.md
+++ b/docs/api/type-aliases/StorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/StorageStrategy.md
+++ b/docs/api/type-aliases/StorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/StorageStrategy.md
+++ b/docs/api/type-aliases/StorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
+++ b/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
+++ b/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
+++ b/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
+++ b/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
+++ b/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/docs/api/variables/useAuthStore.md
+++ b/docs/api/variables/useAuthStore.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.40**](../README.md)
+[**EEN API Toolkit v0.3.41**](../README.md)
 
 ***
 

--- a/docs/api/variables/useAuthStore.md
+++ b/docs/api/variables/useAuthStore.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.42**](../README.md)
+[**EEN API Toolkit v0.3.43**](../README.md)
 
 ***
 

--- a/docs/api/variables/useAuthStore.md
+++ b/docs/api/variables/useAuthStore.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.38**](../README.md)
+[**EEN API Toolkit v0.3.39**](../README.md)
 
 ***
 

--- a/docs/api/variables/useAuthStore.md
+++ b/docs/api/variables/useAuthStore.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.39**](../README.md)
+[**EEN API Toolkit v0.3.40**](../README.md)
 
 ***
 

--- a/docs/api/variables/useAuthStore.md
+++ b/docs/api/variables/useAuthStore.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.41**](../README.md)
+[**EEN API Toolkit v0.3.42**](../README.md)
 
 ***
 

--- a/examples/vue-alerts-metrics/src/App.vue
+++ b/examples/vue-alerts-metrics/src/App.vue
@@ -1,9 +1,15 @@
 <script setup lang="ts">
+import { onMounted, computed } from 'vue'
 import { useAuthStore } from 'een-api-toolkit'
-import { computed } from 'vue'
 
 const authStore = useAuthStore()
 const isAuthenticated = computed(() => authStore.isAuthenticated)
+
+// Initialize auth store from storage on app mount
+// This restores the session if a valid token exists in localStorage/sessionStorage
+onMounted(() => {
+  authStore.initialize()
+})
 </script>
 
 <template>

--- a/examples/vue-bridges/e2e/auth.spec.ts
+++ b/examples/vue-bridges/e2e/auth.spec.ts
@@ -203,4 +203,101 @@ test.describe('Vue Bridges Example - Auth', () => {
     await expect(page.locator('[data-testid="not-authenticated"]')).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
     await expect(page.locator('[data-testid="nav-login"]')).toBeVisible()
   })
+
+  test('after logout, localStorage is cleared and new login flow is required', async ({ page }) => {
+    skipIfNoProxy()
+    skipIfNoCredentials()
+
+    // First login
+    await performLogin(page, TEST_USER!, TEST_PASSWORD!)
+    await expect(page.locator('[data-testid="nav-logout"]')).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+
+    // Verify we're authenticated
+    await expect(page.locator('[data-testid="nav-bridges"]')).toBeVisible()
+
+    // Logout
+    await page.click('[data-testid="nav-logout"]')
+    await page.waitForURL('**/')
+    await expect(page.locator('[data-testid="not-authenticated"]')).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+
+    // Verify localStorage is cleared (session data removed)
+    const tokenAfterLogout = await page.evaluate(() => localStorage.getItem('een_token'))
+    expect(tokenAfterLogout).toBeNull()
+
+    const sessionIdAfterLogout = await page.evaluate(() => localStorage.getItem('een_sessionId'))
+    expect(sessionIdAfterLogout).toBeNull()
+
+    const hostnameAfterLogout = await page.evaluate(() => localStorage.getItem('een_hostname'))
+    expect(hostnameAfterLogout).toBeNull()
+
+    // Verify the app shows not-authenticated state (proves our session is cleared)
+    await expect(page.locator('[data-testid="not-authenticated"]')).toBeVisible()
+    await expect(page.locator('[data-testid="nav-login"]')).toBeVisible()
+    await expect(page.locator('[data-testid="nav-logout"]')).not.toBeVisible()
+
+    // Click login to start new OAuth flow
+    await page.click('[data-testid="login-button"]')
+    await page.waitForURL('/login')
+
+    // Click OAuth login button - this initiates the OAuth redirect
+    await page.click('button:has-text("Login with Eagle Eye Networks")')
+
+    // Wait for either:
+    // 1. OAuth page (if IDP session expired) - user needs to enter credentials
+    // 2. Callback/bridges page (if IDP remembers user via cookies) - auto-login
+    // Either way, our localStorage was cleared and user had to initiate a new login
+    await page.waitForURL(/eagleeyenetworks\.com|127\.0\.0\.1:3333/, { timeout: TIMEOUTS.AUTH_COMPLETE })
+
+    // If we ended up back at our app (auto-login via IDP cookies), verify we're authenticated again
+    const currentUrl = page.url()
+    if (currentUrl.includes('127.0.0.1:3333')) {
+      // Auto-logged in - wait for the full flow to complete
+      await page.waitForURL('**/bridges', { timeout: TIMEOUTS.AUTH_COMPLETE })
+      await expect(page.locator('[data-testid="nav-bridges"]')).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+      await expect(page.locator('[data-testid="nav-logout"]')).toBeVisible()
+
+      // Verify localStorage has new token (proves it was cleared and refilled)
+      const newToken = await page.evaluate(() => localStorage.getItem('een_token'))
+      expect(newToken).not.toBeNull()
+    } else {
+      // At OAuth page - user needs to enter credentials
+      const emailInput = page.locator('#authentication--input__email')
+      await expect(emailInput).toBeVisible({ timeout: TIMEOUTS.ELEMENT_VISIBLE })
+    }
+  })
+
+  test('localStorage: second tab shares session without re-login', async ({ page, context }) => {
+    skipIfNoProxy()
+    skipIfNoCredentials()
+
+    // First tab: login
+    await performLogin(page, TEST_USER!, TEST_PASSWORD!)
+    await expect(page.locator('[data-testid="nav-logout"]')).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+
+    // Verify localStorage has token
+    const tokenInFirstTab = await page.evaluate(() => localStorage.getItem('een_token'))
+    expect(tokenInFirstTab).not.toBeNull()
+
+    // Open second tab in same browser context (shares localStorage)
+    const secondTab = await context.newPage()
+    await secondTab.goto('/')
+
+    // Second tab should be authenticated immediately (no login needed)
+    // because localStorage is shared and App.vue calls initialize()
+    await expect(secondTab.locator('[data-testid="nav-logout"]')).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+    await expect(secondTab.locator('[data-testid="nav-bridges"]')).toBeVisible()
+    await expect(secondTab.locator('[data-testid="nav-login"]')).not.toBeVisible()
+
+    // Verify second tab has the same token from localStorage
+    const tokenInSecondTab = await secondTab.evaluate(() => localStorage.getItem('een_token'))
+    expect(tokenInSecondTab).toBe(tokenInFirstTab)
+
+    // Navigate to bridges in second tab - should work without login
+    await secondTab.click('[data-testid="nav-bridges"]')
+    await secondTab.waitForURL('**/bridges')
+    await expect(secondTab.locator('.bridge-grid, .no-bridges')).toBeVisible({ timeout: TIMEOUTS.ELEMENT_VISIBLE })
+
+    // Clean up second tab
+    await secondTab.close()
+  })
 })

--- a/examples/vue-bridges/src/App.vue
+++ b/examples/vue-bridges/src/App.vue
@@ -1,9 +1,15 @@
 <script setup lang="ts">
+import { onMounted, computed } from 'vue'
 import { useAuthStore } from 'een-api-toolkit'
-import { computed } from 'vue'
 
 const authStore = useAuthStore()
 const isAuthenticated = computed(() => authStore.isAuthenticated)
+
+// Initialize auth store from storage on app mount
+// This restores the session if a valid token exists in localStorage/sessionStorage
+onMounted(() => {
+  authStore.initialize()
+})
 </script>
 
 <template>

--- a/examples/vue-cameras/src/App.vue
+++ b/examples/vue-cameras/src/App.vue
@@ -1,9 +1,15 @@
 <script setup lang="ts">
+import { onMounted, computed } from 'vue'
 import { useAuthStore } from 'een-api-toolkit'
-import { computed } from 'vue'
 
 const authStore = useAuthStore()
 const isAuthenticated = computed(() => authStore.isAuthenticated)
+
+// Initialize auth store from storage on app mount
+// This restores the session if a valid token exists in localStorage/sessionStorage
+onMounted(() => {
+  authStore.initialize()
+})
 </script>
 
 <template>

--- a/examples/vue-event-subscriptions/src/App.vue
+++ b/examples/vue-event-subscriptions/src/App.vue
@@ -1,12 +1,18 @@
 <script setup lang="ts">
+import { onMounted, computed } from 'vue'
 import { useAuthStore } from 'een-api-toolkit'
-import { computed } from 'vue'
 import { useRouter } from 'vue-router'
 
 const authStore = useAuthStore()
 const router = useRouter()
 
 const isAuthenticated = computed(() => authStore.isAuthenticated)
+
+// Initialize auth store from storage on app mount
+// This restores the session if a valid token exists in localStorage/sessionStorage
+onMounted(() => {
+  authStore.initialize()
+})
 const refreshFailed = computed(() => authStore.refreshFailed)
 const refreshFailedMessage = computed(() => authStore.refreshFailedMessage)
 const isRefreshing = computed(() => authStore.isRefreshing)

--- a/examples/vue-event-subscriptions/src/views/LiveEvents.vue
+++ b/examples/vue-event-subscriptions/src/views/LiveEvents.vue
@@ -380,7 +380,7 @@ watch(selectedSubscriptionId, (newId) => {
       <ul class="warning-list">
         <li>SSE URLs are single-use. Once disconnected, the subscription cannot be reconnected.</li>
         <li>To receive events again after disconnecting, create a new subscription.</li>
-        <li>Subscriptions have a 15-minute TTL and expire if not connected.</li>
+        <li>SSE subscriptions have a server-determined 15-minute TTL (not configurable) and expire if not connected.</li>
       </ul>
     </div>
 

--- a/examples/vue-events/src/App.vue
+++ b/examples/vue-events/src/App.vue
@@ -1,9 +1,15 @@
 <script setup lang="ts">
+import { onMounted, computed } from 'vue'
 import { useAuthStore } from 'een-api-toolkit'
-import { computed } from 'vue'
 
 const authStore = useAuthStore()
 const isAuthenticated = computed(() => authStore.isAuthenticated)
+
+// Initialize auth store from storage on app mount
+// This restores the session if a valid token exists in localStorage/sessionStorage
+onMounted(() => {
+  authStore.initialize()
+})
 </script>
 
 <template>

--- a/examples/vue-layouts/src/App.vue
+++ b/examples/vue-layouts/src/App.vue
@@ -1,9 +1,15 @@
 <script setup lang="ts">
+import { onMounted, computed } from 'vue'
 import { useAuthStore } from 'een-api-toolkit'
-import { computed } from 'vue'
 
 const authStore = useAuthStore()
 const isAuthenticated = computed(() => authStore.isAuthenticated)
+
+// Initialize auth store from storage on app mount
+// This restores the session if a valid token exists in localStorage/sessionStorage
+onMounted(() => {
+  authStore.initialize()
+})
 </script>
 
 <template>

--- a/examples/vue-users/package-lock.json
+++ b/examples/vue-users/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-api-toolkit-example",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit-example",
-      "version": "0.0.25",
+      "version": "0.0.26",
       "dependencies": {
         "een-api-toolkit": "file:../..",
         "pinia": "^3.0.4",

--- a/examples/vue-users/package.json
+++ b/examples/vue-users/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit-example",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/vue-users/src/App.vue
+++ b/examples/vue-users/src/App.vue
@@ -1,9 +1,15 @@
 <script setup lang="ts">
+import { onMounted, computed } from 'vue'
 import { useAuthStore } from 'een-api-toolkit'
-import { computed } from 'vue'
 
 const authStore = useAuthStore()
 const isAuthenticated = computed(() => authStore.isAuthenticated)
+
+// Initialize auth store from storage on app mount
+// This restores the session if a valid token exists in localStorage/sessionStorage
+onMounted(() => {
+  authStore.initialize()
+})
 </script>
 
 <template>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.39",
+  "version": "0.3.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit",
-      "version": "0.3.39",
+      "version": "0.3.40",
       "license": "MIT",
       "bin": {
         "een-setup-agents": "scripts/setup-agents.ts"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.40",
+  "version": "0.3.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit",
-      "version": "0.3.40",
+      "version": "0.3.41",
       "license": "MIT",
       "bin": {
         "een-setup-agents": "scripts/setup-agents.ts"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.41",
+  "version": "0.3.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit",
-      "version": "0.3.41",
+      "version": "0.3.42",
       "license": "MIT",
       "bin": {
         "een-setup-agents": "scripts/setup-agents.ts"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.38",
+  "version": "0.3.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit",
-      "version": "0.3.38",
+      "version": "0.3.39",
       "license": "MIT",
       "bin": {
         "een-setup-agents": "scripts/setup-agents.ts"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.42",
+  "version": "0.3.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit",
-      "version": "0.3.42",
+      "version": "0.3.43",
       "license": "MIT",
       "bin": {
         "een-setup-agents": "scripts/setup-agents.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.38",
+  "version": "0.3.39",
   "description": "EEN Video platform API v3.0 library for Vue 3",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.40",
+  "version": "0.3.41",
   "description": "EEN Video platform API v3.0 library for Vue 3",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.41",
+  "version": "0.3.42",
   "description": "EEN Video platform API v3.0 library for Vue 3",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.42",
+  "version": "0.3.43",
   "description": "EEN Video platform API v3.0 library for Vue 3",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.39",
+  "version": "0.3.40",
   "description": "EEN Video platform API v3.0 library for Vue 3",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/scripts/generate-ai-context.ts
+++ b/scripts/generate-ai-context.ts
@@ -724,6 +724,47 @@ authStore.sessionId        // Session identifier
 
 ---
 
+## Session Persistence (IMPORTANT)
+
+**To restore sessions from storage on page load, you must call \`authStore.initialize()\` in your App.vue.**
+
+Without this call, users will need to log in again after every page refresh, even with \`localStorage\` strategy.
+
+### App.vue Setup
+
+\`\`\`vue
+<script setup lang="ts">
+import { onMounted, computed } from 'vue'
+import { useAuthStore } from 'een-api-toolkit'
+
+const authStore = useAuthStore()
+const isAuthenticated = computed(() => authStore.isAuthenticated)
+
+// CRITICAL: Initialize auth store from storage on app mount
+// This restores the session if a valid token exists in localStorage/sessionStorage
+onMounted(() => {
+  authStore.initialize()
+})
+</script>
+\`\`\`
+
+### What initialize() Does
+
+1. Loads token, expiration, session ID, and base URL from configured storage
+2. If token exists and is **not expired**: Sets up auto-refresh timer
+3. If token exists but **is expired**: Clears auth state (user must re-login)
+4. If no token: No action (user must login)
+
+### Storage Strategy Behavior
+
+| Strategy | Persists Across Refresh? | Requires initialize()? |
+|----------|-------------------------|------------------------|
+| \`localStorage\` | Yes | Yes |
+| \`sessionStorage\` | Yes (within tab) | Yes |
+| \`memory\` | No | No (always requires re-login) |
+
+---
+
 ## Vue Router Auth Guard
 
 Protect routes that require authentication:

--- a/src/__tests__/auth.store.test.ts
+++ b/src/__tests__/auth.store.test.ts
@@ -1,0 +1,426 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useAuthStore } from '../auth/store'
+import { setStorageStrategy, clearMemoryStorage, getStorageAdapter } from '../utils/storage'
+
+/**
+ * Tests for auth store session persistence across different storage strategies.
+ *
+ * These tests verify that:
+ * 1. Sessions persist correctly with localStorage strategy
+ * 2. Sessions persist correctly with sessionStorage strategy
+ * 3. Sessions do NOT persist with memory strategy (by design)
+ * 4. Logout clears sessions from all storage strategies
+ * 5. initialize() correctly restores sessions from storage
+ */
+
+describe('Auth Store Session Persistence', () => {
+  // Save original localStorage/sessionStorage
+  const originalLocalStorage = globalThis.localStorage
+  const originalSessionStorage = globalThis.sessionStorage
+
+  // Mock storages
+  let mockLocalStorage: Record<string, string>
+  let mockSessionStorage: Record<string, string>
+
+  function setupMockLocalStorage() {
+    mockLocalStorage = {}
+    globalThis.localStorage = {
+      getItem: (key: string) => mockLocalStorage[key] ?? null,
+      setItem: (key: string, value: string) => {
+        mockLocalStorage[key] = value
+      },
+      removeItem: (key: string) => {
+        delete mockLocalStorage[key]
+      },
+      clear: () => {
+        mockLocalStorage = {}
+      },
+      key: (index: number) => Object.keys(mockLocalStorage)[index] ?? null,
+      length: Object.keys(mockLocalStorage).length
+    } as Storage
+  }
+
+  function setupMockSessionStorage() {
+    mockSessionStorage = {}
+    globalThis.sessionStorage = {
+      getItem: (key: string) => mockSessionStorage[key] ?? null,
+      setItem: (key: string, value: string) => {
+        mockSessionStorage[key] = value
+      },
+      removeItem: (key: string) => {
+        delete mockSessionStorage[key]
+      },
+      clear: () => {
+        mockSessionStorage = {}
+      },
+      key: (index: number) => Object.keys(mockSessionStorage)[index] ?? null,
+      length: Object.keys(mockSessionStorage).length
+    } as Storage
+  }
+
+  beforeEach(() => {
+    // Create fresh Pinia instance for each test
+    setActivePinia(createPinia())
+    clearMemoryStorage()
+    setupMockLocalStorage()
+    setupMockSessionStorage()
+  })
+
+  afterEach(() => {
+    // Restore original storage
+    globalThis.localStorage = originalLocalStorage
+    globalThis.sessionStorage = originalSessionStorage
+    clearMemoryStorage()
+    vi.clearAllMocks()
+  })
+
+  describe('localStorage strategy', () => {
+    beforeEach(() => {
+      setStorageStrategy('localStorage')
+    })
+
+    it('should persist session to localStorage after setToken', () => {
+      const authStore = useAuthStore()
+
+      // Set token (simulates successful login)
+      authStore.setToken('test-token-123', 3600)
+      authStore.setBaseUrl('https://c001.eagleeyenetworks.com')
+      authStore.setSessionId('session-abc')
+
+      // Verify data is in localStorage
+      expect(mockLocalStorage['een_token']).toBe('test-token-123')
+      expect(mockLocalStorage['een_hostname']).toBe('c001.eagleeyenetworks.com')
+      expect(mockLocalStorage['een_sessionId']).toBe('session-abc')
+    })
+
+    it('should restore session from localStorage on initialize()', () => {
+      // Pre-populate localStorage (simulates data from previous session)
+      const futureExpiration = Date.now() + 3600000 // 1 hour from now
+      mockLocalStorage['een_token'] = 'persisted-token'
+      mockLocalStorage['een_tokenExpiration'] = String(futureExpiration)
+      mockLocalStorage['een_hostname'] = 'c002.eagleeyenetworks.com'
+      mockLocalStorage['een_sessionId'] = 'persisted-session'
+
+      // Create new store (simulates page refresh)
+      setActivePinia(createPinia())
+      const authStore = useAuthStore()
+
+      // Before initialize, store should be empty
+      expect(authStore.token).toBeNull()
+      expect(authStore.isAuthenticated).toBe(false)
+
+      // Call initialize (this is what App.vue should do on mount)
+      authStore.initialize()
+
+      // After initialize, session should be restored
+      expect(authStore.token).toBe('persisted-token')
+      expect(authStore.isAuthenticated).toBe(true)
+      expect(authStore.baseUrl).toBe('https://c002.eagleeyenetworks.com')
+      expect(authStore.sessionId).toBe('persisted-session')
+    })
+
+    it('should clear localStorage on logout', () => {
+      const authStore = useAuthStore()
+
+      // Set up authenticated state
+      authStore.setToken('test-token', 3600)
+      authStore.setBaseUrl('https://c001.eagleeyenetworks.com')
+      authStore.setSessionId('test-session')
+
+      // Verify data is in localStorage
+      expect(mockLocalStorage['een_token']).toBe('test-token')
+
+      // Logout
+      authStore.logout()
+
+      // Verify localStorage is cleared
+      expect(mockLocalStorage['een_token']).toBeUndefined()
+      expect(mockLocalStorage['een_tokenExpiration']).toBeUndefined()
+      expect(mockLocalStorage['een_hostname']).toBeUndefined()
+      expect(mockLocalStorage['een_sessionId']).toBeUndefined()
+
+      // Verify store is cleared
+      expect(authStore.token).toBeNull()
+      expect(authStore.isAuthenticated).toBe(false)
+    })
+
+    it('should clear expired token on initialize()', () => {
+      // Pre-populate localStorage with expired token
+      const pastExpiration = Date.now() - 3600000 // 1 hour ago
+      mockLocalStorage['een_token'] = 'expired-token'
+      mockLocalStorage['een_tokenExpiration'] = String(pastExpiration)
+      mockLocalStorage['een_hostname'] = 'c001.eagleeyenetworks.com'
+
+      // Create new store and initialize
+      setActivePinia(createPinia())
+      const authStore = useAuthStore()
+      authStore.initialize()
+
+      // Expired token should be cleared
+      expect(authStore.token).toBeNull()
+      expect(authStore.isAuthenticated).toBe(false)
+      expect(mockLocalStorage['een_token']).toBeUndefined()
+    })
+  })
+
+  describe('sessionStorage strategy', () => {
+    beforeEach(() => {
+      setStorageStrategy('sessionStorage')
+    })
+
+    it('should persist session to sessionStorage after setToken', () => {
+      const authStore = useAuthStore()
+
+      // Set token (simulates successful login)
+      authStore.setToken('test-token-456', 3600)
+      authStore.setBaseUrl('https://c003.eagleeyenetworks.com')
+      authStore.setSessionId('session-def')
+
+      // Verify data is in sessionStorage
+      expect(mockSessionStorage['een_token']).toBe('test-token-456')
+      expect(mockSessionStorage['een_hostname']).toBe('c003.eagleeyenetworks.com')
+      expect(mockSessionStorage['een_sessionId']).toBe('session-def')
+    })
+
+    it('should restore session from sessionStorage on initialize()', () => {
+      // Pre-populate sessionStorage (simulates data from same tab session)
+      const futureExpiration = Date.now() + 3600000
+      mockSessionStorage['een_token'] = 'session-persisted-token'
+      mockSessionStorage['een_tokenExpiration'] = String(futureExpiration)
+      mockSessionStorage['een_hostname'] = 'c004.eagleeyenetworks.com'
+      mockSessionStorage['een_sessionId'] = 'session-persisted'
+
+      // Create new store (simulates component remount within same tab)
+      setActivePinia(createPinia())
+      const authStore = useAuthStore()
+
+      // Before initialize
+      expect(authStore.token).toBeNull()
+
+      // Call initialize
+      authStore.initialize()
+
+      // Session should be restored
+      expect(authStore.token).toBe('session-persisted-token')
+      expect(authStore.isAuthenticated).toBe(true)
+      expect(authStore.baseUrl).toBe('https://c004.eagleeyenetworks.com')
+    })
+
+    it('should clear sessionStorage on logout', () => {
+      const authStore = useAuthStore()
+
+      // Set up authenticated state
+      authStore.setToken('test-token', 3600)
+      authStore.setBaseUrl('https://c001.eagleeyenetworks.com')
+
+      // Verify data is in sessionStorage
+      expect(mockSessionStorage['een_token']).toBe('test-token')
+
+      // Logout
+      authStore.logout()
+
+      // Verify sessionStorage is cleared
+      expect(mockSessionStorage['een_token']).toBeUndefined()
+      expect(mockSessionStorage['een_tokenExpiration']).toBeUndefined()
+      expect(mockSessionStorage['een_hostname']).toBeUndefined()
+    })
+  })
+
+  describe('memory strategy', () => {
+    beforeEach(() => {
+      setStorageStrategy('memory')
+    })
+
+    it('should store token in memory only', () => {
+      const authStore = useAuthStore()
+
+      // Set token
+      authStore.setToken('memory-token', 3600)
+      authStore.setBaseUrl('https://c005.eagleeyenetworks.com')
+
+      // Token should be in memory storage
+      const storage = getStorageAdapter()
+      expect(storage.getItem('een_token')).toBe('memory-token')
+
+      // But NOT in localStorage or sessionStorage
+      expect(mockLocalStorage['een_token']).toBeUndefined()
+      expect(mockSessionStorage['een_token']).toBeUndefined()
+    })
+
+    it('should NOT restore session after memory is cleared (simulates page refresh)', () => {
+      const authStore = useAuthStore()
+
+      // Set token in memory
+      authStore.setToken('memory-only-token', 3600)
+      authStore.setBaseUrl('https://c006.eagleeyenetworks.com')
+
+      expect(authStore.isAuthenticated).toBe(true)
+
+      // Clear memory storage (simulates page refresh losing memory)
+      clearMemoryStorage()
+
+      // Create new store (simulates page refresh)
+      setActivePinia(createPinia())
+      const newAuthStore = useAuthStore()
+
+      // Call initialize
+      newAuthStore.initialize()
+
+      // Session should NOT be restored (memory was cleared)
+      expect(newAuthStore.token).toBeNull()
+      expect(newAuthStore.isAuthenticated).toBe(false)
+    })
+
+    it('should clear memory storage on logout', () => {
+      const authStore = useAuthStore()
+
+      // Set up authenticated state
+      authStore.setToken('memory-token', 3600)
+
+      const storage = getStorageAdapter()
+      expect(storage.getItem('een_token')).toBe('memory-token')
+
+      // Logout
+      authStore.logout()
+
+      // Memory storage should be cleared
+      expect(storage.getItem('een_token')).toBeNull()
+      expect(authStore.token).toBeNull()
+      expect(authStore.isAuthenticated).toBe(false)
+    })
+
+    it('memory strategy should not expose tokens to localStorage/sessionStorage (XSS protection)', () => {
+      const authStore = useAuthStore()
+
+      // Set token in memory
+      authStore.setToken('secret-token', 3600)
+
+      // Token should NOT be accessible via localStorage or sessionStorage
+      // This protects against XSS attacks that try to read browser storage
+      expect(mockLocalStorage['een_token']).toBeUndefined()
+      expect(mockSessionStorage['een_token']).toBeUndefined()
+    })
+  })
+
+  describe('session persistence behavior comparison', () => {
+    it('localStorage: session survives "page refresh" (initialize after new pinia)', () => {
+      setStorageStrategy('localStorage')
+
+      // Login
+      const authStore1 = useAuthStore()
+      authStore1.setToken('ls-token', 3600)
+      authStore1.setBaseUrl('https://c001.eagleeyenetworks.com')
+      expect(authStore1.isAuthenticated).toBe(true)
+
+      // "Page refresh" - new Pinia, call initialize
+      setActivePinia(createPinia())
+      const authStore2 = useAuthStore()
+      authStore2.initialize()
+
+      // Session should be restored
+      expect(authStore2.isAuthenticated).toBe(true)
+      expect(authStore2.token).toBe('ls-token')
+    })
+
+    it('sessionStorage: session survives "page refresh" within same tab', () => {
+      setStorageStrategy('sessionStorage')
+
+      // Login
+      const authStore1 = useAuthStore()
+      authStore1.setToken('ss-token', 3600)
+      authStore1.setBaseUrl('https://c001.eagleeyenetworks.com')
+      expect(authStore1.isAuthenticated).toBe(true)
+
+      // "Page refresh" within same tab - new Pinia, call initialize
+      setActivePinia(createPinia())
+      const authStore2 = useAuthStore()
+      authStore2.initialize()
+
+      // Session should be restored
+      expect(authStore2.isAuthenticated).toBe(true)
+      expect(authStore2.token).toBe('ss-token')
+    })
+
+    it('memory: session does NOT survive "page refresh"', () => {
+      setStorageStrategy('memory')
+
+      // Login
+      const authStore1 = useAuthStore()
+      authStore1.setToken('mem-token', 3600)
+      authStore1.setBaseUrl('https://c001.eagleeyenetworks.com')
+      expect(authStore1.isAuthenticated).toBe(true)
+
+      // "Page refresh" - clear memory, new Pinia, call initialize
+      clearMemoryStorage()
+      setActivePinia(createPinia())
+      const authStore2 = useAuthStore()
+      authStore2.initialize()
+
+      // Session should NOT be restored (memory was cleared)
+      expect(authStore2.isAuthenticated).toBe(false)
+      expect(authStore2.token).toBeNull()
+    })
+
+    it('all strategies: logout clears session completely', () => {
+      const strategies = ['localStorage', 'sessionStorage', 'memory'] as const
+
+      for (const strategy of strategies) {
+        // Setup
+        setStorageStrategy(strategy)
+        setActivePinia(createPinia())
+        if (strategy === 'localStorage') setupMockLocalStorage()
+        if (strategy === 'sessionStorage') setupMockSessionStorage()
+        if (strategy === 'memory') clearMemoryStorage()
+
+        const authStore = useAuthStore()
+
+        // Login
+        authStore.setToken(`${strategy}-token`, 3600)
+        authStore.setBaseUrl('https://c001.eagleeyenetworks.com')
+        expect(authStore.isAuthenticated).toBe(true)
+
+        // Logout
+        authStore.logout()
+
+        // Session should be completely cleared
+        expect(authStore.isAuthenticated).toBe(false)
+        expect(authStore.token).toBeNull()
+
+        // Storage should be cleared
+        const storage = getStorageAdapter()
+        expect(storage.getItem('een_token')).toBeNull()
+      }
+    })
+  })
+
+  describe('initialize() without prior session', () => {
+    it('should not throw when no session exists in localStorage', () => {
+      setStorageStrategy('localStorage')
+      const authStore = useAuthStore()
+
+      // Should not throw
+      expect(() => authStore.initialize()).not.toThrow()
+
+      // Should remain unauthenticated
+      expect(authStore.isAuthenticated).toBe(false)
+      expect(authStore.token).toBeNull()
+    })
+
+    it('should not throw when no session exists in sessionStorage', () => {
+      setStorageStrategy('sessionStorage')
+      const authStore = useAuthStore()
+
+      expect(() => authStore.initialize()).not.toThrow()
+      expect(authStore.isAuthenticated).toBe(false)
+    })
+
+    it('should not throw when no session exists in memory', () => {
+      setStorageStrategy('memory')
+      const authStore = useAuthStore()
+
+      expect(() => authStore.initialize()).not.toThrow()
+      expect(authStore.isAuthenticated).toBe(false)
+    })
+  })
+})

--- a/src/__tests__/auth.store.test.ts
+++ b/src/__tests__/auth.store.test.ts
@@ -423,4 +423,245 @@ describe('Auth Store Session Persistence', () => {
       expect(authStore.isAuthenticated).toBe(false)
     })
   })
+
+  describe('login -> logout -> second login requires credentials', () => {
+    it('localStorage: after logout, second login requires new credentials', () => {
+      setStorageStrategy('localStorage')
+
+      // First login
+      const authStore1 = useAuthStore()
+      authStore1.setToken('first-login-token', 3600)
+      authStore1.setBaseUrl('https://c001.eagleeyenetworks.com')
+      authStore1.setSessionId('first-session')
+      expect(authStore1.isAuthenticated).toBe(true)
+
+      // Verify token is in storage
+      expect(mockLocalStorage['een_token']).toBe('first-login-token')
+
+      // Logout
+      authStore1.logout()
+      expect(authStore1.isAuthenticated).toBe(false)
+
+      // Verify storage is cleared
+      expect(mockLocalStorage['een_token']).toBeUndefined()
+      expect(mockLocalStorage['een_sessionId']).toBeUndefined()
+
+      // Simulate page refresh after logout - new Pinia instance
+      setActivePinia(createPinia())
+      const authStore2 = useAuthStore()
+
+      // Try to initialize (restore from storage)
+      authStore2.initialize()
+
+      // Should NOT be authenticated - storage was cleared by logout
+      // This proves a second login with credentials is required
+      expect(authStore2.isAuthenticated).toBe(false)
+      expect(authStore2.token).toBeNull()
+      expect(authStore2.sessionId).toBeNull()
+    })
+
+    it('sessionStorage: after logout, second login requires new credentials', () => {
+      setStorageStrategy('sessionStorage')
+
+      // First login
+      const authStore1 = useAuthStore()
+      authStore1.setToken('session-first-token', 3600)
+      authStore1.setBaseUrl('https://c002.eagleeyenetworks.com')
+      authStore1.setSessionId('session-first')
+      expect(authStore1.isAuthenticated).toBe(true)
+
+      // Verify token is in storage
+      expect(mockSessionStorage['een_token']).toBe('session-first-token')
+
+      // Logout
+      authStore1.logout()
+
+      // Verify storage is cleared
+      expect(mockSessionStorage['een_token']).toBeUndefined()
+
+      // Simulate new store instance
+      setActivePinia(createPinia())
+      const authStore2 = useAuthStore()
+      authStore2.initialize()
+
+      // Should NOT be authenticated
+      expect(authStore2.isAuthenticated).toBe(false)
+      expect(authStore2.token).toBeNull()
+    })
+
+    it('memory: after logout, second login requires new credentials', () => {
+      setStorageStrategy('memory')
+
+      // First login
+      const authStore1 = useAuthStore()
+      authStore1.setToken('memory-first-token', 3600)
+      authStore1.setBaseUrl('https://c003.eagleeyenetworks.com')
+      expect(authStore1.isAuthenticated).toBe(true)
+
+      // Logout
+      authStore1.logout()
+
+      // Memory is cleared
+      const storage = getStorageAdapter()
+      expect(storage.getItem('een_token')).toBeNull()
+
+      // New store instance
+      setActivePinia(createPinia())
+      const authStore2 = useAuthStore()
+      authStore2.initialize()
+
+      // Should NOT be authenticated
+      expect(authStore2.isAuthenticated).toBe(false)
+    })
+
+    it('localStorage: logout clears ALL auth data, not just token', () => {
+      setStorageStrategy('localStorage')
+
+      const authStore = useAuthStore()
+
+      // Set up full authenticated state
+      authStore.setToken('test-token', 3600)
+      authStore.setBaseUrl('https://c001.eagleeyenetworks.com')
+      authStore.setSessionId('test-session')
+      authStore.setRefreshTokenMarker('present')
+
+      // Verify all data is stored
+      expect(mockLocalStorage['een_token']).toBe('test-token')
+      expect(mockLocalStorage['een_hostname']).toBe('c001.eagleeyenetworks.com')
+      expect(mockLocalStorage['een_sessionId']).toBe('test-session')
+      expect(mockLocalStorage['een_refreshTokenMarker']).toBe('present')
+      expect(mockLocalStorage['een_tokenExpiration']).toBeDefined()
+
+      // Logout
+      authStore.logout()
+
+      // ALL auth data should be cleared
+      expect(mockLocalStorage['een_token']).toBeUndefined()
+      expect(mockLocalStorage['een_hostname']).toBeUndefined()
+      expect(mockLocalStorage['een_sessionId']).toBeUndefined()
+      expect(mockLocalStorage['een_refreshTokenMarker']).toBeUndefined()
+      expect(mockLocalStorage['een_tokenExpiration']).toBeUndefined()
+
+      // In-memory state should also be cleared
+      expect(authStore.token).toBeNull()
+      expect(authStore.sessionId).toBeNull()
+      expect(authStore.hostname).toBeNull()
+      expect(authStore.refreshTokenMarker).toBeNull()
+    })
+  })
+
+  describe('multi-tab session sharing', () => {
+    it('localStorage: second tab shares session without re-login', () => {
+      setStorageStrategy('localStorage')
+
+      // First tab: login
+      const tab1Store = useAuthStore()
+      tab1Store.setToken('shared-token', 3600)
+      tab1Store.setBaseUrl('https://c001.eagleeyenetworks.com')
+      tab1Store.setSessionId('shared-session')
+      expect(tab1Store.isAuthenticated).toBe(true)
+
+      // Second tab: new Pinia instance (simulates new tab with same localStorage)
+      setActivePinia(createPinia())
+      const tab2Store = useAuthStore()
+
+      // Before initialize, tab2 is not authenticated
+      expect(tab2Store.token).toBeNull()
+      expect(tab2Store.isAuthenticated).toBe(false)
+
+      // After initialize, tab2 should share the session from localStorage
+      tab2Store.initialize()
+
+      expect(tab2Store.isAuthenticated).toBe(true)
+      expect(tab2Store.token).toBe('shared-token')
+      expect(tab2Store.sessionId).toBe('shared-session')
+      expect(tab2Store.baseUrl).toBe('https://c001.eagleeyenetworks.com')
+    })
+
+    it('sessionStorage: second tab does NOT share session (tab-isolated)', () => {
+      setStorageStrategy('sessionStorage')
+
+      // First tab: login
+      const tab1Store = useAuthStore()
+      tab1Store.setToken('tab1-token', 3600)
+      tab1Store.setBaseUrl('https://c001.eagleeyenetworks.com')
+      expect(tab1Store.isAuthenticated).toBe(true)
+
+      // Verify token is in sessionStorage
+      expect(mockSessionStorage['een_token']).toBe('tab1-token')
+
+      // Second tab: new Pinia instance
+      // In a real browser, sessionStorage is per-tab, so a new tab would have empty sessionStorage
+      // We simulate this by clearing the mock sessionStorage (simulating new tab's empty storage)
+      setActivePinia(createPinia())
+
+      // Clear sessionStorage to simulate new tab (each tab has its own sessionStorage)
+      mockSessionStorage = {}
+      globalThis.sessionStorage = {
+        getItem: (key: string) => mockSessionStorage[key] ?? null,
+        setItem: (key: string, value: string) => { mockSessionStorage[key] = value },
+        removeItem: (key: string) => { delete mockSessionStorage[key] },
+        clear: () => { mockSessionStorage = {} },
+        key: (index: number) => Object.keys(mockSessionStorage)[index] ?? null,
+        length: Object.keys(mockSessionStorage).length
+      } as Storage
+
+      const tab2Store = useAuthStore()
+      tab2Store.initialize()
+
+      // Tab2 should NOT be authenticated (sessionStorage is isolated per tab)
+      expect(tab2Store.isAuthenticated).toBe(false)
+      expect(tab2Store.token).toBeNull()
+    })
+
+    it('memory: second tab does NOT share session', () => {
+      setStorageStrategy('memory')
+
+      // First tab: login
+      const tab1Store = useAuthStore()
+      tab1Store.setToken('memory-token', 3600)
+      tab1Store.setBaseUrl('https://c001.eagleeyenetworks.com')
+      expect(tab1Store.isAuthenticated).toBe(true)
+
+      // Second tab: new Pinia instance with cleared memory (simulates new tab)
+      // Memory storage is in-process, so a new tab would have empty memory
+      clearMemoryStorage()
+      setActivePinia(createPinia())
+
+      const tab2Store = useAuthStore()
+      tab2Store.initialize()
+
+      // Tab2 should NOT be authenticated (memory is not shared between tabs)
+      expect(tab2Store.isAuthenticated).toBe(false)
+      expect(tab2Store.token).toBeNull()
+    })
+
+    it('localStorage: changes in one tab are visible in another after initialize', () => {
+      setStorageStrategy('localStorage')
+
+      // Tab1: login
+      const tab1Store = useAuthStore()
+      tab1Store.setToken('original-token', 3600)
+      tab1Store.setBaseUrl('https://c001.eagleeyenetworks.com')
+
+      // Tab2: initialize and verify session
+      setActivePinia(createPinia())
+      const tab2Store = useAuthStore()
+      tab2Store.initialize()
+      expect(tab2Store.token).toBe('original-token')
+
+      // Tab1: logout (clears localStorage)
+      tab1Store.logout()
+      expect(mockLocalStorage['een_token']).toBeUndefined()
+
+      // Tab2: if it re-initializes (e.g., after page refresh), session is gone
+      setActivePinia(createPinia())
+      const tab2StoreRefreshed = useAuthStore()
+      tab2StoreRefreshed.initialize()
+
+      // Tab2 is now logged out because localStorage was cleared by Tab1
+      expect(tab2StoreRefreshed.isAuthenticated).toBe(false)
+      expect(tab2StoreRefreshed.token).toBeNull()
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- **Fixed session persistence**: Added `authStore.initialize()` call to all example apps so sessions restore from localStorage/sessionStorage on page refresh
- **Clarified SSE TTL documentation**: The `timeToLiveSeconds` for SSE subscriptions is read-only and server-determined (15 minutes)
- **Added comprehensive auth store tests**: 26 unit tests covering all storage strategies
- **Added E2E tests**: Multi-tab session sharing and login/logout flow verification

## Changes

### Session Persistence Fix
- All 7 example apps now call `authStore.initialize()` in `App.vue` `onMounted`
- Without this call, users had to re-login after every page refresh even with localStorage strategy

### Documentation Updates
- Updated AI-AUTH.md with Session Persistence section
- Updated een-setup-agent and een-auth-agent with `initialize()` requirement
- Clarified SSE subscription TTL is read-only in AI-EVENTS.md and een-events-agent

### New Tests (26 unit + 15 E2E for vue-bridges)

**Unit Tests (`auth.store.test.ts`):**
- Session persistence for all 3 storage strategies
- Login → logout → second login requires credentials
- Multi-tab session sharing (localStorage shares, sessionStorage/memory don't)

**E2E Tests (`vue-bridges/e2e/auth.spec.ts`):**
- After logout, localStorage is cleared
- Second tab shares session without re-login (localStorage)

## Test plan

- [x] Unit tests pass: `npm test -- src/__tests__/auth.store.test.ts` (26 tests)
- [x] Root E2E tests pass: `npm run test:e2e` (40 tests)
- [x] vue-bridges E2E tests pass (15 tests)
- [x] vue-users, vue-cameras, vue-events E2E tests pass

## Storage Strategy Behavior

| Strategy | Persists After Refresh | Second Tab Shares |
|----------|----------------------|------------------|
| localStorage | ✓ Yes | ✓ Yes |
| sessionStorage | ✓ Yes (same tab) | ✗ No |
| memory | ✗ No | ✗ No |

🤖 Generated with [Claude Code](https://claude.com/claude-code)