### PR TITLE
fix: restrict workflow_dispatch to production branch

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,10 +16,11 @@ on:
 
 jobs:
   publish:
-    # Run if: test workflow succeeded, OR manually triggered
-    # Note: test-release.yml only runs on PRs merged to production (or workflow_dispatch),
-    # so a successful workflow_run already implies a production-targeted merge.
-    # head_branch is the PR *source* branch (e.g. 'develop'), not the target.
+    # Run if: test workflow succeeded, OR manually triggered.
+    # test-release.yml restricts workflow_dispatch to production branch only,
+    # so a successful workflow_run implies either a PR merge to production or
+    # a manual dispatch on production. head_branch is the branch the triggering
+    # workflow ran on (PR source branch or dispatch branch).
     if: >
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success') ||

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,15 +16,15 @@ on:
 
 jobs:
   publish:
-    # Run if: test workflow succeeded, OR manually triggered.
-    # test-release.yml restricts workflow_dispatch to production branch only,
+    # Run if: test workflow succeeded, OR manually triggered on production only.
+    # test-release.yml also restricts workflow_dispatch to production branch,
     # so a successful workflow_run implies either a PR merge to production or
-    # a manual dispatch on production. head_branch is the branch the triggering
-    # workflow ran on (PR source branch or dispatch branch).
+    # a manual dispatch on production. The production check on workflow_dispatch
+    # here is defense-in-depth to prevent direct manual publish from other branches.
     if: >
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success') ||
-      github.event_name == 'workflow_dispatch'
+      (github.event_name == 'workflow_dispatch' && github.ref_name == 'production')
     runs-on: ubuntu-latest
     permissions:
       contents: write  # Required for creating GitHub releases

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -10,8 +10,12 @@ on:
 
 jobs:
   test:
-    # Run if: PR was merged, OR manually triggered
-    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+    # Run if: PR was merged to production, OR manually triggered on production only.
+    # The production branch restriction prevents workflow_dispatch on arbitrary branches
+    # from triggering npm publish via the workflow_run chain.
+    if: >
+      github.event.pull_request.merged == true ||
+      (github.event_name == 'workflow_dispatch' && github.ref_name == 'production')
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
- Restrict `workflow_dispatch` in `test-release.yml` to only run on the `production` branch, preventing collaborators from triggering the test→publish chain from arbitrary branches
- Fix misleading comment in `npm-publish.yml` that incorrectly assumed workflow_dispatch implied a production-targeted merge

## Test plan
- [ ] Verify workflow_dispatch on non-production branch skips the test job
- [ ] Verify workflow_dispatch on production branch still works
- [ ] Verify PR merge to production still triggers test→publish chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)