### PR TITLE
Release v0.3.70: Fix Dependabot TypeScript minor version ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,11 +37,12 @@ updates:
         patterns:
           - "*"
     open-pull-requests-limit: 5
-    # TypeScript pinned to ~5.8.x (allows patch updates within 5.8.x range)
-    # Block major updates only; minor is already constrained by ~ in package.json
+    # TypeScript pinned to ~5.8.x for API Extractor compatibility with vite-plugin-dts
+    # Block major and minor updates; ~ in package.json constrains npm install,
+    # but Dependabot modifies package.json directly so it must be blocked here too
     ignore:
       - dependency-name: "typescript"
-        update-types: ["version-update:semver-major"]
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
       # eslint 10 not yet supported by @typescript-eslint/eslint-plugin 8.x
       - dependency-name: "eslint"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary

- Re-add `semver-minor` ignore for TypeScript in Dependabot config to prevent unwanted 5.8→5.9 bump PRs
- Dependabot modifies `package.json` directly, bypassing the `~5.8.x` constraint — must be blocked at the Dependabot level
- Addresses review feedback from PR #102 and closes Dependabot PR #104
- Documentation updates: fix inaccuracies in CLAUDE.md and README.md, regenerate API docs
- Remove misleading auto-merge comment, add CodeQL and SHA pinning guidance to CLAUDE.md

## Changes

- `.github/dependabot.yml` - Re-add semver-minor to TypeScript ignore, clarify comments
- `.github/workflows/validate-pr.yml` - Add validation to discover-examples job
- `.github/workflows/claude-code-review.yml` - Update SHA version comment to v1.0.48
- `CLAUDE.md` - Fix 7 documentation inaccuracies, add SHA pinning guidance
- `README.md` - Add vue-automations and vue-jobs to examples table
- `docs/` - Regenerated API docs and AI reference docs

## Test Results

- **Lint**: Passed (0 errors, 1 warning)
- **Unit tests**: 619/619 passed
- **Build**: Successful
- **E2E tests**: 11/11 example apps passed

## Security Review

No source code changes — infrastructure and documentation only. No security concerns.

## Version

v0.3.70