### PR TITLE
Add SSRF protection to media session URL validation

### DIFF
--- a/docs/AI-CONTEXT.md
+++ b/docs/AI-CONTEXT.md
@@ -1,6 +1,6 @@
 # EEN API Toolkit - AI Reference
 
-> **Version:** 0.3.67
+> **Version:** 0.3.68
 >
 > This documentation is optimized for AI assistants. It provides focused, domain-specific
 > references to help you understand and use the een-api-toolkit efficiently.

--- a/docs/ai-reference/AI-AUTH.md
+++ b/docs/ai-reference/AI-AUTH.md
@@ -1,6 +1,6 @@
 # Authentication - EEN API Toolkit
 
-> **Version:** 0.3.67
+> **Version:** 0.3.68
 >
 > OAuth flow implementation, token management, and session handling.
 > Load this document when implementing login, logout, or auth guards.

--- a/docs/ai-reference/AI-AUTOMATIONS.md
+++ b/docs/ai-reference/AI-AUTOMATIONS.md
@@ -1,6 +1,6 @@
 # Automations API - EEN API Toolkit
 
-> **Version:** 0.3.67
+> **Version:** 0.3.68
 >
 > Complete reference for automation rules and alert actions.
 > Load this document when working with automated alert workflows.

--- a/docs/ai-reference/AI-DEVICES.md
+++ b/docs/ai-reference/AI-DEVICES.md
@@ -1,6 +1,6 @@
 # Cameras & Bridges API - EEN API Toolkit
 
-> **Version:** 0.3.67
+> **Version:** 0.3.68
 >
 > Complete reference for camera and bridge management.
 > Load this document when working with devices.

--- a/docs/ai-reference/AI-EVENT-DATA-SCHEMAS.md
+++ b/docs/ai-reference/AI-EVENT-DATA-SCHEMAS.md
@@ -1,6 +1,6 @@
 # Event Type to Data Schemas Mapping - EEN API Toolkit
 
-> **Version:** 0.3.67
+> **Version:** 0.3.68
 >
 > Complete reference for event type to data schema mappings.
 > Load this document when building dynamic event queries with the `include` parameter.

--- a/docs/ai-reference/AI-EVENTS.md
+++ b/docs/ai-reference/AI-EVENTS.md
@@ -1,6 +1,6 @@
 # Events, Alerts & Real-Time Streaming - EEN API Toolkit
 
-> **Version:** 0.3.67
+> **Version:** 0.3.68
 >
 > Complete reference for events, alerts, metrics, and SSE subscriptions.
 > Load this document when implementing event-driven features.

--- a/docs/ai-reference/AI-GROUPING.md
+++ b/docs/ai-reference/AI-GROUPING.md
@@ -1,6 +1,6 @@
 # Layouts API - EEN API Toolkit
 
-> **Version:** 0.3.67
+> **Version:** 0.3.68
 >
 > Complete reference for layout management (camera grouping).
 > Load this document when working with layouts.

--- a/docs/ai-reference/AI-JOBS.md
+++ b/docs/ai-reference/AI-JOBS.md
@@ -1,6 +1,6 @@
 # Jobs, Exports, Files & Downloads - EEN API Toolkit
 
-> **Version:** 0.3.67
+> **Version:** 0.3.68
 >
 > Complete reference for async jobs, video exports, and file management.
 > Load this document when implementing export workflows or file downloads.

--- a/docs/ai-reference/AI-MEDIA.md
+++ b/docs/ai-reference/AI-MEDIA.md
@@ -1,6 +1,6 @@
 # Media & Live Video - EEN API Toolkit
 
-> **Version:** 0.3.67
+> **Version:** 0.3.68
 >
 > Complete reference for media retrieval, live streaming, and video playback.
 > Load this document when implementing video features.

--- a/docs/ai-reference/AI-SETUP.md
+++ b/docs/ai-reference/AI-SETUP.md
@@ -1,6 +1,6 @@
 # Vue 3 Application Setup - EEN API Toolkit
 
-> **Version:** 0.3.67
+> **Version:** 0.3.68
 >
 > Complete guide for setting up a Vue 3 application with the een-api-toolkit.
 > Load this document when creating a new project or troubleshooting setup issues.

--- a/docs/ai-reference/AI-USERS.md
+++ b/docs/ai-reference/AI-USERS.md
@@ -1,6 +1,6 @@
 # Users API - EEN API Toolkit
 
-> **Version:** 0.3.67
+> **Version:** 0.3.68
 >
 > Complete reference for user management.
 > Load this document when working with user data.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,8 +1,8 @@
-**EEN API Toolkit v0.3.67**
+**EEN API Toolkit v0.3.68**
 
 ***
 
-# EEN API Toolkit v0.3.67
+# EEN API Toolkit v0.3.68
 
 ## Interfaces
 

--- a/docs/api/functions/addFile.md
+++ b/docs/api/functions/addFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/connectToEventSubscription.md
+++ b/docs/api/functions/connectToEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/createEventSubscription.md
+++ b/docs/api/functions/createEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/createExportJob.md
+++ b/docs/api/functions/createExportJob.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/createLayout.md
+++ b/docs/api/functions/createLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteEventSubscription.md
+++ b/docs/api/functions/deleteEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteFile.md
+++ b/docs/api/functions/deleteFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteJob.md
+++ b/docs/api/functions/deleteJob.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteLayout.md
+++ b/docs/api/functions/deleteLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/downloadDownload.md
+++ b/docs/api/functions/downloadDownload.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/downloadFile.md
+++ b/docs/api/functions/downloadFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/eventTypeHasDataSchemas.md
+++ b/docs/api/functions/eventTypeHasDataSchemas.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/formatTimestamp.md
+++ b/docs/api/functions/formatTimestamp.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAccessToken.md
+++ b/docs/api/functions/getAccessToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlert.md
+++ b/docs/api/functions/getAlert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlertAction.md
+++ b/docs/api/functions/getAlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlertActionRule.md
+++ b/docs/api/functions/getAlertActionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlertConditionRule.md
+++ b/docs/api/functions/getAlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAllDataSchemas.md
+++ b/docs/api/functions/getAllDataSchemas.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAllKnownEventTypes.md
+++ b/docs/api/functions/getAllKnownEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAuthUrl.md
+++ b/docs/api/functions/getAuthUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridge.md
+++ b/docs/api/functions/getBridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridges.md
+++ b/docs/api/functions/getBridges.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCamera.md
+++ b/docs/api/functions/getCamera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameraSettings.md
+++ b/docs/api/functions/getCameraSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameraStatusString.md
+++ b/docs/api/functions/getCameraStatusString.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameras.md
+++ b/docs/api/functions/getCameras.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getClientId.md
+++ b/docs/api/functions/getClientId.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getConfig.md
+++ b/docs/api/functions/getConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCurrentUser.md
+++ b/docs/api/functions/getCurrentUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getDataSchemasForEventType.md
+++ b/docs/api/functions/getDataSchemasForEventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getDownload.md
+++ b/docs/api/functions/getDownload.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEvent.md
+++ b/docs/api/functions/getEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventAlertConditionRule.md
+++ b/docs/api/functions/getEventAlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventAlertConditionRuleFieldValues.md
+++ b/docs/api/functions/getEventAlertConditionRuleFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventMetrics.md
+++ b/docs/api/functions/getEventMetrics.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventSubscription.md
+++ b/docs/api/functions/getEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventTypesForDataSchema.md
+++ b/docs/api/functions/getEventTypesForDataSchema.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getFile.md
+++ b/docs/api/functions/getFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getIncludeParameterForEventTypes.md
+++ b/docs/api/functions/getIncludeParameterForEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getJob.md
+++ b/docs/api/functions/getJob.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayout.md
+++ b/docs/api/functions/getLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayouts.md
+++ b/docs/api/functions/getLayouts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLiveImage.md
+++ b/docs/api/functions/getLiveImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getMediaSession.md
+++ b/docs/api/functions/getMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getNotification.md
+++ b/docs/api/functions/getNotification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getProxyUrl.md
+++ b/docs/api/functions/getProxyUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRecordedImage.md
+++ b/docs/api/functions/getRecordedImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRedirectUri.md
+++ b/docs/api/functions/getRedirectUri.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getStorageStrategy.md
+++ b/docs/api/functions/getStorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUser.md
+++ b/docs/api/functions/getUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUsers.md
+++ b/docs/api/functions/getUsers.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/handleAuthCallback.md
+++ b/docs/api/functions/handleAuthCallback.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/initEenToolkit.md
+++ b/docs/api/functions/initEenToolkit.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/initMediaSession.md
+++ b/docs/api/functions/initMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/isStatusObject.md
+++ b/docs/api/functions/isStatusObject.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertActionRules.md
+++ b/docs/api/functions/listAlertActionRules.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertActions.md
+++ b/docs/api/functions/listAlertActions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertConditionRules.md
+++ b/docs/api/functions/listAlertConditionRules.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertTypes.md
+++ b/docs/api/functions/listAlertTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlerts.md
+++ b/docs/api/functions/listAlerts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/listDownloads.md
+++ b/docs/api/functions/listDownloads.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventAlertConditionRules.md
+++ b/docs/api/functions/listEventAlertConditionRules.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventFieldValues.md
+++ b/docs/api/functions/listEventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventSubscriptions.md
+++ b/docs/api/functions/listEventSubscriptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventTypes.md
+++ b/docs/api/functions/listEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEvents.md
+++ b/docs/api/functions/listEvents.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/listFeeds.md
+++ b/docs/api/functions/listFeeds.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/listFiles.md
+++ b/docs/api/functions/listFiles.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/listJobs.md
+++ b/docs/api/functions/listJobs.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/listMedia.md
+++ b/docs/api/functions/listMedia.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/listNotifications.md
+++ b/docs/api/functions/listNotifications.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/refreshToken.md
+++ b/docs/api/functions/refreshToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/revokeToken.md
+++ b/docs/api/functions/revokeToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/functions/updateLayout.md
+++ b/docs/api/functions/updateLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Alert.md
+++ b/docs/api/interfaces/Alert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertAction.md
+++ b/docs/api/interfaces/AlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertActionRule.md
+++ b/docs/api/interfaces/AlertActionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRule.md
+++ b/docs/api/interfaces/AlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRuleAction.md
+++ b/docs/api/interfaces/AlertConditionRuleAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRuleActor.md
+++ b/docs/api/interfaces/AlertConditionRuleActor.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRuleInsights.md
+++ b/docs/api/interfaces/AlertConditionRuleInsights.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertType.md
+++ b/docs/api/interfaces/AlertType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AutomationAlertAction.md
+++ b/docs/api/interfaces/AutomationAlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Bridge.md
+++ b/docs/api/interfaces/Bridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDeviceInfo.md
+++ b/docs/api/interfaces/BridgeDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDevicePosition.md
+++ b/docs/api/interfaces/BridgeDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeNetworkInfo.md
+++ b/docs/api/interfaces/BridgeNetworkInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Camera.md
+++ b/docs/api/interfaces/Camera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDeviceInfo.md
+++ b/docs/api/interfaces/CameraDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDevicePosition.md
+++ b/docs/api/interfaces/CameraDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRecordingModes.md
+++ b/docs/api/interfaces/CameraRecordingModes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRtspConnectionSettings.md
+++ b/docs/api/interfaces/CameraRtspConnectionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettings.md
+++ b/docs/api/interfaces/CameraSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsAnalog.md
+++ b/docs/api/interfaces/CameraSettingsAnalog.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsAudio.md
+++ b/docs/api/interfaces/CameraSettingsAudio.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsCredentials.md
+++ b/docs/api/interfaces/CameraSettingsCredentials.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsData.md
+++ b/docs/api/interfaces/CameraSettingsData.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsMainVideo.md
+++ b/docs/api/interfaces/CameraSettingsMainVideo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsOperating.md
+++ b/docs/api/interfaces/CameraSettingsOperating.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsPreviewVideo.md
+++ b/docs/api/interfaces/CameraSettingsPreviewVideo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsRetention.md
+++ b/docs/api/interfaces/CameraSettingsRetention.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsScheduledOverride.md
+++ b/docs/api/interfaces/CameraSettingsScheduledOverride.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsTalkdown.md
+++ b/docs/api/interfaces/CameraSettingsTalkdown.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraShareDetails.md
+++ b/docs/api/interfaces/CameraShareDetails.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStatusCounts.md
+++ b/docs/api/interfaces/CameraStatusCounts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStreamUrls.md
+++ b/docs/api/interfaces/CameraStreamUrls.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateEventSubscriptionParams.md
+++ b/docs/api/interfaces/CreateEventSubscriptionParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateExportParams.md
+++ b/docs/api/interfaces/CreateExportParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateFileParams.md
+++ b/docs/api/interfaces/CreateFileParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateLayoutParams.md
+++ b/docs/api/interfaces/CreateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Download.md
+++ b/docs/api/interfaces/Download.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/DownloadFileResult.md
+++ b/docs/api/interfaces/DownloadFileResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenError.md
+++ b/docs/api/interfaces/EenError.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenFile.md
+++ b/docs/api/interfaces/EenFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenToolkitConfig.md
+++ b/docs/api/interfaces/EenToolkitConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Event.md
+++ b/docs/api/interfaces/Event.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventAlertConditionRule.md
+++ b/docs/api/interfaces/EventAlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventAlertConditionRuleFieldValues.md
+++ b/docs/api/interfaces/EventAlertConditionRuleFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventData.md
+++ b/docs/api/interfaces/EventData.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventFieldValues.md
+++ b/docs/api/interfaces/EventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventFilter.md
+++ b/docs/api/interfaces/EventFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventMetric.md
+++ b/docs/api/interfaces/EventMetric.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventResourceFilter.md
+++ b/docs/api/interfaces/EventResourceFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscription.md
+++ b/docs/api/interfaces/EventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionConfig.md
+++ b/docs/api/interfaces/EventSubscriptionConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionFilter.md
+++ b/docs/api/interfaces/EventSubscriptionFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventType.md
+++ b/docs/api/interfaces/EventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventTypeFilter.md
+++ b/docs/api/interfaces/EventTypeFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Feed.md
+++ b/docs/api/interfaces/Feed.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/FilterCreate.md
+++ b/docs/api/interfaces/FilterCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetAlertConditionRuleParams.md
+++ b/docs/api/interfaces/GetAlertConditionRuleParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetAlertParams.md
+++ b/docs/api/interfaces/GetAlertParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetBridgeParams.md
+++ b/docs/api/interfaces/GetBridgeParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetCameraParams.md
+++ b/docs/api/interfaces/GetCameraParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetCameraSettingsParams.md
+++ b/docs/api/interfaces/GetCameraSettingsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetDownloadParams.md
+++ b/docs/api/interfaces/GetDownloadParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventAlertConditionRuleFieldValuesParams.md
+++ b/docs/api/interfaces/GetEventAlertConditionRuleFieldValuesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventMetricsParams.md
+++ b/docs/api/interfaces/GetEventMetricsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventParams.md
+++ b/docs/api/interfaces/GetEventParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetFileParams.md
+++ b/docs/api/interfaces/GetFileParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetJobParams.md
+++ b/docs/api/interfaces/GetJobParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLayoutParams.md
+++ b/docs/api/interfaces/GetLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLiveImageParams.md
+++ b/docs/api/interfaces/GetLiveImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetRecordedImageParams.md
+++ b/docs/api/interfaces/GetRecordedImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetUserParams.md
+++ b/docs/api/interfaces/GetUserParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/HumanValidation.md
+++ b/docs/api/interfaces/HumanValidation.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Job.md
+++ b/docs/api/interfaces/Job.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Layout.md
+++ b/docs/api/interfaces/Layout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPane.md
+++ b/docs/api/interfaces/LayoutPane.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPermissions.md
+++ b/docs/api/interfaces/LayoutPermissions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutSettings.md
+++ b/docs/api/interfaces/LayoutSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertActionRulesParams.md
+++ b/docs/api/interfaces/ListAlertActionRulesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertActionsParams.md
+++ b/docs/api/interfaces/ListAlertActionsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertConditionRulesParams.md
+++ b/docs/api/interfaces/ListAlertConditionRulesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertTypesParams.md
+++ b/docs/api/interfaces/ListAlertTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertsParams.md
+++ b/docs/api/interfaces/ListAlertsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListBridgesParams.md
+++ b/docs/api/interfaces/ListBridgesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListCamerasParams.md
+++ b/docs/api/interfaces/ListCamerasParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListDownloadsParams.md
+++ b/docs/api/interfaces/ListDownloadsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventAlertConditionRulesParams.md
+++ b/docs/api/interfaces/ListEventAlertConditionRulesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventFieldValuesParams.md
+++ b/docs/api/interfaces/ListEventFieldValuesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventSubscriptionsParams.md
+++ b/docs/api/interfaces/ListEventSubscriptionsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventTypesParams.md
+++ b/docs/api/interfaces/ListEventTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventsParams.md
+++ b/docs/api/interfaces/ListEventsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsParams.md
+++ b/docs/api/interfaces/ListFeedsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsResult.md
+++ b/docs/api/interfaces/ListFeedsResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFilesParams.md
+++ b/docs/api/interfaces/ListFilesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListJobsParams.md
+++ b/docs/api/interfaces/ListJobsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListLayoutsParams.md
+++ b/docs/api/interfaces/ListLayoutsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListMediaParams.md
+++ b/docs/api/interfaces/ListMediaParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListNotificationsParams.md
+++ b/docs/api/interfaces/ListNotificationsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListUsersParams.md
+++ b/docs/api/interfaces/ListUsersParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LiveImageResult.md
+++ b/docs/api/interfaces/LiveImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaInterval.md
+++ b/docs/api/interfaces/MediaInterval.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResponse.md
+++ b/docs/api/interfaces/MediaSessionResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResult.md
+++ b/docs/api/interfaces/MediaSessionResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Notification.md
+++ b/docs/api/interfaces/Notification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/NotificationSettings.md
+++ b/docs/api/interfaces/NotificationSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/OutputPortSettings.md
+++ b/docs/api/interfaces/OutputPortSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginatedResult.md
+++ b/docs/api/interfaces/PaginatedResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginationParams.md
+++ b/docs/api/interfaces/PaginationParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PlaySpeakerAudioClipSettings.md
+++ b/docs/api/interfaces/PlaySpeakerAudioClipSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/RecordedImageResult.md
+++ b/docs/api/interfaces/RecordedImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnection.md
+++ b/docs/api/interfaces/SSEConnection.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnectionOptions.md
+++ b/docs/api/interfaces/SSEConnectionOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfig.md
+++ b/docs/api/interfaces/SSEDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfigCreate.md
+++ b/docs/api/interfaces/SSEDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEEvent.md
+++ b/docs/api/interfaces/SSEEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SlackSettings.md
+++ b/docs/api/interfaces/SlackSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SmsSettings.md
+++ b/docs/api/interfaces/SmsSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SmtpSettings.md
+++ b/docs/api/interfaces/SmtpSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/TokenResponse.md
+++ b/docs/api/interfaces/TokenResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UpdateLayoutParams.md
+++ b/docs/api/interfaces/UpdateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/User.md
+++ b/docs/api/interfaces/User.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UserProfile.md
+++ b/docs/api/interfaces/UserProfile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfig.md
+++ b/docs/api/interfaces/WebhookDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfigCreate.md
+++ b/docs/api/interfaces/WebhookDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookSettings.md
+++ b/docs/api/interfaces/WebhookSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ActorType.md
+++ b/docs/api/type-aliases/ActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionSettings.md
+++ b/docs/api/type-aliases/AlertActionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionStatus.md
+++ b/docs/api/type-aliases/AlertActionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionType.md
+++ b/docs/api/type-aliases/AlertActionType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertConditionRuleInclude.md
+++ b/docs/api/type-aliases/AlertConditionRuleInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertInclude.md
+++ b/docs/api/type-aliases/AlertInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertSort.md
+++ b/docs/api/type-aliases/AlertSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/BridgeStatus.md
+++ b/docs/api/type-aliases/BridgeStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraAspectRatio.md
+++ b/docs/api/type-aliases/CameraAspectRatio.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraSettingsInclude.md
+++ b/docs/api/type-aliases/CameraSettingsInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraStatus.md
+++ b/docs/api/type-aliases/CameraStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DataSchema.md
+++ b/docs/api/type-aliases/DataSchema.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfig.md
+++ b/docs/api/type-aliases/DeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfigCreate.md
+++ b/docs/api/type-aliases/DeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DownloadDownloadResult.md
+++ b/docs/api/type-aliases/DownloadDownloadResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DownloadStatus.md
+++ b/docs/api/type-aliases/DownloadStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ErrorCode.md
+++ b/docs/api/type-aliases/ErrorCode.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionDeliveryType.md
+++ b/docs/api/type-aliases/EventSubscriptionDeliveryType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionLifecycle.md
+++ b/docs/api/type-aliases/EventSubscriptionLifecycle.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ExportJobResponse.md
+++ b/docs/api/type-aliases/ExportJobResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ExportType.md
+++ b/docs/api/type-aliases/ExportType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedIncludeOption.md
+++ b/docs/api/type-aliases/FeedIncludeOption.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedMediaType.md
+++ b/docs/api/type-aliases/FeedMediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedStreamType.md
+++ b/docs/api/type-aliases/FeedStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FileIncludeField.md
+++ b/docs/api/type-aliases/FileIncludeField.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FileType.md
+++ b/docs/api/type-aliases/FileType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/GetLayoutInclude.md
+++ b/docs/api/type-aliases/GetLayoutInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/JobState.md
+++ b/docs/api/type-aliases/JobState.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/KnownEventType.md
+++ b/docs/api/type-aliases/KnownEventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneSize.md
+++ b/docs/api/type-aliases/LayoutPaneSize.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneType.md
+++ b/docs/api/type-aliases/LayoutPaneType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsInclude.md
+++ b/docs/api/type-aliases/ListLayoutsInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsSort.md
+++ b/docs/api/type-aliases/ListLayoutsSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaStreamType.md
+++ b/docs/api/type-aliases/MediaStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaType.md
+++ b/docs/api/type-aliases/MediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricActorType.md
+++ b/docs/api/type-aliases/MetricActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricDataPoint.md
+++ b/docs/api/type-aliases/MetricDataPoint.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationCategory.md
+++ b/docs/api/type-aliases/NotificationCategory.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationStatus.md
+++ b/docs/api/type-aliases/NotificationStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/Result.md
+++ b/docs/api/type-aliases/Result.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/SSEConnectionStatus.md
+++ b/docs/api/type-aliases/SSEConnectionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/StorageStrategy.md
+++ b/docs/api/type-aliases/StorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/variables/EVENT_TYPE_DATA_SCHEMAS.md
+++ b/docs/api/variables/EVENT_TYPE_DATA_SCHEMAS.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
+++ b/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/docs/api/variables/useAuthStore.md
+++ b/docs/api/variables/useAuthStore.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.67**](../README.md)
+[**EEN API Toolkit v0.3.68**](../README.md)
 
 ***
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.67",
+  "version": "0.3.68",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit",
-      "version": "0.3.67",
+      "version": "0.3.68",
       "license": "MIT",
       "bin": {
         "een-setup-agents": "scripts/setup-agents.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.67",
+  "version": "0.3.68",
   "description": "EEN Video platform API v3.0 library for Vue 3",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/media/service.ts
+++ b/src/media/service.ts
@@ -648,6 +648,22 @@ export async function initMediaSession(): Promise<Result<MediaSessionResult>> {
   const sessionUrl = sessionResult.data.url
   debug('Calling session URL to set cookie:', sessionUrl)
 
+  // Validate session URL domain to prevent SSRF attacks
+  // Session URLs should only come from trusted EEN domains
+  try {
+    const sessionUrlObj = new URL(sessionUrl)
+    const allowedDomains = ['.eagleeyenetworks.com', '.een.cloud']
+    // Allow both exact domain match (e.g., eagleeyenetworks.com) and subdomain match (e.g., api.eagleeyenetworks.com)
+    const isAllowedDomain = allowedDomains.some(domain =>
+      sessionUrlObj.hostname === domain.substring(1) || sessionUrlObj.hostname.endsWith(domain)
+    )
+    if (!isAllowedDomain) {
+      return failure('VALIDATION_ERROR', `Session URL domain not allowed: ${sessionUrlObj.hostname}`)
+    }
+  } catch {
+    return failure('VALIDATION_ERROR', 'Invalid session URL format')
+  }
+
   const { controller, timeoutId } = createTimeoutController()
 
   try {


### PR DESCRIPTION
## Summary
Added Server-Side Request Forgery (SSRF) protection to the `initMediaSession()` function by validating that session URLs only come from trusted Eagle Eye Networks domains before making requests.

## Changes
- **Security Enhancement**: Implemented domain whitelist validation for session URLs in `src/media/service.ts`
  - Validates session URLs against allowed domains: `.eagleeyenetworks.com` and `.een.cloud`
  - Supports both exact domain matches (e.g., `eagleeyenetworks.com`) and subdomain matches (e.g., `api.eagleeyenetworks.com`)
  - Returns a `VALIDATION_ERROR` if the session URL domain is not in the whitelist
  - Handles URL parsing errors gracefully with appropriate error response

## Implementation Details
- Added try-catch block to safely parse and validate the session URL before use
- Validation occurs immediately after receiving the session URL from the API response
- Prevents potential SSRF attacks by ensuring only trusted domains can be accessed
- Version bumped to 0.3.68 and documentation updated accordingly

https://claude.ai/code/session_011qnaJKuCVVchRwYw3vVxi1