### PR TITLE
fix: revert broken head_branch check and update agents/skill

### DIFF
--- a/.claude/agents/een-auth-agent.md
+++ b/.claude/agents/een-auth-agent.md
@@ -254,21 +254,23 @@ The EEN OAuth login page uses a **two-step authentication flow**:
 1. **Step 1 - Email**: User enters email address and clicks "Next"
 2. **Step 2 - Password**: Password field appears, user enters password and clicks "Sign in"
 
-This is important for Playwright tests - you cannot fill both fields at once:
+This is important for Playwright tests - you cannot fill both fields at once.
+
+**BEST PRACTICE:** Use `getByPlaceholder()` selectors — they are the most reliable across EEN login page versions:
 
 ```typescript
 // Playwright test example for EEN two-step login
 // Step 1: Enter email and click Next
-const emailInput = page.locator('input[type="email"], input[type="text"]').first()
-await emailInput.fill(TEST_USER)
+await page.getByPlaceholder(/email/i).fill(TEST_USER)
 await page.getByRole('button', { name: /next/i }).click()
 
 // Step 2: Wait for password field and fill it
-const passwordInput = page.locator('input[type="password"]')
-await passwordInput.waitFor({ state: 'visible', timeout: 10000 })
-await passwordInput.fill(TEST_PASSWORD)
-await page.getByRole('button', { name: /sign in/i }).click()
+await page.getByPlaceholder(/password/i).fill(TEST_PASSWORD, { timeout: 15000 })
+await page.getByRole('button', { name: /sign in|next/i }).click()
 ```
+
+**NOTE:** The `#authentication--input__email` and `#authentication--input__password` ID selectors
+may not always be present. The `getByPlaceholder()` approach is more reliable.
 
 ## Playwright E2E Test Patterns
 
@@ -283,27 +285,22 @@ Best practices for auth testing:
 ```typescript
 // Complete performLogin helper function
 async function performLogin(page: Page, username: string, password: string): Promise<void> {
-  await page.goto('/login')
-  await page.click('button:has-text("Login with Eagle Eye Networks")')
+  await page.goto('/')
+  await page.getByRole('link', { name: 'Login' }).click()
 
   // Wait for EEN OAuth page
-  await page.waitForURL(/.*eagleeyenetworks.com.*/, { timeout: 30000 })
+  await page.waitForURL(/auth\.eagleeyenetworks\.com|id\.eagleeyenetworks\.com/, { timeout: 15000 })
 
-  // Step 1: Email
-  const emailInput = page.locator('#authentication--input__email, input[type="email"]').first()
-  await emailInput.waitFor({ state: 'visible', timeout: 15000 })
-  await emailInput.fill(username)
-  await page.getByRole('button', { name: 'Next' }).click()
+  // Step 1: Email (use getByPlaceholder - most reliable selector)
+  await page.getByPlaceholder(/email/i).fill(username)
+  await page.getByRole('button', { name: /next/i }).click()
 
-  // Step 2: Password
-  const passwordInput = page.locator('#authentication--input__password, input[type="password"]')
-  await passwordInput.waitFor({ state: 'visible', timeout: 10000 })
-  await passwordInput.fill(password)
-  await page.locator('#next, button:has-text("Sign in")').first().click()
+  // Step 2: Password (appears after Next is clicked)
+  await page.getByPlaceholder(/password/i).fill(password, { timeout: 15000 })
+  await page.getByRole('button', { name: /sign in|next/i }).click()
 
   // Wait for redirect back to app
-  await page.waitForURL(/127\.0\.0\.1:3333/, { timeout: 60000 })
-  await page.waitForURL('**/', { timeout: 60000 })
+  await page.waitForURL('http://127.0.0.1:3333/**', { timeout: 30000 })
 }
 
 // Clear auth state helper

--- a/.claude/agents/een-events-agent.md
+++ b/.claude/agents/een-events-agent.md
@@ -381,22 +381,31 @@ async function fetchNotifications() {
 4. **Cleanup** - Delete subscription when done (or it auto-expires after 15 min of inactivity)
 
 ### createEventSubscription()
+
+**CRITICAL: The subscription API uses nested `deliveryConfig` and `filters` structures, NOT flat params.**
+
 ```typescript
 import {
   createEventSubscription,
   connectToEventSubscription,
   deleteEventSubscription,
-  type CreateEventSubscriptionParams
+  type SSEEvent,
+  type SSEConnection,
+  type SSEConnectionStatus
 } from 'een-api-toolkit'
 
-const subscriptionId = ref<string | null>(null)
-const sseConnection = ref<EventSource | null>(null)
+let sseConnection: SSEConnection | null = null
+let subscriptionId: string | null = null
 
-async function startRealTimeEvents(cameraId: string) {
+async function startRealTimeEvents(cameraId: string, eventTypes: string[]) {
   // Step 1: Create subscription
+  // IMPORTANT: types must be objects with { id: string }, not plain strings
   const result = await createEventSubscription({
-    actors: [`camera:${cameraId}`],
-    types: ['een.motionDetectionEvent.v1', 'een.objectDetectionEvent.v1']
+    deliveryConfig: { type: 'serverSentEvents.v1' },
+    filters: [{
+      actors: [`camera:${cameraId}`],
+      types: eventTypes.map(t => ({ id: t }))
+    }]
   })
 
   if (result.error) {
@@ -404,36 +413,56 @@ async function startRealTimeEvents(cameraId: string) {
     return
   }
 
-  subscriptionId.value = result.data.id
+  subscriptionId = result.data.id
 
-  // Step 2: Connect to SSE stream
-  const connection = connectToEventSubscription(result.data.sseUrl, {
-    onEvent: (event) => {
-      console.log('Real-time event:', event)
-      // Add to events list, show notification, etc.
+  // Step 2: Extract SSE URL from deliveryConfig (NOT from result.data.sseUrl)
+  const sseUrl = result.data.deliveryConfig.type === 'serverSentEvents.v1'
+    ? result.data.deliveryConfig.sseUrl
+    : undefined
+
+  if (!sseUrl) return
+
+  // Step 3: Connect to SSE stream
+  // IMPORTANT: Returns a Result type { data, error }, NOT the connection directly
+  const connectionResult = connectToEventSubscription(sseUrl, {
+    onEvent: (event: SSEEvent) => {
+      console.log('Real-time event:', event.type, event.startTimestamp)
     },
-    onError: (error) => {
-      console.error('SSE error:', error)
+    onError: (err: Error) => {
+      console.error('SSE error:', err.message)
     },
-    onOpen: () => {
-      console.log('SSE connection opened')
+    onStatusChange: (status: SSEConnectionStatus) => {
+      // status: 'connected' | 'connecting' | 'disconnected' | 'error'
+      console.log('SSE status:', status)
     }
   })
 
-  sseConnection.value = connection
+  if (connectionResult.error) {
+    console.error('Failed to connect:', connectionResult.error.message)
+    return
+  }
+
+  sseConnection = connectionResult.data
 }
 
-// Cleanup when component unmounts
-onUnmounted(async () => {
-  // Close SSE connection
-  if (sseConnection.value) {
-    sseConnection.value.close()
+// Cleanup when component unmounts or camera changes
+async function cleanupSSE() {
+  if (sseConnection) {
+    sseConnection.close()
+    sseConnection = null
   }
+  if (subscriptionId) {
+    try {
+      await deleteEventSubscription(subscriptionId)
+    } catch {
+      // Ignore cleanup errors
+    }
+    subscriptionId = null
+  }
+}
 
-  // Delete subscription
-  if (subscriptionId.value) {
-    await deleteEventSubscription(subscriptionId.value)
-  }
+onUnmounted(() => {
+  cleanupSSE()
 })
 ```
 
@@ -568,9 +597,21 @@ async function createMetricsChart(canvas: HTMLCanvasElement, cameraId: string) {
 | SUBSCRIPTION_LIMIT | Too many subscriptions | Delete old subscriptions |
 | SSE_CONNECTION_FAILED | Can't connect to stream | Retry with backoff |
 
+## Common SSE Mistakes
+
+| Mistake | Correct Approach |
+|---------|-----------------|
+| `createEventSubscription({ actors, types })` flat params | Use `{ deliveryConfig: { type: 'serverSentEvents.v1' }, filters: [{ actors, types }] }` |
+| `types: ['een.motionDetectionEvent.v1']` as strings | Use `types: [{ id: 'een.motionDetectionEvent.v1' }]` as objects |
+| `result.data.sseUrl` for the SSE URL | Use `result.data.deliveryConfig.sseUrl` |
+| Treating `connectToEventSubscription()` return as the connection | Returns `{ data: SSEConnection, error }` Result type |
+| Using `onOpen` callback | Use `onStatusChange` with `SSEConnectionStatus` type |
+| Forgetting to clean up when subscribed resource changes | Always clean up existing subscription before starting a new one |
+
 ## Constraints
 - Always use actor format: `camera:{cameraId}` or `account:{accountId}`
-- Always clean up SSE subscriptions on component unmount
+- Always clean up SSE subscriptions on component unmount and when the subscribed resource changes
 - Use formatTimestamp() for all timestamp parameters
 - Include 'data.overlays' in include[] to get bounding box SVGs
 - Handle SSE reconnection for long-running streams
+- Use `listEventFieldValues()` to discover available event types before subscribing

--- a/.claude/agents/een-media-agent.md
+++ b/.claude/agents/een-media-agent.md
@@ -67,13 +67,17 @@ assistant: "I'll use the een-media-agent to diagnose the HLS configuration and a
 - Check authentication before media operations
 - Pass config to LivePlayer's `start()` method, NOT the constructor
 
-## Choosing the Right Preview Method
+## Choosing the Right Video Method
+
+**IMPORTANT DECISION RULE:** When the user asks for "HD video", "main video", "full quality",
+or "live video feed", you MUST use the **Live Video SDK** (`@een/live-video-web-sdk`).
+Only use `multipartUrl` when explicitly asked for "preview", "thumbnail", or "low bandwidth" options.
 
 | Use Case | Method | Why |
 |----------|--------|-----|
 | Grid of 20+ cameras | `getLiveImage()` | Lower bandwidth, manual refresh |
 | Auto-updating preview | `multipartUrl` + `initMediaSession()` | Automatic updates, higher bandwidth |
-| Full-quality live video | Live Video SDK | Full resolution, lowest latency |
+| **Full-quality live video** | **Live Video SDK** | **Full resolution, lowest latency** |
 | Recorded video playback | HLS via `listMedia()` | Seek capability, standard player |
 
 **CRITICAL: Main feeds do NOT support multipartUrl**
@@ -83,7 +87,8 @@ The EEN API only returns `multipartUrl` for **preview feeds** (`type: 'preview'`
 - **Preview feeds** → Use `multipartUrl` (MJPEG in `<img>` element)
 - **Main feeds** → Use **Live Video SDK** (full HD in `<video>` element)
 
-If you need HD quality video, you MUST use the Live Video SDK. Do not attempt to use `multipartUrl` with main feeds - it won't work.
+If you need HD quality video, you MUST use the Live Video SDK (`npm install @een/live-video-web-sdk`).
+Do not attempt to use `multipartUrl` with main feeds - it won't work.
 
 ## Key Functions
 
@@ -312,6 +317,52 @@ The video element MUST be rendered in the DOM before calling `player.start()`.
 </style>
 ```
 
+## CRITICAL: Camera Switching with LivePlayer
+
+The LivePlayer SDK does **NOT cleanly release** the `<video>` element when `stop()` is called.
+Reusing the same `<video>` element for a new LivePlayer instance will result in the video feed
+**not updating** when the user switches cameras.
+
+**Solution:** Use a Vue `:key` to force a fresh `<video>` element on each camera switch:
+
+```vue
+<script setup lang="ts">
+const videoRef = ref<HTMLVideoElement | null>(null)
+const videoKey = ref(0)
+let livePlayer: LivePlayer | null = null
+
+async function startStream(cameraId: string) {
+  // Stop previous player
+  if (livePlayer) {
+    livePlayer.stop()
+    livePlayer = null
+  }
+
+  // CRITICAL: Increment key to force Vue to create a new <video> element
+  videoKey.value++
+  await nextTick()  // Wait for new element to be in DOM
+
+  livePlayer = new LivePlayer()
+  await livePlayer.start({
+    videoElement: videoRef.value!,
+    cameraId,
+    baseUrl: authStore.baseUrl ?? '',
+    jwt: authStore.token ?? ''
+  })
+}
+</script>
+
+<template>
+  <!-- :key forces a fresh DOM element when videoKey changes -->
+  <video :key="videoKey" ref="videoRef" autoplay muted playsinline />
+</template>
+```
+
+**Why this is needed:** After `livePlayer.stop()`, the old `<video>` element retains stale
+MediaSource/WebSocket state. Creating a new LivePlayer on the same element fails silently —
+the video appears frozen on the previous camera's last frame. The `:key` trick makes Vue
+destroy and recreate the DOM element, giving the new LivePlayer a clean slate.
+
 ## Error Handling
 
 | Error Code | Meaning | Action |
@@ -332,3 +383,5 @@ The video element MUST be rendered in the DOM before calling `player.start()`.
 | "Video Stream is done" immediately | Config passed to LivePlayer constructor | MUST use `new LivePlayer()` with no args, then `player.start(config)` |
 | "Video element not found" | Video element not in DOM | Ensure video element is rendered (not hidden by v-if) before SDK init |
 | Black video, no errors (LivePlayer) | Video element hidden by v-if | Use CSS visibility/opacity instead of v-if for conditional video display |
+| Video doesn't change on camera switch | LivePlayer doesn't release video element cleanly | Use Vue `:key` on `<video>` element, increment on each switch (see Camera Switching section) |
+| Used multipartUrl for "HD video" request | multipartUrl only supports preview feeds | Use Live Video SDK (`@een/live-video-web-sdk`) for HD/main feed video |

--- a/.claude/agents/een-setup-agent.md
+++ b/.claude/agents/een-setup-agent.md
@@ -2,8 +2,8 @@
 name: een-setup-agent
 description: |
   Use this agent when creating a new Vue 3 application with een-api-toolkit,
-  when fixing Pinia initialization errors, when troubleshooting OAuth redirect
-  URI issues, or when setting up Vite configuration for EEN applications.
+  when fixing Pinia initialization errors, or when setting up Vite configuration
+  for EEN applications.
 model: inherit
 color: green
 ---
@@ -26,34 +26,37 @@ assistant: "I'll use the een-setup-agent to diagnose and fix the Pinia initializ
 <Task tool call to launch een-setup-agent>
 </example>
 
-<example>
-Context: User has OAuth redirect issues.
-user: "My OAuth login redirects to the wrong URL"
-assistant: "I'll use the een-setup-agent to check your vite.config.ts and redirect URI configuration."
-<Task tool call to launch een-setup-agent>
-</example>
-
 ## Context Files
 Load these documentation files before starting:
 - docs/AI-CONTEXT.md (overview)
 - docs/ai-reference/AI-SETUP.md (primary reference)
 
+## Scope and Agent Delegation
+
+This agent handles **project scaffolding only**: Vite config, main.ts initialization,
+basic router structure, placeholder views, and environment variables.
+
+**After scaffolding, delegate to specialized agents for feature implementation:**
+
+- **een-auth-agent** — OAuth login/logout views, auth callback handling, route guards,
+  session restoration (`authStore.initialize()`), Playwright E2E auth tests.
+  Knows the EEN two-step login flow and correct Playwright selectors.
+- **een-media-agent** — Live video, camera previews, recorded images, HLS playback.
+  Knows when to use Live Video SDK vs multipartUrl and how to handle camera switching.
+- **een-devices-agent** — Camera/bridge listing, filtering, and device details.
+
+**Do NOT implement OAuth views (Login.vue, Callback.vue, Logout.vue) or media components
+yourself.** Create placeholder views, then let the caller invoke the specialized agent.
+
 ## Your Capabilities
-1. Create new Vue 3 project structure for EEN applications
-2. Configure main.ts with proper Pinia + toolkit initialization
-3. Set up vite.config.ts for EEN requirements (127.0.0.1:3333)
-4. Configure Vue Router with OAuth callback handling
-5. Set up environment variables
-6. Debug common setup errors (Pinia not active, redirect URI mismatch)
+1. Create Vue 3 + Vite + TypeScript project structure
+2. Configure main.ts with proper Pinia + toolkit initialization order
+3. Set up vite.config.ts (host: 127.0.0.1, port: 3333)
+4. Create basic router with placeholder routes for /, /login, /callback, /logout
+5. Set up .env environment variables
+6. Debug Pinia initialization errors
 
-## Workflow
-1. Verify prerequisites (Node 20+, Vue 3, Pinia)
-2. Create or modify configuration files
-3. Set up router with OAuth callback pattern
-4. Verify setup by checking for common errors
-5. Reference examples/vue-users/ for working patterns
-
-## Key Configuration Points
+## Key Configuration
 
 ### main.ts Initialization Order
 ```typescript
@@ -74,36 +77,7 @@ app.use(router)
 app.mount('#app')
 ```
 
-### App.vue Session Restoration (CRITICAL)
-**Users will need to re-login after every page refresh unless you call `authStore.initialize()` in App.vue.**
-
-```vue
-<script setup lang="ts">
-import { onMounted, computed } from 'vue'
-import { useAuthStore } from 'een-api-toolkit'
-
-const authStore = useAuthStore()
-const isAuthenticated = computed(() => authStore.isAuthenticated)
-
-// CRITICAL: Initialize auth store from storage on app mount
-// This restores the session if a valid token exists in localStorage/sessionStorage
-onMounted(() => {
-  authStore.initialize()
-})
-</script>
-```
-
-Without `initialize()`:
-- Token is saved to localStorage after login ✓
-- On page refresh, Pinia store starts with empty state
-- `isAuthenticated` returns false → user must login again
-
-With `initialize()`:
-- Token is loaded from localStorage on app mount
-- `isAuthenticated` returns true → session is restored
-- User can continue without re-logging in
-
-### vite.config.ts for EEN OAuth
+### vite.config.ts
 ```typescript
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
@@ -111,48 +85,25 @@ import vue from '@vitejs/plugin-vue'
 export default defineConfig({
   plugins: [vue()],
   server: {
-    // IMPORTANT: Must use 127.0.0.1:3333 for EEN OAuth callback
-    // The EEN Identity Provider only permits this specific redirect URI
-    host: '127.0.0.1',
+    host: '127.0.0.1',  // REQUIRED: Must match EEN OAuth redirect URI
     port: 3333
   }
 })
 ```
 
-### Router with OAuth Callback
-```typescript
-import { createRouter, createWebHistory } from 'vue-router'
-
-const routes = [
-  { path: '/', component: () => import('@/views/Home.vue') },
-  { path: '/login', component: () => import('@/views/Login.vue') },
-  { path: '/callback', component: () => import('@/views/Callback.vue') },
-  { path: '/logout', component: () => import('@/views/Logout.vue') }
-]
-
-const router = createRouter({
-  history: createWebHistory(),
-  routes
-})
-
-export default router
-```
+### Router Skeleton
+Create routes for /, /login, /callback, /logout. Auth guards and OAuth callback
+handling should be implemented by the **een-auth-agent**.
 
 ## Constraints
 - Always use 127.0.0.1, never localhost
 - Always use port 3333
 - Pinia must be installed before initEenToolkit()
-- Never add trailing slashes to redirect URIs
-- Ensure VITE_PROXY_URL is set in .env file
-- **Always call `authStore.initialize()` in App.vue onMounted** for session persistence
+- Ensure VITE_PROXY_URL and VITE_EEN_CLIENT_ID are set in .env
 
-## Common Errors and Solutions
+## Common Errors
 
 | Error | Cause | Solution |
 |-------|-------|----------|
-| "Pinia not active" | initEenToolkit() called before pinia.use() | Reorder initialization in main.ts |
-| "redirect_uri mismatch" | Wrong host/port | Use 127.0.0.1:3333 in vite.config.ts |
-| "Invalid redirect_uri" | Trailing slash | Remove trailing slash from redirect URI |
-| "CORS error" | Proxy not running | Start the OAuth proxy server |
-| Session lost on refresh | Missing initialize() call | Add `authStore.initialize()` in App.vue onMounted |
-| Must login after refresh | Missing initialize() call | Add `authStore.initialize()` in App.vue onMounted |
+| "Pinia not active" | initEenToolkit() called before app.use(pinia) | Reorder initialization in main.ts |
+| Auth/OAuth errors | See **een-auth-agent** | Delegate to een-auth-agent |

--- a/.claude/skills/PR-and-check/SKILL.md
+++ b/.claude/skills/PR-and-check/SKILL.md
@@ -45,6 +45,9 @@ description: Use this skill when you are requested to create a PR for a feature 
   - invoke the `/security-review` skill to analyze code changes for security vulnerabilities
   - if any HIGH severity vulnerabilities are found with confidence >= 8, report findings and stop
   - include security review summary in the PR body
+- Scan for confidential data leakage in documentation:
+  - use the `docs-accuracy-reviewer` agent to scan all changed `.md` files for secrets, credentials, API keys, internal hostnames, email addresses, account IDs, or other confidential information that should not be in a public npm package
+  - if any confidential data is found, report findings and stop
 
 ## 4. Create PR
 - Get version number for the PR body:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,11 +16,13 @@ on:
 
 jobs:
   publish:
-    # Run if: test workflow succeeded on production branch, OR manually triggered
+    # Run if: test workflow succeeded, OR manually triggered
+    # Note: test-release.yml only runs on PRs merged to production (or workflow_dispatch),
+    # so a successful workflow_run already implies a production-targeted merge.
+    # head_branch is the PR *source* branch (e.g. 'develop'), not the target.
     if: >
       (github.event_name == 'workflow_run' &&
-       github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.head_branch == 'production') ||
+       github.event.workflow_run.conclusion == 'success') ||
       github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:

--- a/docs/AI-CONTEXT.md
+++ b/docs/AI-CONTEXT.md
@@ -1,6 +1,6 @@
 # EEN API Toolkit - AI Reference
 
-> **Version:** 0.3.79
+> **Version:** 0.3.80
 >
 > This documentation is optimized for AI assistants. It provides focused, domain-specific
 > references to help you understand and use the een-api-toolkit efficiently.

--- a/docs/ai-reference/AI-AUTH.md
+++ b/docs/ai-reference/AI-AUTH.md
@@ -1,6 +1,6 @@
 # Authentication - EEN API Toolkit
 
-> **Version:** 0.3.79
+> **Version:** 0.3.80
 >
 > OAuth flow implementation, token management, and session handling.
 > Load this document when implementing login, logout, or auth guards.

--- a/docs/ai-reference/AI-AUTOMATIONS.md
+++ b/docs/ai-reference/AI-AUTOMATIONS.md
@@ -1,6 +1,6 @@
 # Automations API - EEN API Toolkit
 
-> **Version:** 0.3.79
+> **Version:** 0.3.80
 >
 > Complete reference for automation rules and alert actions.
 > Load this document when working with automated alert workflows.

--- a/docs/ai-reference/AI-DEVICES.md
+++ b/docs/ai-reference/AI-DEVICES.md
@@ -1,6 +1,6 @@
 # Cameras & Bridges API - EEN API Toolkit
 
-> **Version:** 0.3.79
+> **Version:** 0.3.80
 >
 > Complete reference for camera and bridge management.
 > Load this document when working with devices.

--- a/docs/ai-reference/AI-EVENT-DATA-SCHEMAS.md
+++ b/docs/ai-reference/AI-EVENT-DATA-SCHEMAS.md
@@ -1,6 +1,6 @@
 # Event Type to Data Schemas Mapping - EEN API Toolkit
 
-> **Version:** 0.3.79
+> **Version:** 0.3.80
 >
 > Complete reference for event type to data schema mappings.
 > Load this document when building dynamic event queries with the `include` parameter.

--- a/docs/ai-reference/AI-EVENTS.md
+++ b/docs/ai-reference/AI-EVENTS.md
@@ -1,6 +1,6 @@
 # Events, Alerts & Real-Time Streaming - EEN API Toolkit
 
-> **Version:** 0.3.79
+> **Version:** 0.3.80
 >
 > Complete reference for events, alerts, metrics, and SSE subscriptions.
 > Load this document when implementing event-driven features.

--- a/docs/ai-reference/AI-GROUPING.md
+++ b/docs/ai-reference/AI-GROUPING.md
@@ -1,6 +1,6 @@
 # Layouts API - EEN API Toolkit
 
-> **Version:** 0.3.79
+> **Version:** 0.3.80
 >
 > Complete reference for layout management (camera grouping).
 > Load this document when working with layouts.

--- a/docs/ai-reference/AI-JOBS.md
+++ b/docs/ai-reference/AI-JOBS.md
@@ -1,6 +1,6 @@
 # Jobs, Exports, Files & Downloads - EEN API Toolkit
 
-> **Version:** 0.3.79
+> **Version:** 0.3.80
 >
 > Complete reference for async jobs, video exports, and file management.
 > Load this document when implementing export workflows or file downloads.

--- a/docs/ai-reference/AI-MEDIA.md
+++ b/docs/ai-reference/AI-MEDIA.md
@@ -1,6 +1,6 @@
 # Media & Live Video - EEN API Toolkit
 
-> **Version:** 0.3.79
+> **Version:** 0.3.80
 >
 > Complete reference for media retrieval, live streaming, and video playback.
 > Load this document when implementing video features.

--- a/docs/ai-reference/AI-SETUP.md
+++ b/docs/ai-reference/AI-SETUP.md
@@ -1,6 +1,6 @@
 # Vue 3 Application Setup - EEN API Toolkit
 
-> **Version:** 0.3.79
+> **Version:** 0.3.80
 >
 > Complete guide for setting up a Vue 3 application with the een-api-toolkit.
 > Load this document when creating a new project or troubleshooting setup issues.

--- a/docs/ai-reference/AI-USERS.md
+++ b/docs/ai-reference/AI-USERS.md
@@ -1,6 +1,6 @@
 # Users API - EEN API Toolkit
 
-> **Version:** 0.3.79
+> **Version:** 0.3.80
 >
 > Complete reference for user management.
 > Load this document when working with user data.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,8 +1,8 @@
-**EEN API Toolkit v0.3.79**
+**EEN API Toolkit v0.3.80**
 
 ***
 
-# EEN API Toolkit v0.3.79
+# EEN API Toolkit v0.3.80
 
 ## Interfaces
 

--- a/docs/api/functions/addFile.md
+++ b/docs/api/functions/addFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/connectToEventSubscription.md
+++ b/docs/api/functions/connectToEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/createEventSubscription.md
+++ b/docs/api/functions/createEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/createExportJob.md
+++ b/docs/api/functions/createExportJob.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/createLayout.md
+++ b/docs/api/functions/createLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteEventSubscription.md
+++ b/docs/api/functions/deleteEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteFile.md
+++ b/docs/api/functions/deleteFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteJob.md
+++ b/docs/api/functions/deleteJob.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteLayout.md
+++ b/docs/api/functions/deleteLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/downloadDownload.md
+++ b/docs/api/functions/downloadDownload.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/downloadFile.md
+++ b/docs/api/functions/downloadFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/eventTypeHasDataSchemas.md
+++ b/docs/api/functions/eventTypeHasDataSchemas.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/formatTimestamp.md
+++ b/docs/api/functions/formatTimestamp.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAccessToken.md
+++ b/docs/api/functions/getAccessToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlert.md
+++ b/docs/api/functions/getAlert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlertAction.md
+++ b/docs/api/functions/getAlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlertActionRule.md
+++ b/docs/api/functions/getAlertActionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlertConditionRule.md
+++ b/docs/api/functions/getAlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAllDataSchemas.md
+++ b/docs/api/functions/getAllDataSchemas.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAllKnownEventTypes.md
+++ b/docs/api/functions/getAllKnownEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAuthUrl.md
+++ b/docs/api/functions/getAuthUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridge.md
+++ b/docs/api/functions/getBridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridges.md
+++ b/docs/api/functions/getBridges.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCamera.md
+++ b/docs/api/functions/getCamera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameraSettings.md
+++ b/docs/api/functions/getCameraSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameraStatusString.md
+++ b/docs/api/functions/getCameraStatusString.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameras.md
+++ b/docs/api/functions/getCameras.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getClientId.md
+++ b/docs/api/functions/getClientId.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getConfig.md
+++ b/docs/api/functions/getConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCurrentUser.md
+++ b/docs/api/functions/getCurrentUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getDataSchemasForEventType.md
+++ b/docs/api/functions/getDataSchemasForEventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getDownload.md
+++ b/docs/api/functions/getDownload.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEvent.md
+++ b/docs/api/functions/getEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventAlertConditionRule.md
+++ b/docs/api/functions/getEventAlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventAlertConditionRuleFieldValues.md
+++ b/docs/api/functions/getEventAlertConditionRuleFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventMetrics.md
+++ b/docs/api/functions/getEventMetrics.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventSubscription.md
+++ b/docs/api/functions/getEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventTypesForDataSchema.md
+++ b/docs/api/functions/getEventTypesForDataSchema.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getFile.md
+++ b/docs/api/functions/getFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getIncludeParameterForEventTypes.md
+++ b/docs/api/functions/getIncludeParameterForEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getJob.md
+++ b/docs/api/functions/getJob.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayout.md
+++ b/docs/api/functions/getLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayouts.md
+++ b/docs/api/functions/getLayouts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLiveImage.md
+++ b/docs/api/functions/getLiveImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getMediaSession.md
+++ b/docs/api/functions/getMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getNotification.md
+++ b/docs/api/functions/getNotification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getProxyUrl.md
+++ b/docs/api/functions/getProxyUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRecordedImage.md
+++ b/docs/api/functions/getRecordedImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRedirectUri.md
+++ b/docs/api/functions/getRedirectUri.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getStorageStrategy.md
+++ b/docs/api/functions/getStorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUser.md
+++ b/docs/api/functions/getUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUsers.md
+++ b/docs/api/functions/getUsers.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/handleAuthCallback.md
+++ b/docs/api/functions/handleAuthCallback.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/initEenToolkit.md
+++ b/docs/api/functions/initEenToolkit.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/initMediaSession.md
+++ b/docs/api/functions/initMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/isStatusObject.md
+++ b/docs/api/functions/isStatusObject.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertActionRules.md
+++ b/docs/api/functions/listAlertActionRules.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertActions.md
+++ b/docs/api/functions/listAlertActions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertConditionRules.md
+++ b/docs/api/functions/listAlertConditionRules.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertTypes.md
+++ b/docs/api/functions/listAlertTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlerts.md
+++ b/docs/api/functions/listAlerts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/listDownloads.md
+++ b/docs/api/functions/listDownloads.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventAlertConditionRules.md
+++ b/docs/api/functions/listEventAlertConditionRules.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventFieldValues.md
+++ b/docs/api/functions/listEventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventSubscriptions.md
+++ b/docs/api/functions/listEventSubscriptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventTypes.md
+++ b/docs/api/functions/listEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEvents.md
+++ b/docs/api/functions/listEvents.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/listFeeds.md
+++ b/docs/api/functions/listFeeds.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/listFiles.md
+++ b/docs/api/functions/listFiles.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/listJobs.md
+++ b/docs/api/functions/listJobs.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/listMedia.md
+++ b/docs/api/functions/listMedia.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/listNotifications.md
+++ b/docs/api/functions/listNotifications.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/refreshToken.md
+++ b/docs/api/functions/refreshToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/revokeToken.md
+++ b/docs/api/functions/revokeToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/functions/updateLayout.md
+++ b/docs/api/functions/updateLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Alert.md
+++ b/docs/api/interfaces/Alert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertAction.md
+++ b/docs/api/interfaces/AlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertActionRule.md
+++ b/docs/api/interfaces/AlertActionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRule.md
+++ b/docs/api/interfaces/AlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRuleAction.md
+++ b/docs/api/interfaces/AlertConditionRuleAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRuleActor.md
+++ b/docs/api/interfaces/AlertConditionRuleActor.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRuleInsights.md
+++ b/docs/api/interfaces/AlertConditionRuleInsights.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertType.md
+++ b/docs/api/interfaces/AlertType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AutomationAlertAction.md
+++ b/docs/api/interfaces/AutomationAlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Bridge.md
+++ b/docs/api/interfaces/Bridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDeviceInfo.md
+++ b/docs/api/interfaces/BridgeDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDevicePosition.md
+++ b/docs/api/interfaces/BridgeDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeNetworkInfo.md
+++ b/docs/api/interfaces/BridgeNetworkInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Camera.md
+++ b/docs/api/interfaces/Camera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDeviceInfo.md
+++ b/docs/api/interfaces/CameraDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDevicePosition.md
+++ b/docs/api/interfaces/CameraDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRecordingModes.md
+++ b/docs/api/interfaces/CameraRecordingModes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRtspConnectionSettings.md
+++ b/docs/api/interfaces/CameraRtspConnectionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettings.md
+++ b/docs/api/interfaces/CameraSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsAnalog.md
+++ b/docs/api/interfaces/CameraSettingsAnalog.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsAudio.md
+++ b/docs/api/interfaces/CameraSettingsAudio.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsCredentials.md
+++ b/docs/api/interfaces/CameraSettingsCredentials.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsData.md
+++ b/docs/api/interfaces/CameraSettingsData.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsMainVideo.md
+++ b/docs/api/interfaces/CameraSettingsMainVideo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsOperating.md
+++ b/docs/api/interfaces/CameraSettingsOperating.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsPreviewVideo.md
+++ b/docs/api/interfaces/CameraSettingsPreviewVideo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsRetention.md
+++ b/docs/api/interfaces/CameraSettingsRetention.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsScheduledOverride.md
+++ b/docs/api/interfaces/CameraSettingsScheduledOverride.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsTalkdown.md
+++ b/docs/api/interfaces/CameraSettingsTalkdown.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraShareDetails.md
+++ b/docs/api/interfaces/CameraShareDetails.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStatusCounts.md
+++ b/docs/api/interfaces/CameraStatusCounts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStreamUrls.md
+++ b/docs/api/interfaces/CameraStreamUrls.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateEventSubscriptionParams.md
+++ b/docs/api/interfaces/CreateEventSubscriptionParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateExportParams.md
+++ b/docs/api/interfaces/CreateExportParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateFileParams.md
+++ b/docs/api/interfaces/CreateFileParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateLayoutParams.md
+++ b/docs/api/interfaces/CreateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Download.md
+++ b/docs/api/interfaces/Download.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/DownloadFileResult.md
+++ b/docs/api/interfaces/DownloadFileResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenError.md
+++ b/docs/api/interfaces/EenError.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenFile.md
+++ b/docs/api/interfaces/EenFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenToolkitConfig.md
+++ b/docs/api/interfaces/EenToolkitConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Event.md
+++ b/docs/api/interfaces/Event.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventAlertConditionRule.md
+++ b/docs/api/interfaces/EventAlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventAlertConditionRuleFieldValues.md
+++ b/docs/api/interfaces/EventAlertConditionRuleFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventData.md
+++ b/docs/api/interfaces/EventData.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventFieldValues.md
+++ b/docs/api/interfaces/EventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventFilter.md
+++ b/docs/api/interfaces/EventFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventMetric.md
+++ b/docs/api/interfaces/EventMetric.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventResourceFilter.md
+++ b/docs/api/interfaces/EventResourceFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscription.md
+++ b/docs/api/interfaces/EventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionConfig.md
+++ b/docs/api/interfaces/EventSubscriptionConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionFilter.md
+++ b/docs/api/interfaces/EventSubscriptionFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventType.md
+++ b/docs/api/interfaces/EventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventTypeFilter.md
+++ b/docs/api/interfaces/EventTypeFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Feed.md
+++ b/docs/api/interfaces/Feed.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/FilterCreate.md
+++ b/docs/api/interfaces/FilterCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetAlertConditionRuleParams.md
+++ b/docs/api/interfaces/GetAlertConditionRuleParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetAlertParams.md
+++ b/docs/api/interfaces/GetAlertParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetBridgeParams.md
+++ b/docs/api/interfaces/GetBridgeParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetCameraParams.md
+++ b/docs/api/interfaces/GetCameraParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetCameraSettingsParams.md
+++ b/docs/api/interfaces/GetCameraSettingsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetDownloadParams.md
+++ b/docs/api/interfaces/GetDownloadParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventAlertConditionRuleFieldValuesParams.md
+++ b/docs/api/interfaces/GetEventAlertConditionRuleFieldValuesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventMetricsParams.md
+++ b/docs/api/interfaces/GetEventMetricsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventParams.md
+++ b/docs/api/interfaces/GetEventParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetFileParams.md
+++ b/docs/api/interfaces/GetFileParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetJobParams.md
+++ b/docs/api/interfaces/GetJobParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLayoutParams.md
+++ b/docs/api/interfaces/GetLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLiveImageParams.md
+++ b/docs/api/interfaces/GetLiveImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetRecordedImageParams.md
+++ b/docs/api/interfaces/GetRecordedImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetUserParams.md
+++ b/docs/api/interfaces/GetUserParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/HumanValidation.md
+++ b/docs/api/interfaces/HumanValidation.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Job.md
+++ b/docs/api/interfaces/Job.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Layout.md
+++ b/docs/api/interfaces/Layout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPane.md
+++ b/docs/api/interfaces/LayoutPane.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPermissions.md
+++ b/docs/api/interfaces/LayoutPermissions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutSettings.md
+++ b/docs/api/interfaces/LayoutSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertActionRulesParams.md
+++ b/docs/api/interfaces/ListAlertActionRulesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertActionsParams.md
+++ b/docs/api/interfaces/ListAlertActionsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertConditionRulesParams.md
+++ b/docs/api/interfaces/ListAlertConditionRulesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertTypesParams.md
+++ b/docs/api/interfaces/ListAlertTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertsParams.md
+++ b/docs/api/interfaces/ListAlertsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListBridgesParams.md
+++ b/docs/api/interfaces/ListBridgesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListCamerasParams.md
+++ b/docs/api/interfaces/ListCamerasParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListDownloadsParams.md
+++ b/docs/api/interfaces/ListDownloadsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventAlertConditionRulesParams.md
+++ b/docs/api/interfaces/ListEventAlertConditionRulesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventFieldValuesParams.md
+++ b/docs/api/interfaces/ListEventFieldValuesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventSubscriptionsParams.md
+++ b/docs/api/interfaces/ListEventSubscriptionsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventTypesParams.md
+++ b/docs/api/interfaces/ListEventTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventsParams.md
+++ b/docs/api/interfaces/ListEventsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsParams.md
+++ b/docs/api/interfaces/ListFeedsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsResult.md
+++ b/docs/api/interfaces/ListFeedsResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFilesParams.md
+++ b/docs/api/interfaces/ListFilesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListJobsParams.md
+++ b/docs/api/interfaces/ListJobsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListLayoutsParams.md
+++ b/docs/api/interfaces/ListLayoutsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListMediaParams.md
+++ b/docs/api/interfaces/ListMediaParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListNotificationsParams.md
+++ b/docs/api/interfaces/ListNotificationsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListUsersParams.md
+++ b/docs/api/interfaces/ListUsersParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LiveImageResult.md
+++ b/docs/api/interfaces/LiveImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaInterval.md
+++ b/docs/api/interfaces/MediaInterval.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResponse.md
+++ b/docs/api/interfaces/MediaSessionResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResult.md
+++ b/docs/api/interfaces/MediaSessionResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Notification.md
+++ b/docs/api/interfaces/Notification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/NotificationSettings.md
+++ b/docs/api/interfaces/NotificationSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/OutputPortSettings.md
+++ b/docs/api/interfaces/OutputPortSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginatedResult.md
+++ b/docs/api/interfaces/PaginatedResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginationParams.md
+++ b/docs/api/interfaces/PaginationParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PlaySpeakerAudioClipSettings.md
+++ b/docs/api/interfaces/PlaySpeakerAudioClipSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/RecordedImageResult.md
+++ b/docs/api/interfaces/RecordedImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnection.md
+++ b/docs/api/interfaces/SSEConnection.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnectionOptions.md
+++ b/docs/api/interfaces/SSEConnectionOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfig.md
+++ b/docs/api/interfaces/SSEDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfigCreate.md
+++ b/docs/api/interfaces/SSEDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEEvent.md
+++ b/docs/api/interfaces/SSEEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SlackSettings.md
+++ b/docs/api/interfaces/SlackSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SmsSettings.md
+++ b/docs/api/interfaces/SmsSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SmtpSettings.md
+++ b/docs/api/interfaces/SmtpSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/TokenResponse.md
+++ b/docs/api/interfaces/TokenResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UpdateLayoutParams.md
+++ b/docs/api/interfaces/UpdateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/User.md
+++ b/docs/api/interfaces/User.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UserProfile.md
+++ b/docs/api/interfaces/UserProfile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfig.md
+++ b/docs/api/interfaces/WebhookDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfigCreate.md
+++ b/docs/api/interfaces/WebhookDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookSettings.md
+++ b/docs/api/interfaces/WebhookSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ActorType.md
+++ b/docs/api/type-aliases/ActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionSettings.md
+++ b/docs/api/type-aliases/AlertActionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionStatus.md
+++ b/docs/api/type-aliases/AlertActionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionType.md
+++ b/docs/api/type-aliases/AlertActionType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertConditionRuleInclude.md
+++ b/docs/api/type-aliases/AlertConditionRuleInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertInclude.md
+++ b/docs/api/type-aliases/AlertInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertSort.md
+++ b/docs/api/type-aliases/AlertSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/BridgeStatus.md
+++ b/docs/api/type-aliases/BridgeStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraAspectRatio.md
+++ b/docs/api/type-aliases/CameraAspectRatio.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraSettingsInclude.md
+++ b/docs/api/type-aliases/CameraSettingsInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraStatus.md
+++ b/docs/api/type-aliases/CameraStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DataSchema.md
+++ b/docs/api/type-aliases/DataSchema.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfig.md
+++ b/docs/api/type-aliases/DeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfigCreate.md
+++ b/docs/api/type-aliases/DeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DownloadDownloadResult.md
+++ b/docs/api/type-aliases/DownloadDownloadResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DownloadStatus.md
+++ b/docs/api/type-aliases/DownloadStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ErrorCode.md
+++ b/docs/api/type-aliases/ErrorCode.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionDeliveryType.md
+++ b/docs/api/type-aliases/EventSubscriptionDeliveryType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionLifecycle.md
+++ b/docs/api/type-aliases/EventSubscriptionLifecycle.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ExportJobResponse.md
+++ b/docs/api/type-aliases/ExportJobResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ExportType.md
+++ b/docs/api/type-aliases/ExportType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedIncludeOption.md
+++ b/docs/api/type-aliases/FeedIncludeOption.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedMediaType.md
+++ b/docs/api/type-aliases/FeedMediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedStreamType.md
+++ b/docs/api/type-aliases/FeedStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FileIncludeField.md
+++ b/docs/api/type-aliases/FileIncludeField.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FileType.md
+++ b/docs/api/type-aliases/FileType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/GetLayoutInclude.md
+++ b/docs/api/type-aliases/GetLayoutInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/JobState.md
+++ b/docs/api/type-aliases/JobState.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/KnownEventType.md
+++ b/docs/api/type-aliases/KnownEventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneSize.md
+++ b/docs/api/type-aliases/LayoutPaneSize.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneType.md
+++ b/docs/api/type-aliases/LayoutPaneType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsInclude.md
+++ b/docs/api/type-aliases/ListLayoutsInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsSort.md
+++ b/docs/api/type-aliases/ListLayoutsSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaStreamType.md
+++ b/docs/api/type-aliases/MediaStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaType.md
+++ b/docs/api/type-aliases/MediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricActorType.md
+++ b/docs/api/type-aliases/MetricActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricDataPoint.md
+++ b/docs/api/type-aliases/MetricDataPoint.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationCategory.md
+++ b/docs/api/type-aliases/NotificationCategory.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationStatus.md
+++ b/docs/api/type-aliases/NotificationStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/Result.md
+++ b/docs/api/type-aliases/Result.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/SSEConnectionStatus.md
+++ b/docs/api/type-aliases/SSEConnectionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/StorageStrategy.md
+++ b/docs/api/type-aliases/StorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/variables/EVENT_TYPE_DATA_SCHEMAS.md
+++ b/docs/api/variables/EVENT_TYPE_DATA_SCHEMAS.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
+++ b/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/docs/api/variables/useAuthStore.md
+++ b/docs/api/variables/useAuthStore.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.79**](../README.md)
+[**EEN API Toolkit v0.3.80**](../README.md)
 
 ***
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.79",
+  "version": "0.3.80",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit",
-      "version": "0.3.79",
+      "version": "0.3.80",
       "license": "MIT",
       "bin": {
         "een-setup-agents": "scripts/setup-agents.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.79",
+  "version": "0.3.80",
   "description": "EEN Video platform API v3.0 library for Vue 3",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

Two changes:

1. **Revert broken `head_branch` check in npm-publish workflow** — The `head_branch == 'production'` check added in PR #109 caused all automated publish runs to be skipped. GitHub's `workflow_run.head_branch` refers to the PR **source** branch (e.g. `develop`), not the target. The upstream `test-release.yml` already restricts to PRs merged to production.

2. **Add confidential data scan to PR-and-check skill** — New step in the skill that scans changed `.md` files for secrets, credentials, or confidential information before PR creation. Also includes agent documentation improvements (Playwright selectors, SSE API patterns, LivePlayer camera switching, setup agent scope).

## Commits

- `1bb7297` fix: revert broken head_branch check in npm-publish workflow
- `6afd34a` chore: add confidential data scan to PR-and-check skill and update agents

## Test Results

- **Lint**: 0 errors (1 pre-existing warning)
- **Unit tests**: 644 passed
- **Build**: Success
- **E2E tests**: 6/11 passed; `vue-feeds` flaky failure on `nav-feeds` testid (pre-existing, unrelated)
- **Security review**: No vulnerabilities found
- **Confidential data scan**: No secrets in agent .md files

## Version

`0.3.80`

🤖 Generated with [Claude Code](https://claude.com/claude-code)