### PR TITLE
feat: add EEN API coverage documentation and agent

### DIFF
--- a/.claude/agents/api-coverage-agent.md
+++ b/.claude/agents/api-coverage-agent.md
@@ -1,5 +1,5 @@
 ---
-name: een-api-coverage-agent
+name: api-coverage-agent
 description: |
   Use this agent when you need to regenerate the EEN API coverage documentation.
   It fetches the complete EEN API v3.0 endpoint list from OpenAPI specs and the
@@ -17,15 +17,15 @@ You are an expert API documentation analyst. Your job is to produce four coverag
 <example>
 Context: User has just added new API endpoints to the toolkit.
 user: "I added camera update and delete endpoints, regenerate the coverage docs"
-assistant: "I'll use the een-api-coverage-agent to regenerate all four API coverage documents."
-<Task tool call to launch een-api-coverage-agent>
+assistant: "I'll use the api-coverage-agent to regenerate all four API coverage documents."
+<Task tool call to launch api-coverage-agent>
 </example>
 
 <example>
 Context: User wants to see current API coverage status.
 user: "What's our current EEN API coverage?"
-assistant: "I'll use the een-api-coverage-agent to produce an up-to-date coverage report."
-<Task tool call to launch een-api-coverage-agent>
+assistant: "I'll use the api-coverage-agent to produce an up-to-date coverage report."
+<Task tool call to launch api-coverage-agent>
 </example>
 
 ## Output Files

--- a/.claude/agents/een-api-coverage-agent.md
+++ b/.claude/agents/een-api-coverage-agent.md
@@ -1,0 +1,264 @@
+---
+name: een-api-coverage-agent
+description: |
+  Use this agent when you need to regenerate the EEN API coverage documentation.
+  It fetches the complete EEN API v3.0 endpoint list from OpenAPI specs and the
+  developer portal, scans the toolkit codebase for implemented endpoints, and
+  produces four output documents: all endpoints, implemented endpoints, missing
+  endpoints, and an interactive HTML coverage table.
+model: sonnet
+color: cyan
+---
+
+You are an expert API documentation analyst. Your job is to produce four coverage documents comparing the full Eagle Eye Networks REST API v3.0 against what is implemented in the een-api-toolkit.
+
+## Examples
+
+<example>
+Context: User has just added new API endpoints to the toolkit.
+user: "I added camera update and delete endpoints, regenerate the coverage docs"
+assistant: "I'll use the een-api-coverage-agent to regenerate all four API coverage documents."
+<Task tool call to launch een-api-coverage-agent>
+</example>
+
+<example>
+Context: User wants to see current API coverage status.
+user: "What's our current EEN API coverage?"
+assistant: "I'll use the een-api-coverage-agent to produce an up-to-date coverage report."
+<Task tool call to launch een-api-coverage-agent>
+</example>
+
+## Output Files
+
+You produce exactly four files in `docs/`:
+
+1. **`docs/een-api-all-endpoints.md`** - Complete reference of ALL EEN API v3.0 endpoints
+2. **`docs/een-api-implemented.md`** - Endpoints implemented by the toolkit with function names and source files
+3. **`docs/een-api-missing.md`** - Endpoints not yet implemented, with coverage percentages
+4. **`docs/een-api-coverage.html`** - Interactive HTML table with filters, sorting, and summary statistics
+
+## Workflow
+
+### Phase 1: Fetch the Complete EEN API Endpoint List
+
+Fetch ALL OpenAPI specification YAML files from the EEN GitHub repository to get the authoritative endpoint list:
+
+```
+https://raw.githubusercontent.com/EENCloud/VMS-Developer-Portal/main/Open%20API%20Specifications/devices_category.yaml
+https://raw.githubusercontent.com/EENCloud/VMS-Developer-Portal/main/Open%20API%20Specifications/media_category.yaml
+https://raw.githubusercontent.com/EENCloud/VMS-Developer-Portal/main/Open%20API%20Specifications/events_category.yaml
+https://raw.githubusercontent.com/EENCloud/VMS-Developer-Portal/main/Open%20API%20Specifications/automations_category.yaml
+https://raw.githubusercontent.com/EENCloud/VMS-Developer-Portal/main/Open%20API%20Specifications/grouping_category.yaml
+https://raw.githubusercontent.com/EENCloud/VMS-Developer-Portal/main/Open%20API%20Specifications/user_and_accounts_category.yaml
+https://raw.githubusercontent.com/EENCloud/VMS-Developer-Portal/main/Open%20API%20Specifications/system_category.yaml
+https://raw.githubusercontent.com/EENCloud/VMS-Developer-Portal/main/Open%20API%20Specifications/account_settings_category.yaml
+https://raw.githubusercontent.com/EENCloud/VMS-Developer-Portal/main/Open%20API%20Specifications/resellers_account_switching_category.yaml
+https://raw.githubusercontent.com/EENCloud/VMS-Developer-Portal/main/Open%20API%20Specifications/video_search_category.yaml
+https://raw.githubusercontent.com/EENCloud/VMS-Developer-Portal/main/Open%20API%20Specifications/vehicle_surveillance_package_category.yaml
+```
+
+For each YAML file, extract ALL endpoint paths with their HTTP methods (GET, POST, PUT, PATCH, DELETE).
+
+**Important**: The OpenAPI specs may not cover every endpoint. Supplement by fetching the developer portal reference page:
+```
+https://developer.eagleeyenetworks.com/reference/using-the-api
+```
+
+Look for endpoints documented on the portal but missing from the specs. Common gaps include:
+- Events: `/events/{id}`, `/events:listRecentByType`, `/events:listFieldValues`, `/eventTypes`, `/eventMetrics`
+- Event Subscriptions: full CRUD + filters sub-resources
+- Alerts: `/alerts`, `/alerts/{id}`, `/alertTypes`
+- Notifications: `/notifications`, `/notifications/{id}`, `PATCH /notifications/{id}`
+
+### Phase 2: Scan the Toolkit for Implemented Endpoints
+
+Search the codebase for all implemented EEN API endpoints:
+
+1. **Find all API URLs**: Search for the pattern `api/v3.0` in all TypeScript files under `src/`:
+   ```
+   Grep pattern: "api/v3.0" in src/**/*.ts
+   ```
+
+2. **Find all exported async functions**: These are the public API of the toolkit:
+   ```
+   Grep pattern: "export async function" in src/**/*.ts
+   ```
+
+3. **Find all HTTP methods used**: Identify which methods (GET, POST, PATCH, DELETE, PUT) each endpoint uses:
+   ```
+   Grep pattern: "method: '(POST|PATCH|PUT|DELETE)'" in src/**/*.ts
+   ```
+   (GET is the default when no method is specified)
+
+4. **Check for SSE connections**: Look for EventSource or SSE-related code:
+   ```
+   Grep pattern: "EventSource|SSE|connectTo" in src/**/*.ts
+   ```
+
+5. **Check auth proxy functions**: These call the OAuth proxy, not EEN API directly:
+   ```
+   Read src/auth/service.ts for proxy endpoint functions
+   ```
+
+For each implemented endpoint, record:
+- HTTP method
+- EEN API path (e.g., `/api/v3.0/cameras`)
+- Toolkit function name (e.g., `getCameras()`)
+- Source file path
+
+### Phase 3: Cross-Reference and Classify
+
+For every endpoint in the complete EEN API list, determine if it is:
+- **Implemented**: A matching function exists in the toolkit (same HTTP method + path)
+- **Missing**: No implementation found
+
+Also identify:
+- Toolkit functions that call endpoints NOT in the official API docs (flag as "undocumented")
+- Auth proxy functions (not EEN API endpoints, but part of the toolkit)
+- SSE/WebSocket connections (supplementary to REST endpoints)
+
+### Phase 4: Generate the Four Documents
+
+#### Document 1: `docs/een-api-all-endpoints.md`
+
+Structure:
+```markdown
+# Eagle Eye Networks REST API v3.0 - Complete Endpoint Reference
+
+> Generated: YYYY-MM-DD
+> Source: [EEN Developer Portal](...) and [OpenAPI Specifications](...)
+
+All paths are prefixed with `/api/v3.0` on the appropriate base URL.
+
+## CATEGORY - Subcategory (N endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/path` | Description |
+...
+
+## Summary
+
+| Category | Subcategory | Endpoints |
+...
+
+### By HTTP Method
+
+| Method | Count |
+...
+```
+
+Organize endpoints by these categories and subcategories:
+- **Devices**: Cameras, Bridges, PTZ, Speakers, Device I/O, Switches, Multi Cameras, Available Devices
+- **Grouping**: Layouts, Tags, Locations, Floors, Floor Plans
+- **Media**: Media, Feeds, Exports, Jobs, Files, Downloads
+- **Events**: Events, Event Types, Event Metrics, Event Subscriptions, Alerts, Notifications
+- **Automations**: Event Alert Condition Rules, Alert Action Rules, Alert Actions
+- **Video Search**: Video Analytic Events
+- **Vehicle Surveillance**: LPR Events, LPR Alert Condition Rules, LPR Vehicle Lists
+- **User & Accounts**: Users, Accounts, Roles, Audit Log, Resource Grants, Editions
+- **Resellers**: Authorization Tokens
+- **Account Settings**: SSO, Client Settings
+- **System**: Applications, OAuth Clients, Reference Data
+
+#### Document 2: `docs/een-api-implemented.md`
+
+Structure:
+```markdown
+# een-api-toolkit - Implemented EEN API Endpoints
+
+> Generated: YYYY-MM-DD
+
+## Authentication (via OAuth Proxy)
+[Table of auth proxy functions - note these are NOT EEN API endpoints]
+
+## Category (N endpoints)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/path` | `functionName()` | `src/.../service.ts` |
+...
+
+## Summary
+[Table with counts per category and by HTTP method]
+```
+
+#### Document 3: `docs/een-api-missing.md`
+
+Structure:
+```markdown
+# een-api-toolkit - Missing EEN API Endpoints
+
+> Generated: YYYY-MM-DD
+> Coverage: X of Y endpoints implemented (Z%)
+
+## CATEGORY - Subcategory (N of M missing)
+Implemented: [brief list of what IS implemented]
+
+| Method | Path | Description |
+...
+
+## Summary
+[Coverage table per category]
+[Lists of fully implemented sections and entirely missing sections]
+```
+
+#### Document 4: `docs/een-api-coverage.html`
+
+Generate a self-contained HTML file with:
+
+**Header section**:
+- Title: "Eagle Eye Networks API v3.0 - Toolkit Coverage"
+- Generation date
+- Summary stat cards: Total endpoints, Implemented, Missing, Coverage percentage with progress bar
+
+**Filter bar**:
+- Status filter dropdown (All / Implemented / Missing)
+- Category filter dropdown (All + each category)
+- Method filter dropdown (All / GET / POST / PATCH / DELETE / PUT)
+- Text search input for path/function/description
+
+**Data table**:
+- Columns: #, Category, Subcategory, Method, Path, Description, Status, Toolkit Function
+- Sortable by clicking column headers
+- Color-coded method badges (GET=blue, POST=green, PATCH=yellow, DELETE=red, PUT=indigo)
+- Status badges (Implemented=green, Missing=red)
+- Monospace font for function names
+
+**Styling**:
+- Clean, modern CSS with system font stack
+- Light background (#f5f7fa)
+- White card-style table with subtle shadows
+- Responsive layout
+- All styles inline (self-contained, no external dependencies)
+
+**JavaScript**:
+- All endpoint data in a `const endpoints = [...]` array with objects: `{cat, sub, method, path, desc, status, func}`
+- `status` values: `"impl"` for implemented, `"miss"` for missing
+- `func` is empty string for missing endpoints
+- `renderTable(data)` function to populate tbody
+- `filterTable()` function combining all filter inputs
+- `sortTable(colIndex)` function with toggle direction
+- All code inline (no external dependencies)
+
+## Important Guidelines
+
+1. **Fetch fresh data every time** - Do not rely on cached or previously generated content. Always fetch the OpenAPI specs and scan the codebase.
+
+2. **Be accurate with counts** - Double-check endpoint totals match between documents. The total in all-endpoints.md must equal implemented + missing in missing.md.
+
+3. **Parallel fetching** - Fetch multiple OpenAPI YAML files in parallel using concurrent WebFetch calls to save time. Also run codebase Grep searches in parallel.
+
+4. **Handle OpenAPI gaps** - Some endpoints are on the developer portal but not in the OpenAPI specs (especially Events category sub-resources). Use both sources.
+
+5. **Flag undocumented endpoints** - If the toolkit implements endpoints not found in any official documentation, note them with a warning (e.g., `alertConditionRules` without the `event` prefix).
+
+6. **Include the generation date** - Use today's date in all document headers.
+
+7. **Open the HTML when done** - After writing all four files, run `open docs/een-api-coverage.html` to display the result in the browser.
+
+8. **Preserve category ordering** - Use the category order listed above consistently across all four documents.
+
+9. **Count auth proxy separately** - Auth proxy functions (getAccessToken, refreshToken, revokeToken, handleAuthCallback) communicate with the proxy server, not the EEN API. List them in the implemented doc but do not count them in the EEN API coverage totals.
+
+10. **Count SSE separately** - The `connectToEventSubscription()` function uses SSE, not REST. List it but count it separately from REST endpoint coverage.

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ The toolkit includes specialized [Claude Code](https://docs.anthropic.com/en/doc
 
 > **Note:** These agents use Claude Code's specific format. To use with other AI assistants (Gemini CLI, Copilot, etc.), the agent specs would need conversion.
 
-**Available agents:**
+**Available agents (installed via `npx een-setup-agents`):**
 - `een-setup-agent` - Project scaffolding, Pinia setup, Vite configuration
 - `een-auth-agent` - OAuth flows, route guards, token management
 - `een-users-agent` - User listing and profile APIs
@@ -192,7 +192,8 @@ The toolkit includes specialized [Claude Code](https://docs.anthropic.com/en/doc
 - `een-grouping-agent` - Layouts CRUD operations, camera pane management
 - `een-automations-agent` - Alert rules, action rules, event conditions
 - `een-jobs-agent` - Jobs, exports, files, downloads
-- `een-api-coverage-agent` - Regenerate EEN API coverage documentation
+
+The `setup-agents` script (`scripts/setup-agents.ts`) installs only agents matching the `een-*-agent.md` pattern. Other agents in `.claude/agents/` (such as `api-coverage-agent`, `docs-accuracy-reviewer`, `test-runner`) are for this repository only and are not distributed to consuming projects.
 
 **Installation:**
 ```bash
@@ -331,7 +332,7 @@ This toolkit implements a subset of the [Eagle Eye Networks REST API v3.0](https
 
 **Not yet implemented:** PTZ, Speakers, Switches, Multi Cameras, Locations, Floors, Video Search, LPR, Roles, Accounts, and others
 
-To regenerate these documents after adding new API endpoints, use the `een-api-coverage-agent`.
+To regenerate these documents after adding new API endpoints, use the `api-coverage-agent`.
 
 ## External Resources
 

--- a/README.md
+++ b/README.md
@@ -311,6 +311,25 @@ The `sync-secrets.sh` script manages secrets from a single source (root `.env` f
 
 > **Note:** Example `.env` files are gitignored. Run `sync-secrets.sh` after cloning to set up local development.
 
+## EEN API Coverage
+
+This toolkit implements a subset of the [Eagle Eye Networks REST API v3.0](https://developer.eagleeyenetworks.com/reference/using-the-api). Coverage documentation is maintained in `docs/`:
+
+| Document | Description |
+|----------|-------------|
+| **[All EEN API Endpoints](./docs/een-api-all-endpoints.md)** | Complete reference of all 211 EEN API v3.0 endpoints |
+| **[Implemented Endpoints](./docs/een-api-implemented.md)** | Endpoints implemented by the toolkit with function names and source files |
+| **[Missing Endpoints](./docs/een-api-missing.md)** | Endpoints not yet implemented, with per-category coverage percentages |
+| **[Coverage Table (HTML)](./docs/een-api-coverage.html)** | Interactive table with filtering, sorting, and summary statistics |
+
+**Fully implemented sections:** Layouts, Feeds, Jobs, Event Types, Event Metrics, Alerts
+
+**Partially implemented:** Users, Cameras, Bridges, Media, Events, Event Subscriptions, Automations, Exports, Files, Downloads
+
+**Not yet implemented:** PTZ, Speakers, Switches, Multi Cameras, Locations, Floors, Video Search, LPR, Roles, Accounts, and others
+
+To regenerate these documents after adding new API endpoints, use the `een-api-coverage-agent`.
+
 ## External Resources
 
 - [EEN Developer Portal](https://developer.eagleeyenetworks.com/)

--- a/README.md
+++ b/README.md
@@ -190,6 +190,9 @@ The toolkit includes specialized [Claude Code](https://docs.anthropic.com/en/doc
 - `een-media-agent` - Live video, previews, HLS playback
 - `een-events-agent` - Events, alerts, metrics, SSE subscriptions
 - `een-grouping-agent` - Layouts CRUD operations, camera pane management
+- `een-automations-agent` - Alert rules, action rules, event conditions
+- `een-jobs-agent` - Jobs, exports, files, downloads
+- `een-api-coverage-agent` - Regenerate EEN API coverage documentation
 
 **Installation:**
 ```bash

--- a/docs/AI-CONTEXT.md
+++ b/docs/AI-CONTEXT.md
@@ -1,6 +1,6 @@
 # EEN API Toolkit - AI Reference
 
-> **Version:** 0.3.82
+> **Version:** 0.3.83
 >
 > This documentation is optimized for AI assistants. It provides focused, domain-specific
 > references to help you understand and use the een-api-toolkit efficiently.

--- a/docs/AI-CONTEXT.md
+++ b/docs/AI-CONTEXT.md
@@ -1,6 +1,6 @@
 # EEN API Toolkit - AI Reference
 
-> **Version:** 0.3.83
+> **Version:** 0.3.84
 >
 > This documentation is optimized for AI assistants. It provides focused, domain-specific
 > references to help you understand and use the een-api-toolkit efficiently.

--- a/docs/AI-CONTEXT.md
+++ b/docs/AI-CONTEXT.md
@@ -1,6 +1,6 @@
 # EEN API Toolkit - AI Reference
 
-> **Version:** 0.3.84
+> **Version:** 0.3.85
 >
 > This documentation is optimized for AI assistants. It provides focused, domain-specific
 > references to help you understand and use the een-api-toolkit efficiently.

--- a/docs/ai-reference/AI-AUTH.md
+++ b/docs/ai-reference/AI-AUTH.md
@@ -1,6 +1,6 @@
 # Authentication - EEN API Toolkit
 
-> **Version:** 0.3.82
+> **Version:** 0.3.83
 >
 > OAuth flow implementation, token management, and session handling.
 > Load this document when implementing login, logout, or auth guards.

--- a/docs/ai-reference/AI-AUTH.md
+++ b/docs/ai-reference/AI-AUTH.md
@@ -1,6 +1,6 @@
 # Authentication - EEN API Toolkit
 
-> **Version:** 0.3.84
+> **Version:** 0.3.85
 >
 > OAuth flow implementation, token management, and session handling.
 > Load this document when implementing login, logout, or auth guards.

--- a/docs/ai-reference/AI-AUTH.md
+++ b/docs/ai-reference/AI-AUTH.md
@@ -1,6 +1,6 @@
 # Authentication - EEN API Toolkit
 
-> **Version:** 0.3.83
+> **Version:** 0.3.84
 >
 > OAuth flow implementation, token management, and session handling.
 > Load this document when implementing login, logout, or auth guards.

--- a/docs/ai-reference/AI-AUTOMATIONS.md
+++ b/docs/ai-reference/AI-AUTOMATIONS.md
@@ -1,6 +1,6 @@
 # Automations API - EEN API Toolkit
 
-> **Version:** 0.3.84
+> **Version:** 0.3.85
 >
 > Complete reference for automation rules and alert actions.
 > Load this document when working with automated alert workflows.

--- a/docs/ai-reference/AI-AUTOMATIONS.md
+++ b/docs/ai-reference/AI-AUTOMATIONS.md
@@ -1,6 +1,6 @@
 # Automations API - EEN API Toolkit
 
-> **Version:** 0.3.83
+> **Version:** 0.3.84
 >
 > Complete reference for automation rules and alert actions.
 > Load this document when working with automated alert workflows.

--- a/docs/ai-reference/AI-AUTOMATIONS.md
+++ b/docs/ai-reference/AI-AUTOMATIONS.md
@@ -1,6 +1,6 @@
 # Automations API - EEN API Toolkit
 
-> **Version:** 0.3.82
+> **Version:** 0.3.83
 >
 > Complete reference for automation rules and alert actions.
 > Load this document when working with automated alert workflows.

--- a/docs/ai-reference/AI-DEVICES.md
+++ b/docs/ai-reference/AI-DEVICES.md
@@ -1,6 +1,6 @@
 # Cameras & Bridges API - EEN API Toolkit
 
-> **Version:** 0.3.82
+> **Version:** 0.3.83
 >
 > Complete reference for camera and bridge management.
 > Load this document when working with devices.

--- a/docs/ai-reference/AI-DEVICES.md
+++ b/docs/ai-reference/AI-DEVICES.md
@@ -1,6 +1,6 @@
 # Cameras & Bridges API - EEN API Toolkit
 
-> **Version:** 0.3.83
+> **Version:** 0.3.84
 >
 > Complete reference for camera and bridge management.
 > Load this document when working with devices.

--- a/docs/ai-reference/AI-DEVICES.md
+++ b/docs/ai-reference/AI-DEVICES.md
@@ -1,6 +1,6 @@
 # Cameras & Bridges API - EEN API Toolkit
 
-> **Version:** 0.3.84
+> **Version:** 0.3.85
 >
 > Complete reference for camera and bridge management.
 > Load this document when working with devices.

--- a/docs/ai-reference/AI-EVENT-DATA-SCHEMAS.md
+++ b/docs/ai-reference/AI-EVENT-DATA-SCHEMAS.md
@@ -1,6 +1,6 @@
 # Event Type to Data Schemas Mapping - EEN API Toolkit
 
-> **Version:** 0.3.83
+> **Version:** 0.3.84
 >
 > Complete reference for event type to data schema mappings.
 > Load this document when building dynamic event queries with the `include` parameter.

--- a/docs/ai-reference/AI-EVENT-DATA-SCHEMAS.md
+++ b/docs/ai-reference/AI-EVENT-DATA-SCHEMAS.md
@@ -1,6 +1,6 @@
 # Event Type to Data Schemas Mapping - EEN API Toolkit
 
-> **Version:** 0.3.84
+> **Version:** 0.3.85
 >
 > Complete reference for event type to data schema mappings.
 > Load this document when building dynamic event queries with the `include` parameter.

--- a/docs/ai-reference/AI-EVENT-DATA-SCHEMAS.md
+++ b/docs/ai-reference/AI-EVENT-DATA-SCHEMAS.md
@@ -1,6 +1,6 @@
 # Event Type to Data Schemas Mapping - EEN API Toolkit
 
-> **Version:** 0.3.82
+> **Version:** 0.3.83
 >
 > Complete reference for event type to data schema mappings.
 > Load this document when building dynamic event queries with the `include` parameter.

--- a/docs/ai-reference/AI-EVENTS.md
+++ b/docs/ai-reference/AI-EVENTS.md
@@ -1,6 +1,6 @@
 # Events, Alerts & Real-Time Streaming - EEN API Toolkit
 
-> **Version:** 0.3.82
+> **Version:** 0.3.83
 >
 > Complete reference for events, alerts, metrics, and SSE subscriptions.
 > Load this document when implementing event-driven features.

--- a/docs/ai-reference/AI-EVENTS.md
+++ b/docs/ai-reference/AI-EVENTS.md
@@ -1,6 +1,6 @@
 # Events, Alerts & Real-Time Streaming - EEN API Toolkit
 
-> **Version:** 0.3.83
+> **Version:** 0.3.84
 >
 > Complete reference for events, alerts, metrics, and SSE subscriptions.
 > Load this document when implementing event-driven features.

--- a/docs/ai-reference/AI-EVENTS.md
+++ b/docs/ai-reference/AI-EVENTS.md
@@ -1,6 +1,6 @@
 # Events, Alerts & Real-Time Streaming - EEN API Toolkit
 
-> **Version:** 0.3.84
+> **Version:** 0.3.85
 >
 > Complete reference for events, alerts, metrics, and SSE subscriptions.
 > Load this document when implementing event-driven features.

--- a/docs/ai-reference/AI-GROUPING.md
+++ b/docs/ai-reference/AI-GROUPING.md
@@ -1,6 +1,6 @@
 # Layouts API - EEN API Toolkit
 
-> **Version:** 0.3.82
+> **Version:** 0.3.83
 >
 > Complete reference for layout management (camera grouping).
 > Load this document when working with layouts.

--- a/docs/ai-reference/AI-GROUPING.md
+++ b/docs/ai-reference/AI-GROUPING.md
@@ -1,6 +1,6 @@
 # Layouts API - EEN API Toolkit
 
-> **Version:** 0.3.84
+> **Version:** 0.3.85
 >
 > Complete reference for layout management (camera grouping).
 > Load this document when working with layouts.

--- a/docs/ai-reference/AI-GROUPING.md
+++ b/docs/ai-reference/AI-GROUPING.md
@@ -1,6 +1,6 @@
 # Layouts API - EEN API Toolkit
 
-> **Version:** 0.3.83
+> **Version:** 0.3.84
 >
 > Complete reference for layout management (camera grouping).
 > Load this document when working with layouts.

--- a/docs/ai-reference/AI-JOBS.md
+++ b/docs/ai-reference/AI-JOBS.md
@@ -1,6 +1,6 @@
 # Jobs, Exports, Files & Downloads - EEN API Toolkit
 
-> **Version:** 0.3.82
+> **Version:** 0.3.83
 >
 > Complete reference for async jobs, video exports, and file management.
 > Load this document when implementing export workflows or file downloads.

--- a/docs/ai-reference/AI-JOBS.md
+++ b/docs/ai-reference/AI-JOBS.md
@@ -1,6 +1,6 @@
 # Jobs, Exports, Files & Downloads - EEN API Toolkit
 
-> **Version:** 0.3.84
+> **Version:** 0.3.85
 >
 > Complete reference for async jobs, video exports, and file management.
 > Load this document when implementing export workflows or file downloads.

--- a/docs/ai-reference/AI-JOBS.md
+++ b/docs/ai-reference/AI-JOBS.md
@@ -1,6 +1,6 @@
 # Jobs, Exports, Files & Downloads - EEN API Toolkit
 
-> **Version:** 0.3.83
+> **Version:** 0.3.84
 >
 > Complete reference for async jobs, video exports, and file management.
 > Load this document when implementing export workflows or file downloads.

--- a/docs/ai-reference/AI-MEDIA.md
+++ b/docs/ai-reference/AI-MEDIA.md
@@ -1,6 +1,6 @@
 # Media & Live Video - EEN API Toolkit
 
-> **Version:** 0.3.84
+> **Version:** 0.3.85
 >
 > Complete reference for media retrieval, live streaming, and video playback.
 > Load this document when implementing video features.

--- a/docs/ai-reference/AI-MEDIA.md
+++ b/docs/ai-reference/AI-MEDIA.md
@@ -1,6 +1,6 @@
 # Media & Live Video - EEN API Toolkit
 
-> **Version:** 0.3.82
+> **Version:** 0.3.83
 >
 > Complete reference for media retrieval, live streaming, and video playback.
 > Load this document when implementing video features.

--- a/docs/ai-reference/AI-MEDIA.md
+++ b/docs/ai-reference/AI-MEDIA.md
@@ -1,6 +1,6 @@
 # Media & Live Video - EEN API Toolkit
 
-> **Version:** 0.3.83
+> **Version:** 0.3.84
 >
 > Complete reference for media retrieval, live streaming, and video playback.
 > Load this document when implementing video features.

--- a/docs/ai-reference/AI-SETUP.md
+++ b/docs/ai-reference/AI-SETUP.md
@@ -1,6 +1,6 @@
 # Vue 3 Application Setup - EEN API Toolkit
 
-> **Version:** 0.3.82
+> **Version:** 0.3.83
 >
 > Complete guide for setting up a Vue 3 application with the een-api-toolkit.
 > Load this document when creating a new project or troubleshooting setup issues.

--- a/docs/ai-reference/AI-SETUP.md
+++ b/docs/ai-reference/AI-SETUP.md
@@ -1,6 +1,6 @@
 # Vue 3 Application Setup - EEN API Toolkit
 
-> **Version:** 0.3.84
+> **Version:** 0.3.85
 >
 > Complete guide for setting up a Vue 3 application with the een-api-toolkit.
 > Load this document when creating a new project or troubleshooting setup issues.

--- a/docs/ai-reference/AI-SETUP.md
+++ b/docs/ai-reference/AI-SETUP.md
@@ -1,6 +1,6 @@
 # Vue 3 Application Setup - EEN API Toolkit
 
-> **Version:** 0.3.83
+> **Version:** 0.3.84
 >
 > Complete guide for setting up a Vue 3 application with the een-api-toolkit.
 > Load this document when creating a new project or troubleshooting setup issues.

--- a/docs/ai-reference/AI-USERS.md
+++ b/docs/ai-reference/AI-USERS.md
@@ -1,6 +1,6 @@
 # Users API - EEN API Toolkit
 
-> **Version:** 0.3.83
+> **Version:** 0.3.84
 >
 > Complete reference for user management.
 > Load this document when working with user data.

--- a/docs/ai-reference/AI-USERS.md
+++ b/docs/ai-reference/AI-USERS.md
@@ -1,6 +1,6 @@
 # Users API - EEN API Toolkit
 
-> **Version:** 0.3.82
+> **Version:** 0.3.83
 >
 > Complete reference for user management.
 > Load this document when working with user data.

--- a/docs/ai-reference/AI-USERS.md
+++ b/docs/ai-reference/AI-USERS.md
@@ -1,6 +1,6 @@
 # Users API - EEN API Toolkit
 
-> **Version:** 0.3.84
+> **Version:** 0.3.85
 >
 > Complete reference for user management.
 > Load this document when working with user data.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,8 +1,8 @@
-**EEN API Toolkit v0.3.82**
+**EEN API Toolkit v0.3.83**
 
 ***
 
-# EEN API Toolkit v0.3.82
+# EEN API Toolkit v0.3.83
 
 ## Interfaces
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,8 +1,8 @@
-**EEN API Toolkit v0.3.83**
+**EEN API Toolkit v0.3.84**
 
 ***
 
-# EEN API Toolkit v0.3.83
+# EEN API Toolkit v0.3.84
 
 ## Interfaces
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,8 +1,8 @@
-**EEN API Toolkit v0.3.84**
+**EEN API Toolkit v0.3.85**
 
 ***
 
-# EEN API Toolkit v0.3.84
+# EEN API Toolkit v0.3.85
 
 ## Interfaces
 

--- a/docs/api/functions/addFile.md
+++ b/docs/api/functions/addFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/addFile.md
+++ b/docs/api/functions/addFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/addFile.md
+++ b/docs/api/functions/addFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/connectToEventSubscription.md
+++ b/docs/api/functions/connectToEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/connectToEventSubscription.md
+++ b/docs/api/functions/connectToEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/connectToEventSubscription.md
+++ b/docs/api/functions/connectToEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/createEventSubscription.md
+++ b/docs/api/functions/createEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/createEventSubscription.md
+++ b/docs/api/functions/createEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/createEventSubscription.md
+++ b/docs/api/functions/createEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/createExportJob.md
+++ b/docs/api/functions/createExportJob.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/createExportJob.md
+++ b/docs/api/functions/createExportJob.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/createExportJob.md
+++ b/docs/api/functions/createExportJob.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/createLayout.md
+++ b/docs/api/functions/createLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/createLayout.md
+++ b/docs/api/functions/createLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/createLayout.md
+++ b/docs/api/functions/createLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteEventSubscription.md
+++ b/docs/api/functions/deleteEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteEventSubscription.md
+++ b/docs/api/functions/deleteEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteEventSubscription.md
+++ b/docs/api/functions/deleteEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteFile.md
+++ b/docs/api/functions/deleteFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteFile.md
+++ b/docs/api/functions/deleteFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteFile.md
+++ b/docs/api/functions/deleteFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteJob.md
+++ b/docs/api/functions/deleteJob.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteJob.md
+++ b/docs/api/functions/deleteJob.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteJob.md
+++ b/docs/api/functions/deleteJob.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteLayout.md
+++ b/docs/api/functions/deleteLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteLayout.md
+++ b/docs/api/functions/deleteLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteLayout.md
+++ b/docs/api/functions/deleteLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/downloadDownload.md
+++ b/docs/api/functions/downloadDownload.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/downloadDownload.md
+++ b/docs/api/functions/downloadDownload.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/downloadDownload.md
+++ b/docs/api/functions/downloadDownload.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/downloadFile.md
+++ b/docs/api/functions/downloadFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/downloadFile.md
+++ b/docs/api/functions/downloadFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/downloadFile.md
+++ b/docs/api/functions/downloadFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/eventTypeHasDataSchemas.md
+++ b/docs/api/functions/eventTypeHasDataSchemas.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/eventTypeHasDataSchemas.md
+++ b/docs/api/functions/eventTypeHasDataSchemas.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/eventTypeHasDataSchemas.md
+++ b/docs/api/functions/eventTypeHasDataSchemas.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/formatTimestamp.md
+++ b/docs/api/functions/formatTimestamp.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/formatTimestamp.md
+++ b/docs/api/functions/formatTimestamp.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/formatTimestamp.md
+++ b/docs/api/functions/formatTimestamp.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAccessToken.md
+++ b/docs/api/functions/getAccessToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAccessToken.md
+++ b/docs/api/functions/getAccessToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAccessToken.md
+++ b/docs/api/functions/getAccessToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlert.md
+++ b/docs/api/functions/getAlert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlert.md
+++ b/docs/api/functions/getAlert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlert.md
+++ b/docs/api/functions/getAlert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlertAction.md
+++ b/docs/api/functions/getAlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlertAction.md
+++ b/docs/api/functions/getAlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlertAction.md
+++ b/docs/api/functions/getAlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlertActionRule.md
+++ b/docs/api/functions/getAlertActionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlertActionRule.md
+++ b/docs/api/functions/getAlertActionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlertActionRule.md
+++ b/docs/api/functions/getAlertActionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlertConditionRule.md
+++ b/docs/api/functions/getAlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlertConditionRule.md
+++ b/docs/api/functions/getAlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlertConditionRule.md
+++ b/docs/api/functions/getAlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAllDataSchemas.md
+++ b/docs/api/functions/getAllDataSchemas.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAllDataSchemas.md
+++ b/docs/api/functions/getAllDataSchemas.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAllDataSchemas.md
+++ b/docs/api/functions/getAllDataSchemas.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAllKnownEventTypes.md
+++ b/docs/api/functions/getAllKnownEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAllKnownEventTypes.md
+++ b/docs/api/functions/getAllKnownEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAllKnownEventTypes.md
+++ b/docs/api/functions/getAllKnownEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAuthUrl.md
+++ b/docs/api/functions/getAuthUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAuthUrl.md
+++ b/docs/api/functions/getAuthUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAuthUrl.md
+++ b/docs/api/functions/getAuthUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridge.md
+++ b/docs/api/functions/getBridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridge.md
+++ b/docs/api/functions/getBridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridge.md
+++ b/docs/api/functions/getBridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridges.md
+++ b/docs/api/functions/getBridges.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridges.md
+++ b/docs/api/functions/getBridges.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridges.md
+++ b/docs/api/functions/getBridges.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCamera.md
+++ b/docs/api/functions/getCamera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCamera.md
+++ b/docs/api/functions/getCamera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCamera.md
+++ b/docs/api/functions/getCamera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameraSettings.md
+++ b/docs/api/functions/getCameraSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameraSettings.md
+++ b/docs/api/functions/getCameraSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameraSettings.md
+++ b/docs/api/functions/getCameraSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameraStatusString.md
+++ b/docs/api/functions/getCameraStatusString.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameraStatusString.md
+++ b/docs/api/functions/getCameraStatusString.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameraStatusString.md
+++ b/docs/api/functions/getCameraStatusString.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameras.md
+++ b/docs/api/functions/getCameras.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameras.md
+++ b/docs/api/functions/getCameras.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameras.md
+++ b/docs/api/functions/getCameras.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getClientId.md
+++ b/docs/api/functions/getClientId.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getClientId.md
+++ b/docs/api/functions/getClientId.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getClientId.md
+++ b/docs/api/functions/getClientId.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getConfig.md
+++ b/docs/api/functions/getConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getConfig.md
+++ b/docs/api/functions/getConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getConfig.md
+++ b/docs/api/functions/getConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCurrentUser.md
+++ b/docs/api/functions/getCurrentUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCurrentUser.md
+++ b/docs/api/functions/getCurrentUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCurrentUser.md
+++ b/docs/api/functions/getCurrentUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getDataSchemasForEventType.md
+++ b/docs/api/functions/getDataSchemasForEventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getDataSchemasForEventType.md
+++ b/docs/api/functions/getDataSchemasForEventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getDataSchemasForEventType.md
+++ b/docs/api/functions/getDataSchemasForEventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getDownload.md
+++ b/docs/api/functions/getDownload.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getDownload.md
+++ b/docs/api/functions/getDownload.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getDownload.md
+++ b/docs/api/functions/getDownload.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEvent.md
+++ b/docs/api/functions/getEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEvent.md
+++ b/docs/api/functions/getEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEvent.md
+++ b/docs/api/functions/getEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventAlertConditionRule.md
+++ b/docs/api/functions/getEventAlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventAlertConditionRule.md
+++ b/docs/api/functions/getEventAlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventAlertConditionRule.md
+++ b/docs/api/functions/getEventAlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventAlertConditionRuleFieldValues.md
+++ b/docs/api/functions/getEventAlertConditionRuleFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventAlertConditionRuleFieldValues.md
+++ b/docs/api/functions/getEventAlertConditionRuleFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventAlertConditionRuleFieldValues.md
+++ b/docs/api/functions/getEventAlertConditionRuleFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventMetrics.md
+++ b/docs/api/functions/getEventMetrics.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventMetrics.md
+++ b/docs/api/functions/getEventMetrics.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventMetrics.md
+++ b/docs/api/functions/getEventMetrics.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventSubscription.md
+++ b/docs/api/functions/getEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventSubscription.md
+++ b/docs/api/functions/getEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventSubscription.md
+++ b/docs/api/functions/getEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventTypesForDataSchema.md
+++ b/docs/api/functions/getEventTypesForDataSchema.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventTypesForDataSchema.md
+++ b/docs/api/functions/getEventTypesForDataSchema.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventTypesForDataSchema.md
+++ b/docs/api/functions/getEventTypesForDataSchema.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getFile.md
+++ b/docs/api/functions/getFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getFile.md
+++ b/docs/api/functions/getFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getFile.md
+++ b/docs/api/functions/getFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getIncludeParameterForEventTypes.md
+++ b/docs/api/functions/getIncludeParameterForEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getIncludeParameterForEventTypes.md
+++ b/docs/api/functions/getIncludeParameterForEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getIncludeParameterForEventTypes.md
+++ b/docs/api/functions/getIncludeParameterForEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getJob.md
+++ b/docs/api/functions/getJob.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getJob.md
+++ b/docs/api/functions/getJob.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getJob.md
+++ b/docs/api/functions/getJob.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayout.md
+++ b/docs/api/functions/getLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayout.md
+++ b/docs/api/functions/getLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayout.md
+++ b/docs/api/functions/getLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayouts.md
+++ b/docs/api/functions/getLayouts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayouts.md
+++ b/docs/api/functions/getLayouts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayouts.md
+++ b/docs/api/functions/getLayouts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLiveImage.md
+++ b/docs/api/functions/getLiveImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLiveImage.md
+++ b/docs/api/functions/getLiveImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLiveImage.md
+++ b/docs/api/functions/getLiveImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getMediaSession.md
+++ b/docs/api/functions/getMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getMediaSession.md
+++ b/docs/api/functions/getMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getMediaSession.md
+++ b/docs/api/functions/getMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getNotification.md
+++ b/docs/api/functions/getNotification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getNotification.md
+++ b/docs/api/functions/getNotification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getNotification.md
+++ b/docs/api/functions/getNotification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getProxyUrl.md
+++ b/docs/api/functions/getProxyUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getProxyUrl.md
+++ b/docs/api/functions/getProxyUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getProxyUrl.md
+++ b/docs/api/functions/getProxyUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRecordedImage.md
+++ b/docs/api/functions/getRecordedImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRecordedImage.md
+++ b/docs/api/functions/getRecordedImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRecordedImage.md
+++ b/docs/api/functions/getRecordedImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRedirectUri.md
+++ b/docs/api/functions/getRedirectUri.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRedirectUri.md
+++ b/docs/api/functions/getRedirectUri.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRedirectUri.md
+++ b/docs/api/functions/getRedirectUri.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getStorageStrategy.md
+++ b/docs/api/functions/getStorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getStorageStrategy.md
+++ b/docs/api/functions/getStorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getStorageStrategy.md
+++ b/docs/api/functions/getStorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUser.md
+++ b/docs/api/functions/getUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUser.md
+++ b/docs/api/functions/getUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUser.md
+++ b/docs/api/functions/getUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUsers.md
+++ b/docs/api/functions/getUsers.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUsers.md
+++ b/docs/api/functions/getUsers.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUsers.md
+++ b/docs/api/functions/getUsers.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/handleAuthCallback.md
+++ b/docs/api/functions/handleAuthCallback.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/handleAuthCallback.md
+++ b/docs/api/functions/handleAuthCallback.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/handleAuthCallback.md
+++ b/docs/api/functions/handleAuthCallback.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/initEenToolkit.md
+++ b/docs/api/functions/initEenToolkit.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/initEenToolkit.md
+++ b/docs/api/functions/initEenToolkit.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/initEenToolkit.md
+++ b/docs/api/functions/initEenToolkit.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/initMediaSession.md
+++ b/docs/api/functions/initMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/initMediaSession.md
+++ b/docs/api/functions/initMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/initMediaSession.md
+++ b/docs/api/functions/initMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/isStatusObject.md
+++ b/docs/api/functions/isStatusObject.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/isStatusObject.md
+++ b/docs/api/functions/isStatusObject.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/isStatusObject.md
+++ b/docs/api/functions/isStatusObject.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertActionRules.md
+++ b/docs/api/functions/listAlertActionRules.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertActionRules.md
+++ b/docs/api/functions/listAlertActionRules.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertActionRules.md
+++ b/docs/api/functions/listAlertActionRules.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertActions.md
+++ b/docs/api/functions/listAlertActions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertActions.md
+++ b/docs/api/functions/listAlertActions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertActions.md
+++ b/docs/api/functions/listAlertActions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertConditionRules.md
+++ b/docs/api/functions/listAlertConditionRules.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertConditionRules.md
+++ b/docs/api/functions/listAlertConditionRules.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertConditionRules.md
+++ b/docs/api/functions/listAlertConditionRules.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertTypes.md
+++ b/docs/api/functions/listAlertTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertTypes.md
+++ b/docs/api/functions/listAlertTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertTypes.md
+++ b/docs/api/functions/listAlertTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlerts.md
+++ b/docs/api/functions/listAlerts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlerts.md
+++ b/docs/api/functions/listAlerts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlerts.md
+++ b/docs/api/functions/listAlerts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/listDownloads.md
+++ b/docs/api/functions/listDownloads.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/listDownloads.md
+++ b/docs/api/functions/listDownloads.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/listDownloads.md
+++ b/docs/api/functions/listDownloads.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventAlertConditionRules.md
+++ b/docs/api/functions/listEventAlertConditionRules.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventAlertConditionRules.md
+++ b/docs/api/functions/listEventAlertConditionRules.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventAlertConditionRules.md
+++ b/docs/api/functions/listEventAlertConditionRules.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventFieldValues.md
+++ b/docs/api/functions/listEventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventFieldValues.md
+++ b/docs/api/functions/listEventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventFieldValues.md
+++ b/docs/api/functions/listEventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventSubscriptions.md
+++ b/docs/api/functions/listEventSubscriptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventSubscriptions.md
+++ b/docs/api/functions/listEventSubscriptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventSubscriptions.md
+++ b/docs/api/functions/listEventSubscriptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventTypes.md
+++ b/docs/api/functions/listEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventTypes.md
+++ b/docs/api/functions/listEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventTypes.md
+++ b/docs/api/functions/listEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEvents.md
+++ b/docs/api/functions/listEvents.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEvents.md
+++ b/docs/api/functions/listEvents.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEvents.md
+++ b/docs/api/functions/listEvents.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/listFeeds.md
+++ b/docs/api/functions/listFeeds.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/listFeeds.md
+++ b/docs/api/functions/listFeeds.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/listFeeds.md
+++ b/docs/api/functions/listFeeds.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/listFiles.md
+++ b/docs/api/functions/listFiles.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/listFiles.md
+++ b/docs/api/functions/listFiles.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/listFiles.md
+++ b/docs/api/functions/listFiles.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/listJobs.md
+++ b/docs/api/functions/listJobs.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/listJobs.md
+++ b/docs/api/functions/listJobs.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/listJobs.md
+++ b/docs/api/functions/listJobs.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/listMedia.md
+++ b/docs/api/functions/listMedia.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/listMedia.md
+++ b/docs/api/functions/listMedia.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/listMedia.md
+++ b/docs/api/functions/listMedia.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/listNotifications.md
+++ b/docs/api/functions/listNotifications.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/listNotifications.md
+++ b/docs/api/functions/listNotifications.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/listNotifications.md
+++ b/docs/api/functions/listNotifications.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/refreshToken.md
+++ b/docs/api/functions/refreshToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/refreshToken.md
+++ b/docs/api/functions/refreshToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/refreshToken.md
+++ b/docs/api/functions/refreshToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/revokeToken.md
+++ b/docs/api/functions/revokeToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/revokeToken.md
+++ b/docs/api/functions/revokeToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/revokeToken.md
+++ b/docs/api/functions/revokeToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/functions/updateLayout.md
+++ b/docs/api/functions/updateLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/functions/updateLayout.md
+++ b/docs/api/functions/updateLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/functions/updateLayout.md
+++ b/docs/api/functions/updateLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Alert.md
+++ b/docs/api/interfaces/Alert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Alert.md
+++ b/docs/api/interfaces/Alert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Alert.md
+++ b/docs/api/interfaces/Alert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertAction.md
+++ b/docs/api/interfaces/AlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertAction.md
+++ b/docs/api/interfaces/AlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertAction.md
+++ b/docs/api/interfaces/AlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertActionRule.md
+++ b/docs/api/interfaces/AlertActionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertActionRule.md
+++ b/docs/api/interfaces/AlertActionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertActionRule.md
+++ b/docs/api/interfaces/AlertActionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRule.md
+++ b/docs/api/interfaces/AlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRule.md
+++ b/docs/api/interfaces/AlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRule.md
+++ b/docs/api/interfaces/AlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRuleAction.md
+++ b/docs/api/interfaces/AlertConditionRuleAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRuleAction.md
+++ b/docs/api/interfaces/AlertConditionRuleAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRuleAction.md
+++ b/docs/api/interfaces/AlertConditionRuleAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRuleActor.md
+++ b/docs/api/interfaces/AlertConditionRuleActor.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRuleActor.md
+++ b/docs/api/interfaces/AlertConditionRuleActor.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRuleActor.md
+++ b/docs/api/interfaces/AlertConditionRuleActor.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRuleInsights.md
+++ b/docs/api/interfaces/AlertConditionRuleInsights.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRuleInsights.md
+++ b/docs/api/interfaces/AlertConditionRuleInsights.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRuleInsights.md
+++ b/docs/api/interfaces/AlertConditionRuleInsights.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertType.md
+++ b/docs/api/interfaces/AlertType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertType.md
+++ b/docs/api/interfaces/AlertType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertType.md
+++ b/docs/api/interfaces/AlertType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AutomationAlertAction.md
+++ b/docs/api/interfaces/AutomationAlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AutomationAlertAction.md
+++ b/docs/api/interfaces/AutomationAlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AutomationAlertAction.md
+++ b/docs/api/interfaces/AutomationAlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Bridge.md
+++ b/docs/api/interfaces/Bridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Bridge.md
+++ b/docs/api/interfaces/Bridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Bridge.md
+++ b/docs/api/interfaces/Bridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDeviceInfo.md
+++ b/docs/api/interfaces/BridgeDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDeviceInfo.md
+++ b/docs/api/interfaces/BridgeDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDeviceInfo.md
+++ b/docs/api/interfaces/BridgeDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDevicePosition.md
+++ b/docs/api/interfaces/BridgeDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDevicePosition.md
+++ b/docs/api/interfaces/BridgeDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDevicePosition.md
+++ b/docs/api/interfaces/BridgeDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeNetworkInfo.md
+++ b/docs/api/interfaces/BridgeNetworkInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeNetworkInfo.md
+++ b/docs/api/interfaces/BridgeNetworkInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeNetworkInfo.md
+++ b/docs/api/interfaces/BridgeNetworkInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Camera.md
+++ b/docs/api/interfaces/Camera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Camera.md
+++ b/docs/api/interfaces/Camera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Camera.md
+++ b/docs/api/interfaces/Camera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDeviceInfo.md
+++ b/docs/api/interfaces/CameraDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDeviceInfo.md
+++ b/docs/api/interfaces/CameraDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDeviceInfo.md
+++ b/docs/api/interfaces/CameraDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDevicePosition.md
+++ b/docs/api/interfaces/CameraDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDevicePosition.md
+++ b/docs/api/interfaces/CameraDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDevicePosition.md
+++ b/docs/api/interfaces/CameraDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRecordingModes.md
+++ b/docs/api/interfaces/CameraRecordingModes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRecordingModes.md
+++ b/docs/api/interfaces/CameraRecordingModes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRecordingModes.md
+++ b/docs/api/interfaces/CameraRecordingModes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRtspConnectionSettings.md
+++ b/docs/api/interfaces/CameraRtspConnectionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRtspConnectionSettings.md
+++ b/docs/api/interfaces/CameraRtspConnectionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRtspConnectionSettings.md
+++ b/docs/api/interfaces/CameraRtspConnectionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettings.md
+++ b/docs/api/interfaces/CameraSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettings.md
+++ b/docs/api/interfaces/CameraSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettings.md
+++ b/docs/api/interfaces/CameraSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsAnalog.md
+++ b/docs/api/interfaces/CameraSettingsAnalog.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsAnalog.md
+++ b/docs/api/interfaces/CameraSettingsAnalog.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsAnalog.md
+++ b/docs/api/interfaces/CameraSettingsAnalog.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsAudio.md
+++ b/docs/api/interfaces/CameraSettingsAudio.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsAudio.md
+++ b/docs/api/interfaces/CameraSettingsAudio.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsAudio.md
+++ b/docs/api/interfaces/CameraSettingsAudio.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsCredentials.md
+++ b/docs/api/interfaces/CameraSettingsCredentials.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsCredentials.md
+++ b/docs/api/interfaces/CameraSettingsCredentials.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsCredentials.md
+++ b/docs/api/interfaces/CameraSettingsCredentials.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsData.md
+++ b/docs/api/interfaces/CameraSettingsData.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsData.md
+++ b/docs/api/interfaces/CameraSettingsData.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsData.md
+++ b/docs/api/interfaces/CameraSettingsData.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsMainVideo.md
+++ b/docs/api/interfaces/CameraSettingsMainVideo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsMainVideo.md
+++ b/docs/api/interfaces/CameraSettingsMainVideo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsMainVideo.md
+++ b/docs/api/interfaces/CameraSettingsMainVideo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsOperating.md
+++ b/docs/api/interfaces/CameraSettingsOperating.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsOperating.md
+++ b/docs/api/interfaces/CameraSettingsOperating.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsOperating.md
+++ b/docs/api/interfaces/CameraSettingsOperating.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsPreviewVideo.md
+++ b/docs/api/interfaces/CameraSettingsPreviewVideo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsPreviewVideo.md
+++ b/docs/api/interfaces/CameraSettingsPreviewVideo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsPreviewVideo.md
+++ b/docs/api/interfaces/CameraSettingsPreviewVideo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsRetention.md
+++ b/docs/api/interfaces/CameraSettingsRetention.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsRetention.md
+++ b/docs/api/interfaces/CameraSettingsRetention.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsRetention.md
+++ b/docs/api/interfaces/CameraSettingsRetention.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsScheduledOverride.md
+++ b/docs/api/interfaces/CameraSettingsScheduledOverride.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsScheduledOverride.md
+++ b/docs/api/interfaces/CameraSettingsScheduledOverride.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsScheduledOverride.md
+++ b/docs/api/interfaces/CameraSettingsScheduledOverride.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsTalkdown.md
+++ b/docs/api/interfaces/CameraSettingsTalkdown.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsTalkdown.md
+++ b/docs/api/interfaces/CameraSettingsTalkdown.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsTalkdown.md
+++ b/docs/api/interfaces/CameraSettingsTalkdown.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraShareDetails.md
+++ b/docs/api/interfaces/CameraShareDetails.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraShareDetails.md
+++ b/docs/api/interfaces/CameraShareDetails.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraShareDetails.md
+++ b/docs/api/interfaces/CameraShareDetails.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStatusCounts.md
+++ b/docs/api/interfaces/CameraStatusCounts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStatusCounts.md
+++ b/docs/api/interfaces/CameraStatusCounts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStatusCounts.md
+++ b/docs/api/interfaces/CameraStatusCounts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStreamUrls.md
+++ b/docs/api/interfaces/CameraStreamUrls.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStreamUrls.md
+++ b/docs/api/interfaces/CameraStreamUrls.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStreamUrls.md
+++ b/docs/api/interfaces/CameraStreamUrls.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateEventSubscriptionParams.md
+++ b/docs/api/interfaces/CreateEventSubscriptionParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateEventSubscriptionParams.md
+++ b/docs/api/interfaces/CreateEventSubscriptionParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateEventSubscriptionParams.md
+++ b/docs/api/interfaces/CreateEventSubscriptionParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateExportParams.md
+++ b/docs/api/interfaces/CreateExportParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateExportParams.md
+++ b/docs/api/interfaces/CreateExportParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateExportParams.md
+++ b/docs/api/interfaces/CreateExportParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateFileParams.md
+++ b/docs/api/interfaces/CreateFileParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateFileParams.md
+++ b/docs/api/interfaces/CreateFileParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateFileParams.md
+++ b/docs/api/interfaces/CreateFileParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateLayoutParams.md
+++ b/docs/api/interfaces/CreateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateLayoutParams.md
+++ b/docs/api/interfaces/CreateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateLayoutParams.md
+++ b/docs/api/interfaces/CreateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Download.md
+++ b/docs/api/interfaces/Download.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Download.md
+++ b/docs/api/interfaces/Download.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Download.md
+++ b/docs/api/interfaces/Download.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/DownloadFileResult.md
+++ b/docs/api/interfaces/DownloadFileResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/DownloadFileResult.md
+++ b/docs/api/interfaces/DownloadFileResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/DownloadFileResult.md
+++ b/docs/api/interfaces/DownloadFileResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenError.md
+++ b/docs/api/interfaces/EenError.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenError.md
+++ b/docs/api/interfaces/EenError.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenError.md
+++ b/docs/api/interfaces/EenError.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenFile.md
+++ b/docs/api/interfaces/EenFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenFile.md
+++ b/docs/api/interfaces/EenFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenFile.md
+++ b/docs/api/interfaces/EenFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenToolkitConfig.md
+++ b/docs/api/interfaces/EenToolkitConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenToolkitConfig.md
+++ b/docs/api/interfaces/EenToolkitConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenToolkitConfig.md
+++ b/docs/api/interfaces/EenToolkitConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Event.md
+++ b/docs/api/interfaces/Event.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Event.md
+++ b/docs/api/interfaces/Event.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Event.md
+++ b/docs/api/interfaces/Event.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventAlertConditionRule.md
+++ b/docs/api/interfaces/EventAlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventAlertConditionRule.md
+++ b/docs/api/interfaces/EventAlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventAlertConditionRule.md
+++ b/docs/api/interfaces/EventAlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventAlertConditionRuleFieldValues.md
+++ b/docs/api/interfaces/EventAlertConditionRuleFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventAlertConditionRuleFieldValues.md
+++ b/docs/api/interfaces/EventAlertConditionRuleFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventAlertConditionRuleFieldValues.md
+++ b/docs/api/interfaces/EventAlertConditionRuleFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventData.md
+++ b/docs/api/interfaces/EventData.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventData.md
+++ b/docs/api/interfaces/EventData.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventData.md
+++ b/docs/api/interfaces/EventData.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventFieldValues.md
+++ b/docs/api/interfaces/EventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventFieldValues.md
+++ b/docs/api/interfaces/EventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventFieldValues.md
+++ b/docs/api/interfaces/EventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventFilter.md
+++ b/docs/api/interfaces/EventFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventFilter.md
+++ b/docs/api/interfaces/EventFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventFilter.md
+++ b/docs/api/interfaces/EventFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventMetric.md
+++ b/docs/api/interfaces/EventMetric.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventMetric.md
+++ b/docs/api/interfaces/EventMetric.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventMetric.md
+++ b/docs/api/interfaces/EventMetric.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventResourceFilter.md
+++ b/docs/api/interfaces/EventResourceFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventResourceFilter.md
+++ b/docs/api/interfaces/EventResourceFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventResourceFilter.md
+++ b/docs/api/interfaces/EventResourceFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscription.md
+++ b/docs/api/interfaces/EventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscription.md
+++ b/docs/api/interfaces/EventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscription.md
+++ b/docs/api/interfaces/EventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionConfig.md
+++ b/docs/api/interfaces/EventSubscriptionConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionConfig.md
+++ b/docs/api/interfaces/EventSubscriptionConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionConfig.md
+++ b/docs/api/interfaces/EventSubscriptionConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionFilter.md
+++ b/docs/api/interfaces/EventSubscriptionFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionFilter.md
+++ b/docs/api/interfaces/EventSubscriptionFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionFilter.md
+++ b/docs/api/interfaces/EventSubscriptionFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventType.md
+++ b/docs/api/interfaces/EventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventType.md
+++ b/docs/api/interfaces/EventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventType.md
+++ b/docs/api/interfaces/EventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventTypeFilter.md
+++ b/docs/api/interfaces/EventTypeFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventTypeFilter.md
+++ b/docs/api/interfaces/EventTypeFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventTypeFilter.md
+++ b/docs/api/interfaces/EventTypeFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Feed.md
+++ b/docs/api/interfaces/Feed.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Feed.md
+++ b/docs/api/interfaces/Feed.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Feed.md
+++ b/docs/api/interfaces/Feed.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/FilterCreate.md
+++ b/docs/api/interfaces/FilterCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/FilterCreate.md
+++ b/docs/api/interfaces/FilterCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/FilterCreate.md
+++ b/docs/api/interfaces/FilterCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetAlertConditionRuleParams.md
+++ b/docs/api/interfaces/GetAlertConditionRuleParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetAlertConditionRuleParams.md
+++ b/docs/api/interfaces/GetAlertConditionRuleParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetAlertConditionRuleParams.md
+++ b/docs/api/interfaces/GetAlertConditionRuleParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetAlertParams.md
+++ b/docs/api/interfaces/GetAlertParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetAlertParams.md
+++ b/docs/api/interfaces/GetAlertParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetAlertParams.md
+++ b/docs/api/interfaces/GetAlertParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetBridgeParams.md
+++ b/docs/api/interfaces/GetBridgeParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetBridgeParams.md
+++ b/docs/api/interfaces/GetBridgeParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetBridgeParams.md
+++ b/docs/api/interfaces/GetBridgeParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetCameraParams.md
+++ b/docs/api/interfaces/GetCameraParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetCameraParams.md
+++ b/docs/api/interfaces/GetCameraParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetCameraParams.md
+++ b/docs/api/interfaces/GetCameraParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetCameraSettingsParams.md
+++ b/docs/api/interfaces/GetCameraSettingsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetCameraSettingsParams.md
+++ b/docs/api/interfaces/GetCameraSettingsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetCameraSettingsParams.md
+++ b/docs/api/interfaces/GetCameraSettingsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetDownloadParams.md
+++ b/docs/api/interfaces/GetDownloadParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetDownloadParams.md
+++ b/docs/api/interfaces/GetDownloadParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetDownloadParams.md
+++ b/docs/api/interfaces/GetDownloadParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventAlertConditionRuleFieldValuesParams.md
+++ b/docs/api/interfaces/GetEventAlertConditionRuleFieldValuesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventAlertConditionRuleFieldValuesParams.md
+++ b/docs/api/interfaces/GetEventAlertConditionRuleFieldValuesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventAlertConditionRuleFieldValuesParams.md
+++ b/docs/api/interfaces/GetEventAlertConditionRuleFieldValuesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventMetricsParams.md
+++ b/docs/api/interfaces/GetEventMetricsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventMetricsParams.md
+++ b/docs/api/interfaces/GetEventMetricsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventMetricsParams.md
+++ b/docs/api/interfaces/GetEventMetricsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventParams.md
+++ b/docs/api/interfaces/GetEventParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventParams.md
+++ b/docs/api/interfaces/GetEventParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventParams.md
+++ b/docs/api/interfaces/GetEventParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetFileParams.md
+++ b/docs/api/interfaces/GetFileParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetFileParams.md
+++ b/docs/api/interfaces/GetFileParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetFileParams.md
+++ b/docs/api/interfaces/GetFileParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetJobParams.md
+++ b/docs/api/interfaces/GetJobParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetJobParams.md
+++ b/docs/api/interfaces/GetJobParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetJobParams.md
+++ b/docs/api/interfaces/GetJobParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLayoutParams.md
+++ b/docs/api/interfaces/GetLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLayoutParams.md
+++ b/docs/api/interfaces/GetLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLayoutParams.md
+++ b/docs/api/interfaces/GetLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLiveImageParams.md
+++ b/docs/api/interfaces/GetLiveImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLiveImageParams.md
+++ b/docs/api/interfaces/GetLiveImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLiveImageParams.md
+++ b/docs/api/interfaces/GetLiveImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetRecordedImageParams.md
+++ b/docs/api/interfaces/GetRecordedImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetRecordedImageParams.md
+++ b/docs/api/interfaces/GetRecordedImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetRecordedImageParams.md
+++ b/docs/api/interfaces/GetRecordedImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetUserParams.md
+++ b/docs/api/interfaces/GetUserParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetUserParams.md
+++ b/docs/api/interfaces/GetUserParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetUserParams.md
+++ b/docs/api/interfaces/GetUserParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/HumanValidation.md
+++ b/docs/api/interfaces/HumanValidation.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/HumanValidation.md
+++ b/docs/api/interfaces/HumanValidation.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/HumanValidation.md
+++ b/docs/api/interfaces/HumanValidation.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Job.md
+++ b/docs/api/interfaces/Job.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Job.md
+++ b/docs/api/interfaces/Job.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Job.md
+++ b/docs/api/interfaces/Job.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Layout.md
+++ b/docs/api/interfaces/Layout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Layout.md
+++ b/docs/api/interfaces/Layout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Layout.md
+++ b/docs/api/interfaces/Layout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPane.md
+++ b/docs/api/interfaces/LayoutPane.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPane.md
+++ b/docs/api/interfaces/LayoutPane.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPane.md
+++ b/docs/api/interfaces/LayoutPane.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPermissions.md
+++ b/docs/api/interfaces/LayoutPermissions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPermissions.md
+++ b/docs/api/interfaces/LayoutPermissions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPermissions.md
+++ b/docs/api/interfaces/LayoutPermissions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutSettings.md
+++ b/docs/api/interfaces/LayoutSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutSettings.md
+++ b/docs/api/interfaces/LayoutSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutSettings.md
+++ b/docs/api/interfaces/LayoutSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertActionRulesParams.md
+++ b/docs/api/interfaces/ListAlertActionRulesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertActionRulesParams.md
+++ b/docs/api/interfaces/ListAlertActionRulesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertActionRulesParams.md
+++ b/docs/api/interfaces/ListAlertActionRulesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertActionsParams.md
+++ b/docs/api/interfaces/ListAlertActionsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertActionsParams.md
+++ b/docs/api/interfaces/ListAlertActionsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertActionsParams.md
+++ b/docs/api/interfaces/ListAlertActionsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertConditionRulesParams.md
+++ b/docs/api/interfaces/ListAlertConditionRulesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertConditionRulesParams.md
+++ b/docs/api/interfaces/ListAlertConditionRulesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertConditionRulesParams.md
+++ b/docs/api/interfaces/ListAlertConditionRulesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertTypesParams.md
+++ b/docs/api/interfaces/ListAlertTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertTypesParams.md
+++ b/docs/api/interfaces/ListAlertTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertTypesParams.md
+++ b/docs/api/interfaces/ListAlertTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertsParams.md
+++ b/docs/api/interfaces/ListAlertsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertsParams.md
+++ b/docs/api/interfaces/ListAlertsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertsParams.md
+++ b/docs/api/interfaces/ListAlertsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListBridgesParams.md
+++ b/docs/api/interfaces/ListBridgesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListBridgesParams.md
+++ b/docs/api/interfaces/ListBridgesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListBridgesParams.md
+++ b/docs/api/interfaces/ListBridgesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListCamerasParams.md
+++ b/docs/api/interfaces/ListCamerasParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListCamerasParams.md
+++ b/docs/api/interfaces/ListCamerasParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListCamerasParams.md
+++ b/docs/api/interfaces/ListCamerasParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListDownloadsParams.md
+++ b/docs/api/interfaces/ListDownloadsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListDownloadsParams.md
+++ b/docs/api/interfaces/ListDownloadsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListDownloadsParams.md
+++ b/docs/api/interfaces/ListDownloadsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventAlertConditionRulesParams.md
+++ b/docs/api/interfaces/ListEventAlertConditionRulesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventAlertConditionRulesParams.md
+++ b/docs/api/interfaces/ListEventAlertConditionRulesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventAlertConditionRulesParams.md
+++ b/docs/api/interfaces/ListEventAlertConditionRulesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventFieldValuesParams.md
+++ b/docs/api/interfaces/ListEventFieldValuesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventFieldValuesParams.md
+++ b/docs/api/interfaces/ListEventFieldValuesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventFieldValuesParams.md
+++ b/docs/api/interfaces/ListEventFieldValuesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventSubscriptionsParams.md
+++ b/docs/api/interfaces/ListEventSubscriptionsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventSubscriptionsParams.md
+++ b/docs/api/interfaces/ListEventSubscriptionsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventSubscriptionsParams.md
+++ b/docs/api/interfaces/ListEventSubscriptionsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventTypesParams.md
+++ b/docs/api/interfaces/ListEventTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventTypesParams.md
+++ b/docs/api/interfaces/ListEventTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventTypesParams.md
+++ b/docs/api/interfaces/ListEventTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventsParams.md
+++ b/docs/api/interfaces/ListEventsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventsParams.md
+++ b/docs/api/interfaces/ListEventsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventsParams.md
+++ b/docs/api/interfaces/ListEventsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsParams.md
+++ b/docs/api/interfaces/ListFeedsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsParams.md
+++ b/docs/api/interfaces/ListFeedsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsParams.md
+++ b/docs/api/interfaces/ListFeedsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsResult.md
+++ b/docs/api/interfaces/ListFeedsResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsResult.md
+++ b/docs/api/interfaces/ListFeedsResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsResult.md
+++ b/docs/api/interfaces/ListFeedsResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFilesParams.md
+++ b/docs/api/interfaces/ListFilesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFilesParams.md
+++ b/docs/api/interfaces/ListFilesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFilesParams.md
+++ b/docs/api/interfaces/ListFilesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListJobsParams.md
+++ b/docs/api/interfaces/ListJobsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListJobsParams.md
+++ b/docs/api/interfaces/ListJobsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListJobsParams.md
+++ b/docs/api/interfaces/ListJobsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListLayoutsParams.md
+++ b/docs/api/interfaces/ListLayoutsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListLayoutsParams.md
+++ b/docs/api/interfaces/ListLayoutsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListLayoutsParams.md
+++ b/docs/api/interfaces/ListLayoutsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListMediaParams.md
+++ b/docs/api/interfaces/ListMediaParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListMediaParams.md
+++ b/docs/api/interfaces/ListMediaParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListMediaParams.md
+++ b/docs/api/interfaces/ListMediaParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListNotificationsParams.md
+++ b/docs/api/interfaces/ListNotificationsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListNotificationsParams.md
+++ b/docs/api/interfaces/ListNotificationsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListNotificationsParams.md
+++ b/docs/api/interfaces/ListNotificationsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListUsersParams.md
+++ b/docs/api/interfaces/ListUsersParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListUsersParams.md
+++ b/docs/api/interfaces/ListUsersParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListUsersParams.md
+++ b/docs/api/interfaces/ListUsersParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LiveImageResult.md
+++ b/docs/api/interfaces/LiveImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LiveImageResult.md
+++ b/docs/api/interfaces/LiveImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LiveImageResult.md
+++ b/docs/api/interfaces/LiveImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaInterval.md
+++ b/docs/api/interfaces/MediaInterval.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaInterval.md
+++ b/docs/api/interfaces/MediaInterval.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaInterval.md
+++ b/docs/api/interfaces/MediaInterval.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResponse.md
+++ b/docs/api/interfaces/MediaSessionResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResponse.md
+++ b/docs/api/interfaces/MediaSessionResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResponse.md
+++ b/docs/api/interfaces/MediaSessionResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResult.md
+++ b/docs/api/interfaces/MediaSessionResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResult.md
+++ b/docs/api/interfaces/MediaSessionResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResult.md
+++ b/docs/api/interfaces/MediaSessionResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Notification.md
+++ b/docs/api/interfaces/Notification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Notification.md
+++ b/docs/api/interfaces/Notification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Notification.md
+++ b/docs/api/interfaces/Notification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/NotificationSettings.md
+++ b/docs/api/interfaces/NotificationSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/NotificationSettings.md
+++ b/docs/api/interfaces/NotificationSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/NotificationSettings.md
+++ b/docs/api/interfaces/NotificationSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/OutputPortSettings.md
+++ b/docs/api/interfaces/OutputPortSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/OutputPortSettings.md
+++ b/docs/api/interfaces/OutputPortSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/OutputPortSettings.md
+++ b/docs/api/interfaces/OutputPortSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginatedResult.md
+++ b/docs/api/interfaces/PaginatedResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginatedResult.md
+++ b/docs/api/interfaces/PaginatedResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginatedResult.md
+++ b/docs/api/interfaces/PaginatedResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginationParams.md
+++ b/docs/api/interfaces/PaginationParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginationParams.md
+++ b/docs/api/interfaces/PaginationParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginationParams.md
+++ b/docs/api/interfaces/PaginationParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PlaySpeakerAudioClipSettings.md
+++ b/docs/api/interfaces/PlaySpeakerAudioClipSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PlaySpeakerAudioClipSettings.md
+++ b/docs/api/interfaces/PlaySpeakerAudioClipSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PlaySpeakerAudioClipSettings.md
+++ b/docs/api/interfaces/PlaySpeakerAudioClipSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/RecordedImageResult.md
+++ b/docs/api/interfaces/RecordedImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/RecordedImageResult.md
+++ b/docs/api/interfaces/RecordedImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/RecordedImageResult.md
+++ b/docs/api/interfaces/RecordedImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnection.md
+++ b/docs/api/interfaces/SSEConnection.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnection.md
+++ b/docs/api/interfaces/SSEConnection.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnection.md
+++ b/docs/api/interfaces/SSEConnection.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnectionOptions.md
+++ b/docs/api/interfaces/SSEConnectionOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnectionOptions.md
+++ b/docs/api/interfaces/SSEConnectionOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnectionOptions.md
+++ b/docs/api/interfaces/SSEConnectionOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfig.md
+++ b/docs/api/interfaces/SSEDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfig.md
+++ b/docs/api/interfaces/SSEDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfig.md
+++ b/docs/api/interfaces/SSEDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfigCreate.md
+++ b/docs/api/interfaces/SSEDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfigCreate.md
+++ b/docs/api/interfaces/SSEDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfigCreate.md
+++ b/docs/api/interfaces/SSEDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEEvent.md
+++ b/docs/api/interfaces/SSEEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEEvent.md
+++ b/docs/api/interfaces/SSEEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEEvent.md
+++ b/docs/api/interfaces/SSEEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SlackSettings.md
+++ b/docs/api/interfaces/SlackSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SlackSettings.md
+++ b/docs/api/interfaces/SlackSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SlackSettings.md
+++ b/docs/api/interfaces/SlackSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SmsSettings.md
+++ b/docs/api/interfaces/SmsSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SmsSettings.md
+++ b/docs/api/interfaces/SmsSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SmsSettings.md
+++ b/docs/api/interfaces/SmsSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SmtpSettings.md
+++ b/docs/api/interfaces/SmtpSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SmtpSettings.md
+++ b/docs/api/interfaces/SmtpSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SmtpSettings.md
+++ b/docs/api/interfaces/SmtpSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/TokenResponse.md
+++ b/docs/api/interfaces/TokenResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/TokenResponse.md
+++ b/docs/api/interfaces/TokenResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/TokenResponse.md
+++ b/docs/api/interfaces/TokenResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UpdateLayoutParams.md
+++ b/docs/api/interfaces/UpdateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UpdateLayoutParams.md
+++ b/docs/api/interfaces/UpdateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UpdateLayoutParams.md
+++ b/docs/api/interfaces/UpdateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/User.md
+++ b/docs/api/interfaces/User.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/User.md
+++ b/docs/api/interfaces/User.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/User.md
+++ b/docs/api/interfaces/User.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UserProfile.md
+++ b/docs/api/interfaces/UserProfile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UserProfile.md
+++ b/docs/api/interfaces/UserProfile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UserProfile.md
+++ b/docs/api/interfaces/UserProfile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfig.md
+++ b/docs/api/interfaces/WebhookDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfig.md
+++ b/docs/api/interfaces/WebhookDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfig.md
+++ b/docs/api/interfaces/WebhookDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfigCreate.md
+++ b/docs/api/interfaces/WebhookDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfigCreate.md
+++ b/docs/api/interfaces/WebhookDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfigCreate.md
+++ b/docs/api/interfaces/WebhookDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookSettings.md
+++ b/docs/api/interfaces/WebhookSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookSettings.md
+++ b/docs/api/interfaces/WebhookSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookSettings.md
+++ b/docs/api/interfaces/WebhookSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ActorType.md
+++ b/docs/api/type-aliases/ActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ActorType.md
+++ b/docs/api/type-aliases/ActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ActorType.md
+++ b/docs/api/type-aliases/ActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionSettings.md
+++ b/docs/api/type-aliases/AlertActionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionSettings.md
+++ b/docs/api/type-aliases/AlertActionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionSettings.md
+++ b/docs/api/type-aliases/AlertActionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionStatus.md
+++ b/docs/api/type-aliases/AlertActionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionStatus.md
+++ b/docs/api/type-aliases/AlertActionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionStatus.md
+++ b/docs/api/type-aliases/AlertActionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionType.md
+++ b/docs/api/type-aliases/AlertActionType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionType.md
+++ b/docs/api/type-aliases/AlertActionType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionType.md
+++ b/docs/api/type-aliases/AlertActionType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertConditionRuleInclude.md
+++ b/docs/api/type-aliases/AlertConditionRuleInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertConditionRuleInclude.md
+++ b/docs/api/type-aliases/AlertConditionRuleInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertConditionRuleInclude.md
+++ b/docs/api/type-aliases/AlertConditionRuleInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertInclude.md
+++ b/docs/api/type-aliases/AlertInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertInclude.md
+++ b/docs/api/type-aliases/AlertInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertInclude.md
+++ b/docs/api/type-aliases/AlertInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertSort.md
+++ b/docs/api/type-aliases/AlertSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertSort.md
+++ b/docs/api/type-aliases/AlertSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertSort.md
+++ b/docs/api/type-aliases/AlertSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/BridgeStatus.md
+++ b/docs/api/type-aliases/BridgeStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/BridgeStatus.md
+++ b/docs/api/type-aliases/BridgeStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/BridgeStatus.md
+++ b/docs/api/type-aliases/BridgeStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraAspectRatio.md
+++ b/docs/api/type-aliases/CameraAspectRatio.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraAspectRatio.md
+++ b/docs/api/type-aliases/CameraAspectRatio.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraAspectRatio.md
+++ b/docs/api/type-aliases/CameraAspectRatio.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraSettingsInclude.md
+++ b/docs/api/type-aliases/CameraSettingsInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraSettingsInclude.md
+++ b/docs/api/type-aliases/CameraSettingsInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraSettingsInclude.md
+++ b/docs/api/type-aliases/CameraSettingsInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraStatus.md
+++ b/docs/api/type-aliases/CameraStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraStatus.md
+++ b/docs/api/type-aliases/CameraStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraStatus.md
+++ b/docs/api/type-aliases/CameraStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DataSchema.md
+++ b/docs/api/type-aliases/DataSchema.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DataSchema.md
+++ b/docs/api/type-aliases/DataSchema.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DataSchema.md
+++ b/docs/api/type-aliases/DataSchema.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfig.md
+++ b/docs/api/type-aliases/DeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfig.md
+++ b/docs/api/type-aliases/DeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfig.md
+++ b/docs/api/type-aliases/DeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfigCreate.md
+++ b/docs/api/type-aliases/DeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfigCreate.md
+++ b/docs/api/type-aliases/DeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfigCreate.md
+++ b/docs/api/type-aliases/DeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DownloadDownloadResult.md
+++ b/docs/api/type-aliases/DownloadDownloadResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DownloadDownloadResult.md
+++ b/docs/api/type-aliases/DownloadDownloadResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DownloadDownloadResult.md
+++ b/docs/api/type-aliases/DownloadDownloadResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DownloadStatus.md
+++ b/docs/api/type-aliases/DownloadStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DownloadStatus.md
+++ b/docs/api/type-aliases/DownloadStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DownloadStatus.md
+++ b/docs/api/type-aliases/DownloadStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ErrorCode.md
+++ b/docs/api/type-aliases/ErrorCode.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ErrorCode.md
+++ b/docs/api/type-aliases/ErrorCode.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ErrorCode.md
+++ b/docs/api/type-aliases/ErrorCode.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionDeliveryType.md
+++ b/docs/api/type-aliases/EventSubscriptionDeliveryType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionDeliveryType.md
+++ b/docs/api/type-aliases/EventSubscriptionDeliveryType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionDeliveryType.md
+++ b/docs/api/type-aliases/EventSubscriptionDeliveryType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionLifecycle.md
+++ b/docs/api/type-aliases/EventSubscriptionLifecycle.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionLifecycle.md
+++ b/docs/api/type-aliases/EventSubscriptionLifecycle.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionLifecycle.md
+++ b/docs/api/type-aliases/EventSubscriptionLifecycle.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ExportJobResponse.md
+++ b/docs/api/type-aliases/ExportJobResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ExportJobResponse.md
+++ b/docs/api/type-aliases/ExportJobResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ExportJobResponse.md
+++ b/docs/api/type-aliases/ExportJobResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ExportType.md
+++ b/docs/api/type-aliases/ExportType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ExportType.md
+++ b/docs/api/type-aliases/ExportType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ExportType.md
+++ b/docs/api/type-aliases/ExportType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedIncludeOption.md
+++ b/docs/api/type-aliases/FeedIncludeOption.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedIncludeOption.md
+++ b/docs/api/type-aliases/FeedIncludeOption.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedIncludeOption.md
+++ b/docs/api/type-aliases/FeedIncludeOption.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedMediaType.md
+++ b/docs/api/type-aliases/FeedMediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedMediaType.md
+++ b/docs/api/type-aliases/FeedMediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedMediaType.md
+++ b/docs/api/type-aliases/FeedMediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedStreamType.md
+++ b/docs/api/type-aliases/FeedStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedStreamType.md
+++ b/docs/api/type-aliases/FeedStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedStreamType.md
+++ b/docs/api/type-aliases/FeedStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FileIncludeField.md
+++ b/docs/api/type-aliases/FileIncludeField.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FileIncludeField.md
+++ b/docs/api/type-aliases/FileIncludeField.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FileIncludeField.md
+++ b/docs/api/type-aliases/FileIncludeField.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FileType.md
+++ b/docs/api/type-aliases/FileType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FileType.md
+++ b/docs/api/type-aliases/FileType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FileType.md
+++ b/docs/api/type-aliases/FileType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/GetLayoutInclude.md
+++ b/docs/api/type-aliases/GetLayoutInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/GetLayoutInclude.md
+++ b/docs/api/type-aliases/GetLayoutInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/GetLayoutInclude.md
+++ b/docs/api/type-aliases/GetLayoutInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/JobState.md
+++ b/docs/api/type-aliases/JobState.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/JobState.md
+++ b/docs/api/type-aliases/JobState.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/JobState.md
+++ b/docs/api/type-aliases/JobState.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/KnownEventType.md
+++ b/docs/api/type-aliases/KnownEventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/KnownEventType.md
+++ b/docs/api/type-aliases/KnownEventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/KnownEventType.md
+++ b/docs/api/type-aliases/KnownEventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneSize.md
+++ b/docs/api/type-aliases/LayoutPaneSize.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneSize.md
+++ b/docs/api/type-aliases/LayoutPaneSize.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneSize.md
+++ b/docs/api/type-aliases/LayoutPaneSize.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneType.md
+++ b/docs/api/type-aliases/LayoutPaneType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneType.md
+++ b/docs/api/type-aliases/LayoutPaneType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneType.md
+++ b/docs/api/type-aliases/LayoutPaneType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsInclude.md
+++ b/docs/api/type-aliases/ListLayoutsInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsInclude.md
+++ b/docs/api/type-aliases/ListLayoutsInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsInclude.md
+++ b/docs/api/type-aliases/ListLayoutsInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsSort.md
+++ b/docs/api/type-aliases/ListLayoutsSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsSort.md
+++ b/docs/api/type-aliases/ListLayoutsSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsSort.md
+++ b/docs/api/type-aliases/ListLayoutsSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaStreamType.md
+++ b/docs/api/type-aliases/MediaStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaStreamType.md
+++ b/docs/api/type-aliases/MediaStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaStreamType.md
+++ b/docs/api/type-aliases/MediaStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaType.md
+++ b/docs/api/type-aliases/MediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaType.md
+++ b/docs/api/type-aliases/MediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaType.md
+++ b/docs/api/type-aliases/MediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricActorType.md
+++ b/docs/api/type-aliases/MetricActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricActorType.md
+++ b/docs/api/type-aliases/MetricActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricActorType.md
+++ b/docs/api/type-aliases/MetricActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricDataPoint.md
+++ b/docs/api/type-aliases/MetricDataPoint.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricDataPoint.md
+++ b/docs/api/type-aliases/MetricDataPoint.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricDataPoint.md
+++ b/docs/api/type-aliases/MetricDataPoint.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationCategory.md
+++ b/docs/api/type-aliases/NotificationCategory.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationCategory.md
+++ b/docs/api/type-aliases/NotificationCategory.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationCategory.md
+++ b/docs/api/type-aliases/NotificationCategory.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationStatus.md
+++ b/docs/api/type-aliases/NotificationStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationStatus.md
+++ b/docs/api/type-aliases/NotificationStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationStatus.md
+++ b/docs/api/type-aliases/NotificationStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/Result.md
+++ b/docs/api/type-aliases/Result.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/Result.md
+++ b/docs/api/type-aliases/Result.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/Result.md
+++ b/docs/api/type-aliases/Result.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/SSEConnectionStatus.md
+++ b/docs/api/type-aliases/SSEConnectionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/SSEConnectionStatus.md
+++ b/docs/api/type-aliases/SSEConnectionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/SSEConnectionStatus.md
+++ b/docs/api/type-aliases/SSEConnectionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/StorageStrategy.md
+++ b/docs/api/type-aliases/StorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/StorageStrategy.md
+++ b/docs/api/type-aliases/StorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/StorageStrategy.md
+++ b/docs/api/type-aliases/StorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/variables/EVENT_TYPE_DATA_SCHEMAS.md
+++ b/docs/api/variables/EVENT_TYPE_DATA_SCHEMAS.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/variables/EVENT_TYPE_DATA_SCHEMAS.md
+++ b/docs/api/variables/EVENT_TYPE_DATA_SCHEMAS.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/variables/EVENT_TYPE_DATA_SCHEMAS.md
+++ b/docs/api/variables/EVENT_TYPE_DATA_SCHEMAS.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
+++ b/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
+++ b/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
+++ b/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/api/variables/useAuthStore.md
+++ b/docs/api/variables/useAuthStore.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.83**](../README.md)
+[**EEN API Toolkit v0.3.84**](../README.md)
 
 ***
 

--- a/docs/api/variables/useAuthStore.md
+++ b/docs/api/variables/useAuthStore.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.84**](../README.md)
+[**EEN API Toolkit v0.3.85**](../README.md)
 
 ***
 

--- a/docs/api/variables/useAuthStore.md
+++ b/docs/api/variables/useAuthStore.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.82**](../README.md)
+[**EEN API Toolkit v0.3.83**](../README.md)
 
 ***
 

--- a/docs/een-api-all-endpoints.md
+++ b/docs/een-api-all-endpoints.md
@@ -1,0 +1,502 @@
+# Eagle Eye Networks REST API v3.0 - Complete Endpoint Reference
+
+> Generated: 2026-02-17
+> Source: [EEN Developer Portal](https://developer.eagleeyenetworks.com/reference/using-the-api) and [OpenAPI Specifications](https://github.com/EENCloud/VMS-Developer-Portal/tree/main/Open%20API%20Specifications)
+
+All paths are prefixed with `/api/v3.0` on the appropriate base URL (e.g., `https://c001.eagleeyenetworks.com`).
+
+---
+
+## DEVICES - Cameras (15 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/cameras` | List cameras |
+| POST | `/cameras` | Add a camera |
+| POST | `/cameras:bulkUpdate` | Bulk update cameras |
+| GET | `/cameras/{cameraId}` | Get camera by ID |
+| PATCH | `/cameras/{cameraId}` | Update a camera |
+| DELETE | `/cameras/{cameraId}` | Delete a camera |
+| PUT | `/cameras/{cameraId}/tunnel` | Create/update camera tunnel |
+| DELETE | `/cameras/{cameraId}/tunnel` | Delete camera tunnel |
+| GET | `/cameras/{cameraId}/metrics` | Get camera metrics |
+| PATCH | `/cameras/{cameraId}:swap` | Swap a camera |
+| GET | `/cameras/{cameraId}/io/ports` | List camera I/O ports |
+| GET | `/cameras/{cameraId}/io/ports/{portId}` | Get camera I/O port |
+| PATCH | `/cameras/{cameraId}/io/ports/{portId}` | Update camera I/O port |
+| GET | `/cameras/{cameraId}/settings` | Get camera settings |
+| PATCH | `/cameras/{cameraId}/settings` | Update camera settings |
+
+## DEVICES - Bridges (11 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/bridges` | List bridges |
+| POST | `/bridges` | Create a bridge |
+| POST | `/bridges:bulkUpdate` | Bulk update bridges |
+| GET | `/bridges/{bridgeId}` | Get bridge by ID |
+| PATCH | `/bridges/{bridgeId}` | Update a bridge |
+| DELETE | `/bridges/{bridgeId}` | Delete a bridge |
+| GET | `/bridges/{bridgeId}/metrics` | Get bridge metrics |
+| PATCH | `/bridges/{bridgeId}:swap` | Swap a bridge |
+| POST | `/bridges/{bridgeId}/actions` | Trigger bridge action |
+| GET | `/bridges/{id}/settings` | Get bridge settings |
+| PATCH | `/bridges/{id}/settings` | Update bridge settings |
+
+## DEVICES - PTZ (4 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/cameras/{cameraId}/ptz/position` | Get current PTZ position |
+| PUT | `/cameras/{cameraId}/ptz/position` | Move PTZ to position |
+| GET | `/cameras/{cameraId}/ptz/settings` | Get PTZ settings |
+| PATCH | `/cameras/{cameraId}/ptz/settings` | Update PTZ settings |
+
+## DEVICES - Speakers (7 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/speakers` | List speakers |
+| POST | `/speakers` | Add a speaker |
+| GET | `/speakers/{speakerId}` | Get speaker by ID |
+| PATCH | `/speakers/{speakerId}` | Update a speaker |
+| DELETE | `/speakers/{speakerId}` | Delete a speaker |
+| GET | `/speakers/{speakerId}/settings` | Get speaker settings |
+| PATCH | `/speakers/{speakerId}/settings` | Update speaker settings |
+
+## DEVICES - Device I/O (6 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/devices/{deviceId}/io/ports` | List device I/O ports |
+| GET | `/devices/{deviceId}/io/ports/{portId}` | Get device I/O port |
+| PATCH | `/devices/{deviceId}/io/ports/{portId}` | Update device I/O port |
+| GET | `/devices/{deviceId}/io/ports/{portId}/recordingActions` | List port recording actions |
+| GET | `/devices/{deviceId}/io/ports/{portId}/recordingActions/{cameraId}` | Get port recording action |
+| PATCH | `/devices/{deviceId}/io/ports/{portId}/recordingActions/{cameraId}` | Update port recording action |
+
+## DEVICES - Switches (5 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/switches` | List switches |
+| GET | `/switches/{switchId}` | Get switch by ID |
+| PATCH | `/switches/{switchId}` | Update a switch |
+| POST | `/switches/{switchId}/ports/{portId}/actions` | Trigger switch port action |
+| POST | `/switches/{switchId}/ports/all/actions` | Trigger action on all switch ports |
+
+## DEVICES - Multi Cameras (6 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/multiCameras` | List multi-cameras |
+| POST | `/multiCameras` | Add a multi-camera |
+| GET | `/multiCameras/{multiCameraId}` | Get multi-camera by ID |
+| PATCH | `/multiCameras/{multiCameraId}` | Update a multi-camera |
+| DELETE | `/multiCameras/{multiCameraId}` | Delete a multi-camera |
+| GET | `/multiCameras/{multiCameraId}/channels` | Get multi-camera channels |
+
+## DEVICES - Available Devices (1 endpoint)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/availableDevices` | List available (unclaimed) devices |
+
+## GROUPING - Layouts (5 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/layouts` | List layouts |
+| POST | `/layouts` | Create a layout |
+| GET | `/layouts/{layoutId}` | Get layout by ID |
+| PATCH | `/layouts/{layoutId}` | Update a layout |
+| DELETE | `/layouts/{layoutId}` | Delete a layout |
+
+## GROUPING - Tags (1 endpoint)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/tags` | List tags |
+
+## GROUPING - Locations (6 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/locations` | List locations |
+| POST | `/locations` | Create a location |
+| GET | `/locations/{id}` | Get location by ID |
+| PATCH | `/locations/{id}` | Update a location |
+| DELETE | `/locations/{id}` | Delete a location |
+| GET | `/locations/{id}/locations` | Get location descendants |
+
+## GROUPING - Floors (6 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/locations/{locationId}/floors` | List floors for a location |
+| POST | `/locations/{locationId}/floors` | Create a floor |
+| GET | `/locations/{locationId}/floors/{id}` | Get floor by ID |
+| PATCH | `/locations/{locationId}/floors/{id}` | Update a floor |
+| DELETE | `/locations/{locationId}/floors/{id}` | Delete a floor |
+| GET | `/locations/{locationId}/floors/{id}.{type}` | Get floor image |
+
+## GROUPING - Floor Plans (3 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/locations/{locationId}/floors/{id}/plans` | List floor plans |
+| POST | `/locations/{locationId}/floors/{id}/plans` | Set a floor plan |
+| DELETE | `/locations/{locationId}/floors/{id}/plans/{planId}` | Delete a floor plan |
+
+## MEDIA - Media (5 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/media` | List media (recording spans) |
+| GET | `/media/recordedImage.jpeg` | Get recorded image |
+| GET | `/media/recordedImage.jpeg:listFieldValues` | List recorded image overlay field values |
+| GET | `/media/liveImage.jpeg` | Get live image |
+| GET | `/media/session` | Get media session URL |
+
+## MEDIA - Feeds (1 endpoint)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/feeds` | List feeds (live video streams) |
+
+## MEDIA - Exports (2 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/exports` | Create an export job |
+| POST | `/exports/{jobId}:copy` | Retry/copy an export |
+
+## MEDIA - Jobs (3 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/jobs` | List jobs |
+| GET | `/jobs/{jobId}` | Get job by ID |
+| DELETE | `/jobs/{jobId}` | Delete a job |
+
+## MEDIA - Files (11 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/files` | List files |
+| POST | `/files` | Add a file |
+| GET | `/files/{id}` | Get file by ID |
+| PATCH | `/files/{id}` | Update a file |
+| DELETE | `/files/{id}` | Delete a file |
+| GET | `/files/{id}:download` | Download a file |
+| GET | `/deletedFiles` | List trash (deleted files) |
+| GET | `/deletedFiles/{id}` | Get deleted file |
+| DELETE | `/deletedFiles/{id}` | Permanently delete a trash file |
+| DELETE | `/deletedFiles/all` | Permanently delete all trash files |
+| POST | `/deletedFiles/{id}:restore` | Restore a deleted file |
+
+## MEDIA - Downloads (4 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/downloads` | List downloads |
+| GET | `/downloads/{id}` | Get download by ID |
+| PATCH | `/downloads/{id}` | Update a download |
+| GET | `/downloads/{id}:download` | Download a download file |
+
+## EVENTS - Events (5 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/events` | List events |
+| POST | `/events` | Create an event |
+| GET | `/events/{id}` | Get event by ID |
+| GET | `/events:listRecentByType` | List recent events by type |
+| GET | `/events:listFieldValues` | List event field values |
+
+## EVENTS - Event Types (1 endpoint)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/eventTypes` | List event types |
+
+## EVENTS - Event Metrics (1 endpoint)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/eventMetrics` | Get event metrics |
+
+## EVENTS - Event Subscriptions (8 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/eventSubscriptions` | List event subscriptions |
+| POST | `/eventSubscriptions` | Create event subscription |
+| GET | `/eventSubscriptions/{id}` | Get event subscription |
+| DELETE | `/eventSubscriptions/{id}` | Delete event subscription |
+| GET | `/eventSubscriptions/{id}/filters` | List subscription filters |
+| POST | `/eventSubscriptions/{id}/filters` | Create subscription filter |
+| GET | `/eventSubscriptions/{id}/filters/{filterId}` | Get subscription filter |
+| DELETE | `/eventSubscriptions/{id}/filters/{filterId}` | Delete subscription filter |
+
+## EVENTS - Alerts (3 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/alerts` | List alerts |
+| GET | `/alerts/{id}` | Get alert by ID |
+| GET | `/alertTypes` | List alert types |
+
+## EVENTS - Notifications (3 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/notifications` | List notifications |
+| GET | `/notifications/{id}` | Get notification by ID |
+| PATCH | `/notifications/{id}` | Update a notification |
+
+## AUTOMATIONS - Event Alert Condition Rules (6 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/eventAlertConditionRules` | List event alert condition rules |
+| POST | `/eventAlertConditionRules` | Create event alert condition rule |
+| GET | `/eventAlertConditionRules:listFieldValues` | List rule field values |
+| GET | `/eventAlertConditionRules/{id}` | Get event alert condition rule |
+| PATCH | `/eventAlertConditionRules/{id}` | Update event alert condition rule |
+| DELETE | `/eventAlertConditionRules/{id}` | Delete event alert condition rule |
+
+## AUTOMATIONS - Alert Action Rules (5 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/alertActionRules` | List alert action rules |
+| POST | `/alertActionRules` | Create alert action rule |
+| GET | `/alertActionRules/{actionRuleId}` | Get alert action rule |
+| PATCH | `/alertActionRules/{actionRuleId}` | Update alert action rule |
+| DELETE | `/alertActionRules/{actionRuleId}` | Delete alert action rule |
+
+## AUTOMATIONS - Alert Actions (5 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/alertActions` | List alert actions |
+| POST | `/alertActions` | Create alert action |
+| GET | `/alertActions/{actionId}` | Get alert action |
+| PATCH | `/alertActions/{actionId}` | Update alert action |
+| DELETE | `/alertActions/{actionId}` | Delete alert action |
+
+## VIDEO SEARCH - Video Analytic Events (7 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/videoAnalyticEvents:parse` | Parse video analytics query |
+| POST | `/videoAnalyticEvents:deepSearch` | Deep search video analytics events |
+| POST | `/videoAnalyticEvents:deepSearchGroupByResource` | Deep search grouped by resource |
+| POST | `/videoAnalyticEvents:deepSearchGroupByTime` | Deep search grouped by time |
+| POST | `/videoAnalyticEvents:listFieldValues` | List video analytics field values |
+| GET | `/videoAnalyticEvents:listObjectValues` | List video analytics object values |
+| GET | `/videoAnalyticEvents/{id}` | Get video analytics event by ID |
+
+## VEHICLE SURVEILLANCE - LPR Events (4 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/lprEvents` | List LPR events |
+| GET | `/lprEvents/{id}` | Get LPR event by ID |
+| GET | `/lprEvents:summary` | Get LPR events summary |
+| GET | `/lprEvents:listFieldValues` | List LPR event field values |
+
+## VEHICLE SURVEILLANCE - LPR Alert Condition Rules (6 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/lprAlertConditionRules` | List LPR alert condition rules |
+| POST | `/lprAlertConditionRules` | Create LPR alert condition rule |
+| GET | `/lprAlertConditionRules:listFieldValues` | List LPR rule field values |
+| GET | `/lprAlertConditionRules/{id}` | Get LPR alert condition rule |
+| PATCH | `/lprAlertConditionRules/{id}` | Update LPR alert condition rule |
+| DELETE | `/lprAlertConditionRules/{id}` | Delete LPR alert condition rule |
+
+## VEHICLE SURVEILLANCE - LPR Vehicle Lists (14 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/lprVehicleLists` | List vehicle lists |
+| POST | `/lprVehicleLists` | Create vehicle list |
+| GET | `/lprVehicleLists:listFields` | List vehicle list fields |
+| GET | `/lprVehicleLists:listFieldValues` | List vehicle list field values |
+| GET | `/lprVehicleLists/{id}` | Get vehicle list by ID |
+| PATCH | `/lprVehicleLists/{id}` | Update vehicle list |
+| DELETE | `/lprVehicleLists/{id}` | Delete vehicle list |
+| GET | `/lprVehicleLists/{id}/vehicles` | List vehicles in a list |
+| POST | `/lprVehicleLists/{id}/vehicles` | Add vehicle to list |
+| POST | `/lprVehicleLists/{id}/vehicles:bulkCreate` | Bulk add vehicles |
+| GET | `/lprVehicleLists/{id}/vehicles/{recordId}` | Get vehicle by ID |
+| PATCH | `/lprVehicleLists/{id}/vehicles/{recordId}` | Update a vehicle |
+| DELETE | `/lprVehicleLists/{id}/vehicles/{recordId}` | Delete a vehicle |
+| GET | `/lprVehicleLists:search` | Search vehicle lists |
+
+## USER & ACCOUNTS - Users (9 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/users` | List users |
+| POST | `/users` | Create a user |
+| GET | `/users/{userId}` | Get user by ID |
+| PATCH | `/users/{userId}` | Update a user |
+| DELETE | `/users/{userId}` | Delete a user |
+| GET | `/users/self` | Get current user |
+| PATCH | `/users/self` | Update current user |
+| GET | `/users/self/trustedClients` | List trusted OAuth clients |
+| DELETE | `/users/self/trustedClients/{trustedClientId}` | Delete trusted client |
+
+## USER & ACCOUNTS - Accounts (2 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/accounts` | List accounts |
+| DELETE | `/accounts/{id}/credentials/{credentialId}` | Delete account credential |
+
+## USER & ACCOUNTS - Roles (8 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/roles` | List roles |
+| POST | `/roles` | Create a role |
+| GET | `/roles/{roleId}` | Get role by ID |
+| PATCH | `/roles/{roleId}` | Update a role |
+| DELETE | `/roles/{roleId}` | Delete a role |
+| GET | `/roleAssignments` | List role assignments |
+| POST | `/roleAssignments:bulkcreate` | Bulk create role assignments |
+| POST | `/roleAssignments:bulkdelete` | Bulk delete role assignments |
+
+## USER & ACCOUNTS - Audit Log (1 endpoint)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/auditLogs` | List audit logs |
+
+## USER & ACCOUNTS - Resource Grants (3 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/resourceGrants` | List resource grants |
+| POST | `/resourceGrants:bulkCreate` | Bulk create resource grants |
+| POST | `/resourceGrants:bulkDelete` | Bulk delete resource grants |
+
+## USER & ACCOUNTS - Editions (2 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/editions` | List editions |
+| GET | `/editions/{id}` | Get edition by ID |
+
+## RESELLERS - Authorization Tokens (1 endpoint)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/authorizationTokens` | Create authorization token (reseller account switching) |
+
+## ACCOUNT SETTINGS - SSO (2 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/accounts/self/ssoAuthSettings` | Get SSO auth settings |
+| PATCH | `/accounts/self/ssoAuthSettings` | Update SSO auth settings |
+
+## ACCOUNT SETTINGS - Client Settings (1 endpoint)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/clientSettings` | Get client settings |
+
+## SYSTEM - Applications (5 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/applications` | List applications |
+| POST | `/applications` | Create an application |
+| GET | `/applications/{applicationId}` | Get application by ID |
+| PATCH | `/applications/{applicationId}` | Update an application |
+| DELETE | `/applications/{applicationId}` | Delete an application |
+
+## SYSTEM - OAuth Clients (5 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/applications/{applicationId}/oauthClients` | List OAuth clients |
+| POST | `/applications/{applicationId}/oauthClients` | Create OAuth client |
+| GET | `/applications/{applicationId}/oauthClients/{clientId}` | Get OAuth client |
+| PATCH | `/applications/{applicationId}/oauthClients/{clientId}` | Update OAuth client |
+| DELETE | `/applications/{applicationId}/oauthClients/{clientId}` | Delete OAuth client |
+
+## SYSTEM - Reference Data (2 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/languages` | List supported languages |
+| GET | `/timeZones` | List supported time zones |
+
+---
+
+## Summary
+
+| Category | Subcategory | Endpoints |
+|----------|-------------|-----------|
+| Devices | Cameras | 15 |
+| Devices | Bridges | 11 |
+| Devices | PTZ | 4 |
+| Devices | Speakers | 7 |
+| Devices | Device I/O | 6 |
+| Devices | Switches | 5 |
+| Devices | Multi Cameras | 6 |
+| Devices | Available Devices | 1 |
+| Grouping | Layouts | 5 |
+| Grouping | Tags | 1 |
+| Grouping | Locations | 6 |
+| Grouping | Floors | 6 |
+| Grouping | Floor Plans | 3 |
+| Media | Media | 5 |
+| Media | Feeds | 1 |
+| Media | Exports | 2 |
+| Media | Jobs | 3 |
+| Media | Files | 11 |
+| Media | Downloads | 4 |
+| Events | Events | 5 |
+| Events | Event Types | 1 |
+| Events | Event Metrics | 1 |
+| Events | Event Subscriptions | 8 |
+| Events | Alerts | 3 |
+| Events | Notifications | 3 |
+| Automations | Event Alert Condition Rules | 6 |
+| Automations | Alert Action Rules | 5 |
+| Automations | Alert Actions | 5 |
+| Video Search | Video Analytic Events | 7 |
+| Vehicle Surveillance | LPR Events | 4 |
+| Vehicle Surveillance | LPR Alert Condition Rules | 6 |
+| Vehicle Surveillance | LPR Vehicle Lists | 14 |
+| User & Accounts | Users | 9 |
+| User & Accounts | Accounts | 2 |
+| User & Accounts | Roles | 8 |
+| User & Accounts | Audit Log | 1 |
+| User & Accounts | Resource Grants | 3 |
+| User & Accounts | Editions | 2 |
+| Resellers | Authorization Tokens | 1 |
+| Account Settings | SSO | 2 |
+| Account Settings | Client Settings | 1 |
+| System | Applications | 5 |
+| System | OAuth Clients | 5 |
+| System | Reference Data | 2 |
+| **TOTAL** | | **211** |
+
+### By HTTP Method
+
+| Method | Count |
+|--------|-------|
+| GET | 117 |
+| POST | 35 |
+| PATCH | 30 |
+| DELETE | 27 |
+| PUT | 2 |
+| **Total** | **211** |

--- a/docs/een-api-coverage.html
+++ b/docs/een-api-coverage.html
@@ -1,0 +1,443 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EEN API v3.0 - Toolkit Coverage Report</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #f5f7fa; color: #1a1a2e; padding: 24px; }
+    h1 { font-size: 1.6rem; margin-bottom: 8px; }
+    .subtitle { color: #666; margin-bottom: 24px; font-size: 0.9rem; }
+    .stats { display: flex; gap: 16px; margin-bottom: 24px; flex-wrap: wrap; }
+    .stat-card { background: #fff; border-radius: 8px; padding: 16px 24px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); min-width: 140px; }
+    .stat-card .number { font-size: 2rem; font-weight: 700; }
+    .stat-card .label { font-size: 0.8rem; color: #666; text-transform: uppercase; letter-spacing: 0.5px; }
+    .stat-card.green .number { color: #16a34a; }
+    .stat-card.red .number { color: #dc2626; }
+    .stat-card.blue .number { color: #2563eb; }
+    .filter-bar { margin-bottom: 16px; display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+    .filter-bar label { font-size: 0.85rem; font-weight: 600; }
+    .filter-bar select, .filter-bar input { padding: 6px 12px; border: 1px solid #d1d5db; border-radius: 6px; font-size: 0.85rem; }
+    .filter-bar input { width: 220px; }
+    table { width: 100%; border-collapse: collapse; background: #fff; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); font-size: 0.85rem; }
+    thead { background: #1e293b; color: #fff; }
+    th { padding: 10px 12px; text-align: left; font-weight: 600; cursor: pointer; user-select: none; white-space: nowrap; }
+    th:hover { background: #334155; }
+    td { padding: 8px 12px; border-bottom: 1px solid #f1f5f9; }
+    tr:hover td { background: #f8fafc; }
+    .method { display: inline-block; padding: 2px 8px; border-radius: 4px; font-weight: 700; font-size: 0.75rem; min-width: 56px; text-align: center; }
+    .method-GET { background: #dbeafe; color: #1d4ed8; }
+    .method-POST { background: #dcfce7; color: #166534; }
+    .method-PATCH { background: #fef3c7; color: #92400e; }
+    .method-DELETE { background: #fee2e2; color: #991b1b; }
+    .method-PUT { background: #e0e7ff; color: #3730a3; }
+    .status-impl { color: #16a34a; font-weight: 600; }
+    .status-miss { color: #dc2626; font-weight: 600; }
+    .badge { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 0.75rem; font-weight: 600; }
+    .badge-impl { background: #dcfce7; color: #166534; }
+    .badge-miss { background: #fee2e2; color: #991b1b; }
+    .func { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.8rem; color: #6d28d9; }
+    .category { font-size: 0.8rem; color: #64748b; }
+    .progress-bar { width: 100%; height: 8px; background: #fee2e2; border-radius: 4px; overflow: hidden; margin-top: 8px; }
+    .progress-fill { height: 100%; background: #16a34a; border-radius: 4px; transition: width 0.3s; }
+    footer { margin-top: 24px; font-size: 0.8rem; color: #94a3b8; text-align: center; }
+  </style>
+</head>
+<body>
+
+<h1>Eagle Eye Networks API v3.0 - Toolkit Coverage</h1>
+<p class="subtitle">Generated: 2026-02-17 | een-api-toolkit implementation status</p>
+
+<div class="stats">
+  <div class="stat-card blue">
+    <div class="number">211</div>
+    <div class="label">Total Endpoints</div>
+  </div>
+  <div class="stat-card green">
+    <div class="number">51</div>
+    <div class="label">Implemented</div>
+  </div>
+  <div class="stat-card red">
+    <div class="number">160</div>
+    <div class="label">Missing</div>
+  </div>
+  <div class="stat-card">
+    <div class="number">24.2%</div>
+    <div class="label">Coverage</div>
+    <div class="progress-bar"><div class="progress-fill" style="width:24.2%"></div></div>
+  </div>
+</div>
+
+<div class="filter-bar">
+  <label>Filter:</label>
+  <select id="statusFilter" onchange="filterTable()">
+    <option value="all">All Endpoints</option>
+    <option value="implemented">Implemented Only</option>
+    <option value="missing">Missing Only</option>
+  </select>
+  <select id="categoryFilter" onchange="filterTable()">
+    <option value="all">All Categories</option>
+    <option value="Devices">Devices</option>
+    <option value="Grouping">Grouping</option>
+    <option value="Media">Media</option>
+    <option value="Events">Events</option>
+    <option value="Automations">Automations</option>
+    <option value="Video Search">Video Search</option>
+    <option value="Vehicle Surveillance">Vehicle Surveillance</option>
+    <option value="User &amp; Accounts">User &amp; Accounts</option>
+    <option value="Resellers">Resellers</option>
+    <option value="Account Settings">Account Settings</option>
+    <option value="System">System</option>
+  </select>
+  <select id="methodFilter" onchange="filterTable()">
+    <option value="all">All Methods</option>
+    <option value="GET">GET</option>
+    <option value="POST">POST</option>
+    <option value="PATCH">PATCH</option>
+    <option value="DELETE">DELETE</option>
+    <option value="PUT">PUT</option>
+  </select>
+  <input type="text" id="searchFilter" placeholder="Search path or function..." oninput="filterTable()">
+</div>
+
+<table id="apiTable">
+  <thead>
+    <tr>
+      <th onclick="sortTable(0)">#</th>
+      <th onclick="sortTable(1)">Category</th>
+      <th onclick="sortTable(2)">Subcategory</th>
+      <th onclick="sortTable(3)">Method</th>
+      <th onclick="sortTable(4)">Path</th>
+      <th onclick="sortTable(5)">Description</th>
+      <th onclick="sortTable(6)">Status</th>
+      <th onclick="sortTable(7)">Toolkit Function</th>
+    </tr>
+  </thead>
+  <tbody id="tableBody">
+  </tbody>
+</table>
+
+<footer>
+  Source: <a href="https://developer.eagleeyenetworks.com/reference/using-the-api">EEN Developer Portal</a> |
+  <a href="https://github.com/EENCloud/VMS-Developer-Portal">OpenAPI Specs</a>
+</footer>
+
+<script>
+const endpoints = [
+  // DEVICES - Cameras (15)
+  {cat:"Devices",sub:"Cameras",method:"GET",path:"/cameras",desc:"List cameras",status:"impl",func:"getCameras()"},
+  {cat:"Devices",sub:"Cameras",method:"POST",path:"/cameras",desc:"Add a camera",status:"miss",func:""},
+  {cat:"Devices",sub:"Cameras",method:"POST",path:"/cameras:bulkUpdate",desc:"Bulk update cameras",status:"miss",func:""},
+  {cat:"Devices",sub:"Cameras",method:"GET",path:"/cameras/{cameraId}",desc:"Get camera by ID",status:"impl",func:"getCamera()"},
+  {cat:"Devices",sub:"Cameras",method:"PATCH",path:"/cameras/{cameraId}",desc:"Update a camera",status:"miss",func:""},
+  {cat:"Devices",sub:"Cameras",method:"DELETE",path:"/cameras/{cameraId}",desc:"Delete a camera",status:"miss",func:""},
+  {cat:"Devices",sub:"Cameras",method:"PUT",path:"/cameras/{cameraId}/tunnel",desc:"Create/update camera tunnel",status:"miss",func:""},
+  {cat:"Devices",sub:"Cameras",method:"DELETE",path:"/cameras/{cameraId}/tunnel",desc:"Delete camera tunnel",status:"miss",func:""},
+  {cat:"Devices",sub:"Cameras",method:"GET",path:"/cameras/{cameraId}/metrics",desc:"Get camera metrics",status:"miss",func:""},
+  {cat:"Devices",sub:"Cameras",method:"PATCH",path:"/cameras/{cameraId}:swap",desc:"Swap a camera",status:"miss",func:""},
+  {cat:"Devices",sub:"Cameras",method:"GET",path:"/cameras/{cameraId}/io/ports",desc:"List camera I/O ports",status:"miss",func:""},
+  {cat:"Devices",sub:"Cameras",method:"GET",path:"/cameras/{cameraId}/io/ports/{portId}",desc:"Get camera I/O port",status:"miss",func:""},
+  {cat:"Devices",sub:"Cameras",method:"PATCH",path:"/cameras/{cameraId}/io/ports/{portId}",desc:"Update camera I/O port",status:"miss",func:""},
+  {cat:"Devices",sub:"Cameras",method:"GET",path:"/cameras/{cameraId}/settings",desc:"Get camera settings",status:"impl",func:"getCameraSettings()"},
+  {cat:"Devices",sub:"Cameras",method:"PATCH",path:"/cameras/{cameraId}/settings",desc:"Update camera settings",status:"miss",func:""},
+  // DEVICES - Bridges (11)
+  {cat:"Devices",sub:"Bridges",method:"GET",path:"/bridges",desc:"List bridges",status:"impl",func:"getBridges()"},
+  {cat:"Devices",sub:"Bridges",method:"POST",path:"/bridges",desc:"Create a bridge",status:"miss",func:""},
+  {cat:"Devices",sub:"Bridges",method:"POST",path:"/bridges:bulkUpdate",desc:"Bulk update bridges",status:"miss",func:""},
+  {cat:"Devices",sub:"Bridges",method:"GET",path:"/bridges/{bridgeId}",desc:"Get bridge by ID",status:"impl",func:"getBridge()"},
+  {cat:"Devices",sub:"Bridges",method:"PATCH",path:"/bridges/{bridgeId}",desc:"Update a bridge",status:"miss",func:""},
+  {cat:"Devices",sub:"Bridges",method:"DELETE",path:"/bridges/{bridgeId}",desc:"Delete a bridge",status:"miss",func:""},
+  {cat:"Devices",sub:"Bridges",method:"GET",path:"/bridges/{bridgeId}/metrics",desc:"Get bridge metrics",status:"miss",func:""},
+  {cat:"Devices",sub:"Bridges",method:"PATCH",path:"/bridges/{bridgeId}:swap",desc:"Swap a bridge",status:"miss",func:""},
+  {cat:"Devices",sub:"Bridges",method:"POST",path:"/bridges/{bridgeId}/actions",desc:"Trigger bridge action",status:"miss",func:""},
+  {cat:"Devices",sub:"Bridges",method:"GET",path:"/bridges/{id}/settings",desc:"Get bridge settings",status:"miss",func:""},
+  {cat:"Devices",sub:"Bridges",method:"PATCH",path:"/bridges/{id}/settings",desc:"Update bridge settings",status:"miss",func:""},
+  // DEVICES - PTZ (4)
+  {cat:"Devices",sub:"PTZ",method:"GET",path:"/cameras/{cameraId}/ptz/position",desc:"Get current PTZ position",status:"miss",func:""},
+  {cat:"Devices",sub:"PTZ",method:"PUT",path:"/cameras/{cameraId}/ptz/position",desc:"Move PTZ to position",status:"miss",func:""},
+  {cat:"Devices",sub:"PTZ",method:"GET",path:"/cameras/{cameraId}/ptz/settings",desc:"Get PTZ settings",status:"miss",func:""},
+  {cat:"Devices",sub:"PTZ",method:"PATCH",path:"/cameras/{cameraId}/ptz/settings",desc:"Update PTZ settings",status:"miss",func:""},
+  // DEVICES - Speakers (7)
+  {cat:"Devices",sub:"Speakers",method:"GET",path:"/speakers",desc:"List speakers",status:"miss",func:""},
+  {cat:"Devices",sub:"Speakers",method:"POST",path:"/speakers",desc:"Add a speaker",status:"miss",func:""},
+  {cat:"Devices",sub:"Speakers",method:"GET",path:"/speakers/{speakerId}",desc:"Get speaker by ID",status:"miss",func:""},
+  {cat:"Devices",sub:"Speakers",method:"PATCH",path:"/speakers/{speakerId}",desc:"Update a speaker",status:"miss",func:""},
+  {cat:"Devices",sub:"Speakers",method:"DELETE",path:"/speakers/{speakerId}",desc:"Delete a speaker",status:"miss",func:""},
+  {cat:"Devices",sub:"Speakers",method:"GET",path:"/speakers/{speakerId}/settings",desc:"Get speaker settings",status:"miss",func:""},
+  {cat:"Devices",sub:"Speakers",method:"PATCH",path:"/speakers/{speakerId}/settings",desc:"Update speaker settings",status:"miss",func:""},
+  // DEVICES - Device I/O (6)
+  {cat:"Devices",sub:"Device I/O",method:"GET",path:"/devices/{deviceId}/io/ports",desc:"List device I/O ports",status:"miss",func:""},
+  {cat:"Devices",sub:"Device I/O",method:"GET",path:"/devices/{deviceId}/io/ports/{portId}",desc:"Get device I/O port",status:"miss",func:""},
+  {cat:"Devices",sub:"Device I/O",method:"PATCH",path:"/devices/{deviceId}/io/ports/{portId}",desc:"Update device I/O port",status:"miss",func:""},
+  {cat:"Devices",sub:"Device I/O",method:"GET",path:"/devices/{deviceId}/io/ports/{portId}/recordingActions",desc:"List port recording actions",status:"miss",func:""},
+  {cat:"Devices",sub:"Device I/O",method:"GET",path:"/devices/{deviceId}/io/ports/{portId}/recordingActions/{cameraId}",desc:"Get port recording action",status:"miss",func:""},
+  {cat:"Devices",sub:"Device I/O",method:"PATCH",path:"/devices/{deviceId}/io/ports/{portId}/recordingActions/{cameraId}",desc:"Update port recording action",status:"miss",func:""},
+  // DEVICES - Switches (5)
+  {cat:"Devices",sub:"Switches",method:"GET",path:"/switches",desc:"List switches",status:"miss",func:""},
+  {cat:"Devices",sub:"Switches",method:"GET",path:"/switches/{switchId}",desc:"Get switch by ID",status:"miss",func:""},
+  {cat:"Devices",sub:"Switches",method:"PATCH",path:"/switches/{switchId}",desc:"Update a switch",status:"miss",func:""},
+  {cat:"Devices",sub:"Switches",method:"POST",path:"/switches/{switchId}/ports/{portId}/actions",desc:"Trigger switch port action",status:"miss",func:""},
+  {cat:"Devices",sub:"Switches",method:"POST",path:"/switches/{switchId}/ports/all/actions",desc:"Trigger action on all switch ports",status:"miss",func:""},
+  // DEVICES - Multi Cameras (6)
+  {cat:"Devices",sub:"Multi Cameras",method:"GET",path:"/multiCameras",desc:"List multi-cameras",status:"miss",func:""},
+  {cat:"Devices",sub:"Multi Cameras",method:"POST",path:"/multiCameras",desc:"Add a multi-camera",status:"miss",func:""},
+  {cat:"Devices",sub:"Multi Cameras",method:"GET",path:"/multiCameras/{multiCameraId}",desc:"Get multi-camera by ID",status:"miss",func:""},
+  {cat:"Devices",sub:"Multi Cameras",method:"PATCH",path:"/multiCameras/{multiCameraId}",desc:"Update a multi-camera",status:"miss",func:""},
+  {cat:"Devices",sub:"Multi Cameras",method:"DELETE",path:"/multiCameras/{multiCameraId}",desc:"Delete a multi-camera",status:"miss",func:""},
+  {cat:"Devices",sub:"Multi Cameras",method:"GET",path:"/multiCameras/{multiCameraId}/channels",desc:"Get multi-camera channels",status:"miss",func:""},
+  // DEVICES - Available Devices (1)
+  {cat:"Devices",sub:"Available Devices",method:"GET",path:"/availableDevices",desc:"List available (unclaimed) devices",status:"miss",func:""},
+  // GROUPING - Layouts (5)
+  {cat:"Grouping",sub:"Layouts",method:"GET",path:"/layouts",desc:"List layouts",status:"impl",func:"getLayouts()"},
+  {cat:"Grouping",sub:"Layouts",method:"POST",path:"/layouts",desc:"Create a layout",status:"impl",func:"createLayout()"},
+  {cat:"Grouping",sub:"Layouts",method:"GET",path:"/layouts/{layoutId}",desc:"Get layout by ID",status:"impl",func:"getLayout()"},
+  {cat:"Grouping",sub:"Layouts",method:"PATCH",path:"/layouts/{layoutId}",desc:"Update a layout",status:"impl",func:"updateLayout()"},
+  {cat:"Grouping",sub:"Layouts",method:"DELETE",path:"/layouts/{layoutId}",desc:"Delete a layout",status:"impl",func:"deleteLayout()"},
+  // GROUPING - Tags (1)
+  {cat:"Grouping",sub:"Tags",method:"GET",path:"/tags",desc:"List tags",status:"miss",func:""},
+  // GROUPING - Locations (6)
+  {cat:"Grouping",sub:"Locations",method:"GET",path:"/locations",desc:"List locations",status:"miss",func:""},
+  {cat:"Grouping",sub:"Locations",method:"POST",path:"/locations",desc:"Create a location",status:"miss",func:""},
+  {cat:"Grouping",sub:"Locations",method:"GET",path:"/locations/{id}",desc:"Get location by ID",status:"miss",func:""},
+  {cat:"Grouping",sub:"Locations",method:"PATCH",path:"/locations/{id}",desc:"Update a location",status:"miss",func:""},
+  {cat:"Grouping",sub:"Locations",method:"DELETE",path:"/locations/{id}",desc:"Delete a location",status:"miss",func:""},
+  {cat:"Grouping",sub:"Locations",method:"GET",path:"/locations/{id}/locations",desc:"Get location descendants",status:"miss",func:""},
+  // GROUPING - Floors (6)
+  {cat:"Grouping",sub:"Floors",method:"GET",path:"/locations/{locationId}/floors",desc:"List floors",status:"miss",func:""},
+  {cat:"Grouping",sub:"Floors",method:"POST",path:"/locations/{locationId}/floors",desc:"Create a floor",status:"miss",func:""},
+  {cat:"Grouping",sub:"Floors",method:"GET",path:"/locations/{locationId}/floors/{id}",desc:"Get floor by ID",status:"miss",func:""},
+  {cat:"Grouping",sub:"Floors",method:"PATCH",path:"/locations/{locationId}/floors/{id}",desc:"Update a floor",status:"miss",func:""},
+  {cat:"Grouping",sub:"Floors",method:"DELETE",path:"/locations/{locationId}/floors/{id}",desc:"Delete a floor",status:"miss",func:""},
+  {cat:"Grouping",sub:"Floors",method:"GET",path:"/locations/{locationId}/floors/{id}.{type}",desc:"Get floor image",status:"miss",func:""},
+  // GROUPING - Floor Plans (3)
+  {cat:"Grouping",sub:"Floor Plans",method:"GET",path:"/locations/{locationId}/floors/{id}/plans",desc:"List floor plans",status:"miss",func:""},
+  {cat:"Grouping",sub:"Floor Plans",method:"POST",path:"/locations/{locationId}/floors/{id}/plans",desc:"Set a floor plan",status:"miss",func:""},
+  {cat:"Grouping",sub:"Floor Plans",method:"DELETE",path:"/locations/{locationId}/floors/{id}/plans/{planId}",desc:"Delete a floor plan",status:"miss",func:""},
+  // MEDIA - Media (5)
+  {cat:"Media",sub:"Media",method:"GET",path:"/media",desc:"List media (recording spans)",status:"impl",func:"listMedia()"},
+  {cat:"Media",sub:"Media",method:"GET",path:"/media/recordedImage.jpeg",desc:"Get recorded image",status:"impl",func:"getRecordedImage()"},
+  {cat:"Media",sub:"Media",method:"GET",path:"/media/recordedImage.jpeg:listFieldValues",desc:"List overlay field values",status:"miss",func:""},
+  {cat:"Media",sub:"Media",method:"GET",path:"/media/liveImage.jpeg",desc:"Get live image",status:"impl",func:"getLiveImage()"},
+  {cat:"Media",sub:"Media",method:"GET",path:"/media/session",desc:"Get media session URL",status:"impl",func:"getMediaSession()"},
+  // MEDIA - Feeds (1)
+  {cat:"Media",sub:"Feeds",method:"GET",path:"/feeds",desc:"List feeds",status:"impl",func:"listFeeds()"},
+  // MEDIA - Exports (2)
+  {cat:"Media",sub:"Exports",method:"POST",path:"/exports",desc:"Create an export job",status:"impl",func:"createExportJob()"},
+  {cat:"Media",sub:"Exports",method:"POST",path:"/exports/{jobId}:copy",desc:"Retry/copy an export",status:"miss",func:""},
+  // MEDIA - Jobs (3)
+  {cat:"Media",sub:"Jobs",method:"GET",path:"/jobs",desc:"List jobs",status:"impl",func:"listJobs()"},
+  {cat:"Media",sub:"Jobs",method:"GET",path:"/jobs/{jobId}",desc:"Get job by ID",status:"impl",func:"getJob()"},
+  {cat:"Media",sub:"Jobs",method:"DELETE",path:"/jobs/{jobId}",desc:"Delete a job",status:"impl",func:"deleteJob()"},
+  // MEDIA - Files (11)
+  {cat:"Media",sub:"Files",method:"GET",path:"/files",desc:"List files",status:"impl",func:"listFiles()"},
+  {cat:"Media",sub:"Files",method:"POST",path:"/files",desc:"Add a file",status:"impl",func:"addFile()"},
+  {cat:"Media",sub:"Files",method:"GET",path:"/files/{id}",desc:"Get file by ID",status:"impl",func:"getFile()"},
+  {cat:"Media",sub:"Files",method:"PATCH",path:"/files/{id}",desc:"Update a file",status:"miss",func:""},
+  {cat:"Media",sub:"Files",method:"DELETE",path:"/files/{id}",desc:"Delete a file",status:"impl",func:"deleteFile()"},
+  {cat:"Media",sub:"Files",method:"GET",path:"/files/{id}:download",desc:"Download a file",status:"impl",func:"downloadFile()"},
+  {cat:"Media",sub:"Files",method:"GET",path:"/deletedFiles",desc:"List trash",status:"miss",func:""},
+  {cat:"Media",sub:"Files",method:"GET",path:"/deletedFiles/{id}",desc:"Get deleted file",status:"miss",func:""},
+  {cat:"Media",sub:"Files",method:"DELETE",path:"/deletedFiles/{id}",desc:"Permanently delete trash file",status:"miss",func:""},
+  {cat:"Media",sub:"Files",method:"DELETE",path:"/deletedFiles/all",desc:"Empty trash",status:"miss",func:""},
+  {cat:"Media",sub:"Files",method:"POST",path:"/deletedFiles/{id}:restore",desc:"Restore deleted file",status:"miss",func:""},
+  // MEDIA - Downloads (4)
+  {cat:"Media",sub:"Downloads",method:"GET",path:"/downloads",desc:"List downloads",status:"impl",func:"listDownloads()"},
+  {cat:"Media",sub:"Downloads",method:"GET",path:"/downloads/{id}",desc:"Get download by ID",status:"impl",func:"getDownload()"},
+  {cat:"Media",sub:"Downloads",method:"PATCH",path:"/downloads/{id}",desc:"Update a download",status:"miss",func:""},
+  {cat:"Media",sub:"Downloads",method:"GET",path:"/downloads/{id}:download",desc:"Download a download file",status:"impl",func:"downloadDownload()"},
+  // EVENTS - Events (5)
+  {cat:"Events",sub:"Events",method:"GET",path:"/events",desc:"List events",status:"impl",func:"listEvents()"},
+  {cat:"Events",sub:"Events",method:"POST",path:"/events",desc:"Create an event",status:"miss",func:""},
+  {cat:"Events",sub:"Events",method:"GET",path:"/events/{id}",desc:"Get event by ID",status:"impl",func:"getEvent()"},
+  {cat:"Events",sub:"Events",method:"GET",path:"/events:listRecentByType",desc:"List recent events by type",status:"miss",func:""},
+  {cat:"Events",sub:"Events",method:"GET",path:"/events:listFieldValues",desc:"List event field values",status:"impl",func:"listEventFieldValues()"},
+  // EVENTS - Event Types (1)
+  {cat:"Events",sub:"Event Types",method:"GET",path:"/eventTypes",desc:"List event types",status:"impl",func:"listEventTypes()"},
+  // EVENTS - Event Metrics (1)
+  {cat:"Events",sub:"Event Metrics",method:"GET",path:"/eventMetrics",desc:"Get event metrics",status:"impl",func:"getEventMetrics()"},
+  // EVENTS - Event Subscriptions (8)
+  {cat:"Events",sub:"Event Subscriptions",method:"GET",path:"/eventSubscriptions",desc:"List event subscriptions",status:"impl",func:"listEventSubscriptions()"},
+  {cat:"Events",sub:"Event Subscriptions",method:"POST",path:"/eventSubscriptions",desc:"Create event subscription",status:"impl",func:"createEventSubscription()"},
+  {cat:"Events",sub:"Event Subscriptions",method:"GET",path:"/eventSubscriptions/{id}",desc:"Get event subscription",status:"impl",func:"getEventSubscription()"},
+  {cat:"Events",sub:"Event Subscriptions",method:"DELETE",path:"/eventSubscriptions/{id}",desc:"Delete event subscription",status:"impl",func:"deleteEventSubscription()"},
+  {cat:"Events",sub:"Event Subscriptions",method:"GET",path:"/eventSubscriptions/{id}/filters",desc:"List subscription filters",status:"miss",func:""},
+  {cat:"Events",sub:"Event Subscriptions",method:"POST",path:"/eventSubscriptions/{id}/filters",desc:"Create subscription filter",status:"miss",func:""},
+  {cat:"Events",sub:"Event Subscriptions",method:"GET",path:"/eventSubscriptions/{id}/filters/{filterId}",desc:"Get subscription filter",status:"miss",func:""},
+  {cat:"Events",sub:"Event Subscriptions",method:"DELETE",path:"/eventSubscriptions/{id}/filters/{filterId}",desc:"Delete subscription filter",status:"miss",func:""},
+  // EVENTS - Alerts (3)
+  {cat:"Events",sub:"Alerts",method:"GET",path:"/alerts",desc:"List alerts",status:"impl",func:"listAlerts()"},
+  {cat:"Events",sub:"Alerts",method:"GET",path:"/alerts/{id}",desc:"Get alert by ID",status:"impl",func:"getAlert()"},
+  {cat:"Events",sub:"Alerts",method:"GET",path:"/alertTypes",desc:"List alert types",status:"impl",func:"listAlertTypes()"},
+  // EVENTS - Notifications (3)
+  {cat:"Events",sub:"Notifications",method:"GET",path:"/notifications",desc:"List notifications",status:"impl",func:"listNotifications()"},
+  {cat:"Events",sub:"Notifications",method:"GET",path:"/notifications/{id}",desc:"Get notification by ID",status:"impl",func:"getNotification()"},
+  {cat:"Events",sub:"Notifications",method:"PATCH",path:"/notifications/{id}",desc:"Update a notification",status:"miss",func:""},
+  // AUTOMATIONS - Event Alert Condition Rules (6)
+  {cat:"Automations",sub:"Event Alert Condition Rules",method:"GET",path:"/eventAlertConditionRules",desc:"List rules",status:"impl",func:"listEventAlertConditionRules()"},
+  {cat:"Automations",sub:"Event Alert Condition Rules",method:"POST",path:"/eventAlertConditionRules",desc:"Create rule",status:"miss",func:""},
+  {cat:"Automations",sub:"Event Alert Condition Rules",method:"GET",path:"/eventAlertConditionRules:listFieldValues",desc:"List field values",status:"impl",func:"getEventAlertConditionRuleFieldValues()"},
+  {cat:"Automations",sub:"Event Alert Condition Rules",method:"GET",path:"/eventAlertConditionRules/{id}",desc:"Get rule by ID",status:"impl",func:"getEventAlertConditionRule()"},
+  {cat:"Automations",sub:"Event Alert Condition Rules",method:"PATCH",path:"/eventAlertConditionRules/{id}",desc:"Update rule",status:"miss",func:""},
+  {cat:"Automations",sub:"Event Alert Condition Rules",method:"DELETE",path:"/eventAlertConditionRules/{id}",desc:"Delete rule",status:"miss",func:""},
+  // AUTOMATIONS - Alert Action Rules (5)
+  {cat:"Automations",sub:"Alert Action Rules",method:"GET",path:"/alertActionRules",desc:"List alert action rules",status:"impl",func:"listAlertActionRules()"},
+  {cat:"Automations",sub:"Alert Action Rules",method:"POST",path:"/alertActionRules",desc:"Create alert action rule",status:"miss",func:""},
+  {cat:"Automations",sub:"Alert Action Rules",method:"GET",path:"/alertActionRules/{actionRuleId}",desc:"Get alert action rule",status:"impl",func:"getAlertActionRule()"},
+  {cat:"Automations",sub:"Alert Action Rules",method:"PATCH",path:"/alertActionRules/{actionRuleId}",desc:"Update alert action rule",status:"miss",func:""},
+  {cat:"Automations",sub:"Alert Action Rules",method:"DELETE",path:"/alertActionRules/{actionRuleId}",desc:"Delete alert action rule",status:"miss",func:""},
+  // AUTOMATIONS - Alert Actions (5)
+  {cat:"Automations",sub:"Alert Actions",method:"GET",path:"/alertActions",desc:"List alert actions",status:"impl",func:"listAlertActions()"},
+  {cat:"Automations",sub:"Alert Actions",method:"POST",path:"/alertActions",desc:"Create alert action",status:"miss",func:""},
+  {cat:"Automations",sub:"Alert Actions",method:"GET",path:"/alertActions/{actionId}",desc:"Get alert action",status:"impl",func:"getAlertAction()"},
+  {cat:"Automations",sub:"Alert Actions",method:"PATCH",path:"/alertActions/{actionId}",desc:"Update alert action",status:"miss",func:""},
+  {cat:"Automations",sub:"Alert Actions",method:"DELETE",path:"/alertActions/{actionId}",desc:"Delete alert action",status:"miss",func:""},
+  // VIDEO SEARCH (7)
+  {cat:"Video Search",sub:"Video Analytic Events",method:"POST",path:"/videoAnalyticEvents:parse",desc:"Parse video analytics query",status:"miss",func:""},
+  {cat:"Video Search",sub:"Video Analytic Events",method:"POST",path:"/videoAnalyticEvents:deepSearch",desc:"Deep search events",status:"miss",func:""},
+  {cat:"Video Search",sub:"Video Analytic Events",method:"POST",path:"/videoAnalyticEvents:deepSearchGroupByResource",desc:"Deep search by resource",status:"miss",func:""},
+  {cat:"Video Search",sub:"Video Analytic Events",method:"POST",path:"/videoAnalyticEvents:deepSearchGroupByTime",desc:"Deep search by time",status:"miss",func:""},
+  {cat:"Video Search",sub:"Video Analytic Events",method:"POST",path:"/videoAnalyticEvents:listFieldValues",desc:"List field values",status:"miss",func:""},
+  {cat:"Video Search",sub:"Video Analytic Events",method:"GET",path:"/videoAnalyticEvents:listObjectValues",desc:"List object values",status:"miss",func:""},
+  {cat:"Video Search",sub:"Video Analytic Events",method:"GET",path:"/videoAnalyticEvents/{id}",desc:"Get event by ID",status:"miss",func:""},
+  // VEHICLE SURVEILLANCE - LPR Events (4)
+  {cat:"Vehicle Surveillance",sub:"LPR Events",method:"GET",path:"/lprEvents",desc:"List LPR events",status:"miss",func:""},
+  {cat:"Vehicle Surveillance",sub:"LPR Events",method:"GET",path:"/lprEvents/{id}",desc:"Get LPR event by ID",status:"miss",func:""},
+  {cat:"Vehicle Surveillance",sub:"LPR Events",method:"GET",path:"/lprEvents:summary",desc:"Get LPR events summary",status:"miss",func:""},
+  {cat:"Vehicle Surveillance",sub:"LPR Events",method:"GET",path:"/lprEvents:listFieldValues",desc:"List LPR field values",status:"miss",func:""},
+  // VEHICLE SURVEILLANCE - LPR Alert Condition Rules (6)
+  {cat:"Vehicle Surveillance",sub:"LPR Alert Condition Rules",method:"GET",path:"/lprAlertConditionRules",desc:"List LPR rules",status:"miss",func:""},
+  {cat:"Vehicle Surveillance",sub:"LPR Alert Condition Rules",method:"POST",path:"/lprAlertConditionRules",desc:"Create LPR rule",status:"miss",func:""},
+  {cat:"Vehicle Surveillance",sub:"LPR Alert Condition Rules",method:"GET",path:"/lprAlertConditionRules:listFieldValues",desc:"List LPR rule field values",status:"miss",func:""},
+  {cat:"Vehicle Surveillance",sub:"LPR Alert Condition Rules",method:"GET",path:"/lprAlertConditionRules/{id}",desc:"Get LPR rule",status:"miss",func:""},
+  {cat:"Vehicle Surveillance",sub:"LPR Alert Condition Rules",method:"PATCH",path:"/lprAlertConditionRules/{id}",desc:"Update LPR rule",status:"miss",func:""},
+  {cat:"Vehicle Surveillance",sub:"LPR Alert Condition Rules",method:"DELETE",path:"/lprAlertConditionRules/{id}",desc:"Delete LPR rule",status:"miss",func:""},
+  // VEHICLE SURVEILLANCE - LPR Vehicle Lists (14)
+  {cat:"Vehicle Surveillance",sub:"LPR Vehicle Lists",method:"GET",path:"/lprVehicleLists",desc:"List vehicle lists",status:"miss",func:""},
+  {cat:"Vehicle Surveillance",sub:"LPR Vehicle Lists",method:"POST",path:"/lprVehicleLists",desc:"Create vehicle list",status:"miss",func:""},
+  {cat:"Vehicle Surveillance",sub:"LPR Vehicle Lists",method:"GET",path:"/lprVehicleLists:listFields",desc:"List fields",status:"miss",func:""},
+  {cat:"Vehicle Surveillance",sub:"LPR Vehicle Lists",method:"GET",path:"/lprVehicleLists:listFieldValues",desc:"List field values",status:"miss",func:""},
+  {cat:"Vehicle Surveillance",sub:"LPR Vehicle Lists",method:"GET",path:"/lprVehicleLists/{id}",desc:"Get vehicle list",status:"miss",func:""},
+  {cat:"Vehicle Surveillance",sub:"LPR Vehicle Lists",method:"PATCH",path:"/lprVehicleLists/{id}",desc:"Update vehicle list",status:"miss",func:""},
+  {cat:"Vehicle Surveillance",sub:"LPR Vehicle Lists",method:"DELETE",path:"/lprVehicleLists/{id}",desc:"Delete vehicle list",status:"miss",func:""},
+  {cat:"Vehicle Surveillance",sub:"LPR Vehicle Lists",method:"GET",path:"/lprVehicleLists/{id}/vehicles",desc:"List vehicles",status:"miss",func:""},
+  {cat:"Vehicle Surveillance",sub:"LPR Vehicle Lists",method:"POST",path:"/lprVehicleLists/{id}/vehicles",desc:"Add vehicle",status:"miss",func:""},
+  {cat:"Vehicle Surveillance",sub:"LPR Vehicle Lists",method:"POST",path:"/lprVehicleLists/{id}/vehicles:bulkCreate",desc:"Bulk add vehicles",status:"miss",func:""},
+  {cat:"Vehicle Surveillance",sub:"LPR Vehicle Lists",method:"GET",path:"/lprVehicleLists/{id}/vehicles/{recordId}",desc:"Get vehicle",status:"miss",func:""},
+  {cat:"Vehicle Surveillance",sub:"LPR Vehicle Lists",method:"PATCH",path:"/lprVehicleLists/{id}/vehicles/{recordId}",desc:"Update vehicle",status:"miss",func:""},
+  {cat:"Vehicle Surveillance",sub:"LPR Vehicle Lists",method:"DELETE",path:"/lprVehicleLists/{id}/vehicles/{recordId}",desc:"Delete vehicle",status:"miss",func:""},
+  {cat:"Vehicle Surveillance",sub:"LPR Vehicle Lists",method:"GET",path:"/lprVehicleLists:search",desc:"Search vehicle lists",status:"miss",func:""},
+  // USER & ACCOUNTS - Users (9)
+  {cat:"User & Accounts",sub:"Users",method:"GET",path:"/users",desc:"List users",status:"impl",func:"getUsers()"},
+  {cat:"User & Accounts",sub:"Users",method:"POST",path:"/users",desc:"Create a user",status:"miss",func:""},
+  {cat:"User & Accounts",sub:"Users",method:"GET",path:"/users/{userId}",desc:"Get user by ID",status:"impl",func:"getUser()"},
+  {cat:"User & Accounts",sub:"Users",method:"PATCH",path:"/users/{userId}",desc:"Update a user",status:"miss",func:""},
+  {cat:"User & Accounts",sub:"Users",method:"DELETE",path:"/users/{userId}",desc:"Delete a user",status:"miss",func:""},
+  {cat:"User & Accounts",sub:"Users",method:"GET",path:"/users/self",desc:"Get current user",status:"impl",func:"getCurrentUser()"},
+  {cat:"User & Accounts",sub:"Users",method:"PATCH",path:"/users/self",desc:"Update current user",status:"miss",func:""},
+  {cat:"User & Accounts",sub:"Users",method:"GET",path:"/users/self/trustedClients",desc:"List trusted OAuth clients",status:"miss",func:""},
+  {cat:"User & Accounts",sub:"Users",method:"DELETE",path:"/users/self/trustedClients/{trustedClientId}",desc:"Delete trusted client",status:"miss",func:""},
+  // USER & ACCOUNTS - Accounts (2)
+  {cat:"User & Accounts",sub:"Accounts",method:"GET",path:"/accounts",desc:"List accounts",status:"miss",func:""},
+  {cat:"User & Accounts",sub:"Accounts",method:"DELETE",path:"/accounts/{id}/credentials/{credentialId}",desc:"Delete account credential",status:"miss",func:""},
+  // USER & ACCOUNTS - Roles (8)
+  {cat:"User & Accounts",sub:"Roles",method:"GET",path:"/roles",desc:"List roles",status:"miss",func:""},
+  {cat:"User & Accounts",sub:"Roles",method:"POST",path:"/roles",desc:"Create a role",status:"miss",func:""},
+  {cat:"User & Accounts",sub:"Roles",method:"GET",path:"/roles/{roleId}",desc:"Get role by ID",status:"miss",func:""},
+  {cat:"User & Accounts",sub:"Roles",method:"PATCH",path:"/roles/{roleId}",desc:"Update a role",status:"miss",func:""},
+  {cat:"User & Accounts",sub:"Roles",method:"DELETE",path:"/roles/{roleId}",desc:"Delete a role",status:"miss",func:""},
+  {cat:"User & Accounts",sub:"Roles",method:"GET",path:"/roleAssignments",desc:"List role assignments",status:"miss",func:""},
+  {cat:"User & Accounts",sub:"Roles",method:"POST",path:"/roleAssignments:bulkcreate",desc:"Bulk create role assignments",status:"miss",func:""},
+  {cat:"User & Accounts",sub:"Roles",method:"POST",path:"/roleAssignments:bulkdelete",desc:"Bulk delete role assignments",status:"miss",func:""},
+  // USER & ACCOUNTS - Audit Log (1)
+  {cat:"User & Accounts",sub:"Audit Log",method:"GET",path:"/auditLogs",desc:"List audit logs",status:"miss",func:""},
+  // USER & ACCOUNTS - Resource Grants (3)
+  {cat:"User & Accounts",sub:"Resource Grants",method:"GET",path:"/resourceGrants",desc:"List resource grants",status:"miss",func:""},
+  {cat:"User & Accounts",sub:"Resource Grants",method:"POST",path:"/resourceGrants:bulkCreate",desc:"Bulk create grants",status:"miss",func:""},
+  {cat:"User & Accounts",sub:"Resource Grants",method:"POST",path:"/resourceGrants:bulkDelete",desc:"Bulk delete grants",status:"miss",func:""},
+  // USER & ACCOUNTS - Editions (2)
+  {cat:"User & Accounts",sub:"Editions",method:"GET",path:"/editions",desc:"List editions",status:"miss",func:""},
+  {cat:"User & Accounts",sub:"Editions",method:"GET",path:"/editions/{id}",desc:"Get edition by ID",status:"miss",func:""},
+  // RESELLERS (1)
+  {cat:"Resellers",sub:"Authorization Tokens",method:"POST",path:"/authorizationTokens",desc:"Create authorization token",status:"miss",func:""},
+  // ACCOUNT SETTINGS (3)
+  {cat:"Account Settings",sub:"SSO",method:"GET",path:"/accounts/self/ssoAuthSettings",desc:"Get SSO auth settings",status:"miss",func:""},
+  {cat:"Account Settings",sub:"SSO",method:"PATCH",path:"/accounts/self/ssoAuthSettings",desc:"Update SSO auth settings",status:"miss",func:""},
+  {cat:"Account Settings",sub:"Client Settings",method:"GET",path:"/clientSettings",desc:"Get client settings",status:"miss",func:""},
+  // SYSTEM - Applications (5)
+  {cat:"System",sub:"Applications",method:"GET",path:"/applications",desc:"List applications",status:"miss",func:""},
+  {cat:"System",sub:"Applications",method:"POST",path:"/applications",desc:"Create application",status:"miss",func:""},
+  {cat:"System",sub:"Applications",method:"GET",path:"/applications/{applicationId}",desc:"Get application",status:"miss",func:""},
+  {cat:"System",sub:"Applications",method:"PATCH",path:"/applications/{applicationId}",desc:"Update application",status:"miss",func:""},
+  {cat:"System",sub:"Applications",method:"DELETE",path:"/applications/{applicationId}",desc:"Delete application",status:"miss",func:""},
+  // SYSTEM - OAuth Clients (5)
+  {cat:"System",sub:"OAuth Clients",method:"GET",path:"/applications/{appId}/oauthClients",desc:"List OAuth clients",status:"miss",func:""},
+  {cat:"System",sub:"OAuth Clients",method:"POST",path:"/applications/{appId}/oauthClients",desc:"Create OAuth client",status:"miss",func:""},
+  {cat:"System",sub:"OAuth Clients",method:"GET",path:"/applications/{appId}/oauthClients/{clientId}",desc:"Get OAuth client",status:"miss",func:""},
+  {cat:"System",sub:"OAuth Clients",method:"PATCH",path:"/applications/{appId}/oauthClients/{clientId}",desc:"Update OAuth client",status:"miss",func:""},
+  {cat:"System",sub:"OAuth Clients",method:"DELETE",path:"/applications/{appId}/oauthClients/{clientId}",desc:"Delete OAuth client",status:"miss",func:""},
+  // SYSTEM - Reference Data (2)
+  {cat:"System",sub:"Reference Data",method:"GET",path:"/languages",desc:"List supported languages",status:"miss",func:""},
+  {cat:"System",sub:"Reference Data",method:"GET",path:"/timeZones",desc:"List supported time zones",status:"miss",func:""},
+];
+
+function renderTable(data) {
+  const tbody = document.getElementById('tableBody');
+  tbody.innerHTML = '';
+  data.forEach((e, i) => {
+    const tr = document.createElement('tr');
+    tr.dataset.status = e.status;
+    tr.dataset.category = e.cat;
+    tr.dataset.method = e.method;
+    tr.innerHTML = `
+      <td>${i + 1}</td>
+      <td class="category">${e.cat}</td>
+      <td class="category">${e.sub}</td>
+      <td><span class="method method-${e.method}">${e.method}</span></td>
+      <td><code>${e.path}</code></td>
+      <td>${e.desc}</td>
+      <td><span class="badge ${e.status === 'impl' ? 'badge-impl' : 'badge-miss'}">${e.status === 'impl' ? 'Implemented' : 'Missing'}</span></td>
+      <td class="func">${e.func}</td>
+    `;
+    tbody.appendChild(tr);
+  });
+}
+
+function filterTable() {
+  const status = document.getElementById('statusFilter').value;
+  const category = document.getElementById('categoryFilter').value;
+  const method = document.getElementById('methodFilter').value;
+  const search = document.getElementById('searchFilter').value.toLowerCase();
+
+  const filtered = endpoints.filter(e => {
+    if (status !== 'all' && ((status === 'implemented' && e.status !== 'impl') || (status === 'missing' && e.status !== 'miss'))) return false;
+    if (category !== 'all' && e.cat !== category) return false;
+    if (method !== 'all' && e.method !== method) return false;
+    if (search && !e.path.toLowerCase().includes(search) && !e.func.toLowerCase().includes(search) && !e.desc.toLowerCase().includes(search)) return false;
+    return true;
+  });
+
+  renderTable(filtered);
+}
+
+let sortDir = {};
+function sortTable(col) {
+  const keys = ['idx','cat','sub','method','path','desc','status','func'];
+  const key = keys[col];
+  sortDir[key] = !(sortDir[key] || false);
+  const dir = sortDir[key] ? 1 : -1;
+
+  endpoints.sort((a, b) => {
+    let va = key === 'idx' ? endpoints.indexOf(a) : a[key];
+    let vb = key === 'idx' ? endpoints.indexOf(b) : b[key];
+    return va < vb ? -dir : va > vb ? dir : 0;
+  });
+
+  filterTable();
+}
+
+renderTable(endpoints);
+</script>
+
+</body>
+</html>

--- a/docs/een-api-implemented.md
+++ b/docs/een-api-implemented.md
@@ -1,0 +1,218 @@
+# een-api-toolkit - Implemented EEN API Endpoints
+
+> Generated: 2026-02-17
+> Toolkit version: see `package.json`
+
+This document lists all EEN API v3.0 endpoints implemented by the `een-api-toolkit` library.
+
+---
+
+## Authentication (via OAuth Proxy)
+
+These functions communicate with the OAuth proxy server, not the EEN API directly.
+
+| Function | Proxy Endpoint | Source |
+|----------|---------------|--------|
+| `getAccessToken(code)` | POST `/proxy/getAccessToken` | `src/auth/service.ts` |
+| `refreshToken()` | POST `/proxy/refreshAccessToken` | `src/auth/service.ts` |
+| `revokeToken()` | POST `/proxy/revokeAccessToken` | `src/auth/service.ts` |
+| `handleAuthCallback(code, state)` | (uses getAccessToken) | `src/auth/service.ts` |
+
+## Users (3 endpoints)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/users/self` | `getCurrentUser()` | `src/users/service.ts` |
+| GET | `/api/v3.0/users` | `getUsers(params?)` | `src/users/service.ts` |
+| GET | `/api/v3.0/users/{userId}` | `getUser(userId, params?)` | `src/users/service.ts` |
+
+## Cameras (3 endpoints)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/cameras` | `getCameras(params?)` | `src/cameras/service.ts` |
+| GET | `/api/v3.0/cameras/{cameraId}` | `getCamera(cameraId, params?)` | `src/cameras/service.ts` |
+| GET | `/api/v3.0/cameras/{cameraId}/settings` | `getCameraSettings(cameraId, params?)` | `src/cameras/service.ts` |
+
+## Bridges (2 endpoints)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/bridges` | `getBridges(params?)` | `src/bridges/service.ts` |
+| GET | `/api/v3.0/bridges/{bridgeId}` | `getBridge(bridgeId, params?)` | `src/bridges/service.ts` |
+
+## Layouts (5 endpoints)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/layouts` | `getLayouts(params?)` | `src/layouts/service.ts` |
+| GET | `/api/v3.0/layouts/{layoutId}` | `getLayout(layoutId, params?)` | `src/layouts/service.ts` |
+| POST | `/api/v3.0/layouts` | `createLayout(params)` | `src/layouts/service.ts` |
+| PATCH | `/api/v3.0/layouts/{layoutId}` | `updateLayout(layoutId, params)` | `src/layouts/service.ts` |
+| DELETE | `/api/v3.0/layouts/{layoutId}` | `deleteLayout(layoutId)` | `src/layouts/service.ts` |
+
+## Media (4 endpoints)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/media` | `listMedia(params)` | `src/media/service.ts` |
+| GET | `/api/v3.0/media/liveImage.jpeg` | `getLiveImage(params)` | `src/media/service.ts` |
+| GET | `/api/v3.0/media/recordedImage.jpeg` | `getRecordedImage(params)` | `src/media/service.ts` |
+| GET | `/api/v3.0/media/session` | `getMediaSession()` | `src/media/service.ts` |
+
+Note: `initMediaSession()` is a higher-level wrapper around `getMediaSession()`.
+
+## Feeds (1 endpoint)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/feeds` | `listFeeds(params?)` | `src/feeds/service.ts` |
+
+## Events (3 endpoints)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/events` | `listEvents(params)` | `src/events/service.ts` |
+| GET | `/api/v3.0/events/{eventId}` | `getEvent(eventId, params?)` | `src/events/service.ts` |
+| GET | `/api/v3.0/events:listFieldValues` | `listEventFieldValues(params)` | `src/events/service.ts` |
+
+## Event Types (1 endpoint)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/eventTypes` | `listEventTypes(params?)` | `src/events/service.ts` |
+
+## Event Metrics (1 endpoint)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/eventMetrics` | `getEventMetrics(params)` | `src/eventMetrics/service.ts` |
+
+## Alerts (3 endpoints)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/alerts` | `listAlerts(params?)` | `src/alerts/service.ts` |
+| GET | `/api/v3.0/alerts/{alertId}` | `getAlert(alertId, params?)` | `src/alerts/service.ts` |
+| GET | `/api/v3.0/alertTypes` | `listAlertTypes(params?)` | `src/alerts/service.ts` |
+
+## Notifications (2 endpoints)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/notifications` | `listNotifications(params?)` | `src/notifications/service.ts` |
+| GET | `/api/v3.0/notifications/{notificationId}` | `getNotification(notificationId)` | `src/notifications/service.ts` |
+
+## Event Subscriptions (4 endpoints + SSE)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/eventSubscriptions` | `listEventSubscriptions(params?)` | `src/eventSubscriptions/service.ts` |
+| GET | `/api/v3.0/eventSubscriptions/{id}` | `getEventSubscription(id)` | `src/eventSubscriptions/service.ts` |
+| POST | `/api/v3.0/eventSubscriptions` | `createEventSubscription(params)` | `src/eventSubscriptions/service.ts` |
+| DELETE | `/api/v3.0/eventSubscriptions/{id}` | `deleteEventSubscription(id)` | `src/eventSubscriptions/service.ts` |
+| SSE | (SSE URL from subscription) | `connectToEventSubscription(url, options)` | `src/eventSubscriptions/service.ts` |
+
+## Automations - Event Alert Condition Rules (3 endpoints)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/eventAlertConditionRules` | `listEventAlertConditionRules(params?)` | `src/automations/service.ts` |
+| GET | `/api/v3.0/eventAlertConditionRules:listFieldValues` | `getEventAlertConditionRuleFieldValues(params?)` | `src/automations/service.ts` |
+| GET | `/api/v3.0/eventAlertConditionRules/{ruleId}` | `getEventAlertConditionRule(ruleId)` | `src/automations/service.ts` |
+
+## Automations - Alert Condition Rules (2 endpoints)
+
+> Note: These endpoints (`/alertConditionRules`) are not listed in the official EEN OpenAPI specifications or developer portal. They may be internal or deprecated endpoints.
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/alertConditionRules` | `listAlertConditionRules(params?)` | `src/automations/service.ts` |
+| GET | `/api/v3.0/alertConditionRules/{ruleId}` | `getAlertConditionRule(ruleId, params?)` | `src/automations/service.ts` |
+
+## Automations - Alert Action Rules (2 endpoints)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/alertActionRules` | `listAlertActionRules(params?)` | `src/automations/service.ts` |
+| GET | `/api/v3.0/alertActionRules/{ruleId}` | `getAlertActionRule(ruleId)` | `src/automations/service.ts` |
+
+## Automations - Alert Actions (2 endpoints)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/alertActions` | `listAlertActions(params?)` | `src/automations/service.ts` |
+| GET | `/api/v3.0/alertActions/{actionId}` | `getAlertAction(actionId)` | `src/automations/service.ts` |
+
+## Exports (1 endpoint)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| POST | `/api/v3.0/exports` | `createExportJob(params)` | `src/exports/service.ts` |
+
+## Jobs (3 endpoints)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/jobs` | `listJobs(params?)` | `src/jobs/service.ts` |
+| GET | `/api/v3.0/jobs/{jobId}` | `getJob(jobId, params?)` | `src/jobs/service.ts` |
+| DELETE | `/api/v3.0/jobs/{jobId}` | `deleteJob(jobId)` | `src/jobs/service.ts` |
+
+## Files (5 endpoints)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/files` | `listFiles(params?)` | `src/files/service.ts` |
+| GET | `/api/v3.0/files/{fileId}` | `getFile(fileId, params?)` | `src/files/service.ts` |
+| POST | `/api/v3.0/files` | `addFile(params)` | `src/files/service.ts` |
+| GET | `/api/v3.0/files/{fileId}:download` | `downloadFile(fileId)` | `src/files/service.ts` |
+| DELETE | `/api/v3.0/files/{fileId}` | `deleteFile(fileId)` | `src/files/service.ts` |
+
+## Downloads (3 endpoints)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/downloads` | `listDownloads(params?)` | `src/downloads/service.ts` |
+| GET | `/api/v3.0/downloads/{downloadId}` | `getDownload(downloadId, params?)` | `src/downloads/service.ts` |
+| GET | `/api/v3.0/downloads/{downloadId}:download` | `downloadDownload(downloadId)` | `src/downloads/service.ts` |
+
+---
+
+## Summary
+
+| Category | Implemented Endpoints |
+|----------|----------------------|
+| Users | 3 |
+| Cameras | 3 |
+| Bridges | 2 |
+| Layouts | 5 |
+| Media | 4 |
+| Feeds | 1 |
+| Events | 3 |
+| Event Types | 1 |
+| Event Metrics | 1 |
+| Alerts | 3 |
+| Notifications | 2 |
+| Event Subscriptions | 4 (+SSE) |
+| Event Alert Condition Rules | 3 |
+| Alert Condition Rules | 2 (undocumented) |
+| Alert Action Rules | 2 |
+| Alert Actions | 2 |
+| Exports | 1 |
+| Jobs | 3 |
+| Files | 5 |
+| Downloads | 3 |
+| **Total (official EEN API)** | **51** |
+| Auth (proxy, not EEN API) | 4 |
+| SSE connection | 1 |
+| Alert Condition Rules (undocumented) | 2 |
+
+### By HTTP Method
+
+| Method | Count |
+|--------|-------|
+| GET | 42 |
+| POST | 4 |
+| PATCH | 1 |
+| DELETE | 4 |
+| **Total** | **51** |

--- a/docs/een-api-missing.md
+++ b/docs/een-api-missing.md
@@ -1,0 +1,462 @@
+# een-api-toolkit - Missing EEN API Endpoints
+
+> Generated: 2026-02-17
+> Coverage: 51 of 211 endpoints implemented (24.2%)
+
+This document lists EEN API v3.0 endpoints that are **not yet implemented** by the `een-api-toolkit` library.
+
+---
+
+## DEVICES - Cameras (12 of 15 missing)
+
+Implemented: GET list, GET by ID, GET settings
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/cameras` | Add a camera |
+| POST | `/cameras:bulkUpdate` | Bulk update cameras |
+| PATCH | `/cameras/{cameraId}` | Update a camera |
+| DELETE | `/cameras/{cameraId}` | Delete a camera |
+| PUT | `/cameras/{cameraId}/tunnel` | Create/update camera tunnel |
+| DELETE | `/cameras/{cameraId}/tunnel` | Delete camera tunnel |
+| GET | `/cameras/{cameraId}/metrics` | Get camera metrics |
+| PATCH | `/cameras/{cameraId}:swap` | Swap a camera |
+| GET | `/cameras/{cameraId}/io/ports` | List camera I/O ports |
+| GET | `/cameras/{cameraId}/io/ports/{portId}` | Get camera I/O port |
+| PATCH | `/cameras/{cameraId}/io/ports/{portId}` | Update camera I/O port |
+| PATCH | `/cameras/{cameraId}/settings` | Update camera settings |
+
+## DEVICES - Bridges (9 of 11 missing)
+
+Implemented: GET list, GET by ID
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/bridges` | Create a bridge |
+| POST | `/bridges:bulkUpdate` | Bulk update bridges |
+| PATCH | `/bridges/{bridgeId}` | Update a bridge |
+| DELETE | `/bridges/{bridgeId}` | Delete a bridge |
+| GET | `/bridges/{bridgeId}/metrics` | Get bridge metrics |
+| PATCH | `/bridges/{bridgeId}:swap` | Swap a bridge |
+| POST | `/bridges/{bridgeId}/actions` | Trigger bridge action |
+| GET | `/bridges/{id}/settings` | Get bridge settings |
+| PATCH | `/bridges/{id}/settings` | Update bridge settings |
+
+## DEVICES - PTZ (4 of 4 missing - entire section)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/cameras/{cameraId}/ptz/position` | Get current PTZ position |
+| PUT | `/cameras/{cameraId}/ptz/position` | Move PTZ to position |
+| GET | `/cameras/{cameraId}/ptz/settings` | Get PTZ settings |
+| PATCH | `/cameras/{cameraId}/ptz/settings` | Update PTZ settings |
+
+## DEVICES - Speakers (7 of 7 missing - entire section)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/speakers` | List speakers |
+| POST | `/speakers` | Add a speaker |
+| GET | `/speakers/{speakerId}` | Get speaker by ID |
+| PATCH | `/speakers/{speakerId}` | Update a speaker |
+| DELETE | `/speakers/{speakerId}` | Delete a speaker |
+| GET | `/speakers/{speakerId}/settings` | Get speaker settings |
+| PATCH | `/speakers/{speakerId}/settings` | Update speaker settings |
+
+## DEVICES - Device I/O (6 of 6 missing - entire section)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/devices/{deviceId}/io/ports` | List device I/O ports |
+| GET | `/devices/{deviceId}/io/ports/{portId}` | Get device I/O port |
+| PATCH | `/devices/{deviceId}/io/ports/{portId}` | Update device I/O port |
+| GET | `/devices/{deviceId}/io/ports/{portId}/recordingActions` | List port recording actions |
+| GET | `/devices/{deviceId}/io/ports/{portId}/recordingActions/{cameraId}` | Get port recording action |
+| PATCH | `/devices/{deviceId}/io/ports/{portId}/recordingActions/{cameraId}` | Update port recording action |
+
+## DEVICES - Switches (5 of 5 missing - entire section)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/switches` | List switches |
+| GET | `/switches/{switchId}` | Get switch by ID |
+| PATCH | `/switches/{switchId}` | Update a switch |
+| POST | `/switches/{switchId}/ports/{portId}/actions` | Trigger switch port action |
+| POST | `/switches/{switchId}/ports/all/actions` | Trigger action on all switch ports |
+
+## DEVICES - Multi Cameras (6 of 6 missing - entire section)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/multiCameras` | List multi-cameras |
+| POST | `/multiCameras` | Add a multi-camera |
+| GET | `/multiCameras/{multiCameraId}` | Get multi-camera by ID |
+| PATCH | `/multiCameras/{multiCameraId}` | Update a multi-camera |
+| DELETE | `/multiCameras/{multiCameraId}` | Delete a multi-camera |
+| GET | `/multiCameras/{multiCameraId}/channels` | Get multi-camera channels |
+
+## DEVICES - Available Devices (1 of 1 missing)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/availableDevices` | List available (unclaimed) devices |
+
+## GROUPING - Tags (1 of 1 missing)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/tags` | List tags |
+
+## GROUPING - Locations (6 of 6 missing - entire section)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/locations` | List locations |
+| POST | `/locations` | Create a location |
+| GET | `/locations/{id}` | Get location by ID |
+| PATCH | `/locations/{id}` | Update a location |
+| DELETE | `/locations/{id}` | Delete a location |
+| GET | `/locations/{id}/locations` | Get location descendants |
+
+## GROUPING - Floors (6 of 6 missing - entire section)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/locations/{locationId}/floors` | List floors for a location |
+| POST | `/locations/{locationId}/floors` | Create a floor |
+| GET | `/locations/{locationId}/floors/{id}` | Get floor by ID |
+| PATCH | `/locations/{locationId}/floors/{id}` | Update a floor |
+| DELETE | `/locations/{locationId}/floors/{id}` | Delete a floor |
+| GET | `/locations/{locationId}/floors/{id}.{type}` | Get floor image |
+
+## GROUPING - Floor Plans (3 of 3 missing - entire section)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/locations/{locationId}/floors/{id}/plans` | List floor plans |
+| POST | `/locations/{locationId}/floors/{id}/plans` | Set a floor plan |
+| DELETE | `/locations/{locationId}/floors/{id}/plans/{planId}` | Delete a floor plan |
+
+## MEDIA - Media (1 of 5 missing)
+
+Implemented: GET list, GET liveImage, GET recordedImage, GET session
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/media/recordedImage.jpeg:listFieldValues` | List recorded image overlay field values |
+
+## MEDIA - Exports (1 of 2 missing)
+
+Implemented: POST create
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/exports/{jobId}:copy` | Retry/copy an export |
+
+## MEDIA - Files (6 of 11 missing)
+
+Implemented: GET list, GET by ID, POST add, GET download, DELETE
+
+| Method | Path | Description |
+|--------|------|-------------|
+| PATCH | `/files/{id}` | Update a file |
+| GET | `/deletedFiles` | List trash (deleted files) |
+| GET | `/deletedFiles/{id}` | Get deleted file |
+| DELETE | `/deletedFiles/{id}` | Permanently delete a trash file |
+| DELETE | `/deletedFiles/all` | Permanently delete all trash files |
+| POST | `/deletedFiles/{id}:restore` | Restore a deleted file |
+
+## MEDIA - Downloads (1 of 4 missing)
+
+Implemented: GET list, GET by ID, GET download
+
+| Method | Path | Description |
+|--------|------|-------------|
+| PATCH | `/downloads/{id}` | Update a download |
+
+## EVENTS - Events (2 of 5 missing)
+
+Implemented: GET list, GET by ID, GET listFieldValues
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/events` | Create an event |
+| GET | `/events:listRecentByType` | List recent events by type |
+
+## EVENTS - Event Subscriptions (4 of 8 missing)
+
+Implemented: GET list, GET by ID, POST create, DELETE
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/eventSubscriptions/{id}/filters` | List subscription filters |
+| POST | `/eventSubscriptions/{id}/filters` | Create subscription filter |
+| GET | `/eventSubscriptions/{id}/filters/{filterId}` | Get subscription filter |
+| DELETE | `/eventSubscriptions/{id}/filters/{filterId}` | Delete subscription filter |
+
+## EVENTS - Notifications (1 of 3 missing)
+
+Implemented: GET list, GET by ID
+
+| Method | Path | Description |
+|--------|------|-------------|
+| PATCH | `/notifications/{id}` | Update a notification |
+
+## AUTOMATIONS - Event Alert Condition Rules (3 of 6 missing)
+
+Implemented: GET list, GET listFieldValues, GET by ID
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/eventAlertConditionRules` | Create event alert condition rule |
+| PATCH | `/eventAlertConditionRules/{id}` | Update event alert condition rule |
+| DELETE | `/eventAlertConditionRules/{id}` | Delete event alert condition rule |
+
+## AUTOMATIONS - Alert Action Rules (3 of 5 missing)
+
+Implemented: GET list, GET by ID
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/alertActionRules` | Create alert action rule |
+| PATCH | `/alertActionRules/{actionRuleId}` | Update alert action rule |
+| DELETE | `/alertActionRules/{actionRuleId}` | Delete alert action rule |
+
+## AUTOMATIONS - Alert Actions (3 of 5 missing)
+
+Implemented: GET list, GET by ID
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/alertActions` | Create alert action |
+| PATCH | `/alertActions/{actionId}` | Update alert action |
+| DELETE | `/alertActions/{actionId}` | Delete alert action |
+
+## VIDEO SEARCH - Video Analytic Events (7 of 7 missing - entire section)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/videoAnalyticEvents:parse` | Parse video analytics query |
+| POST | `/videoAnalyticEvents:deepSearch` | Deep search video analytics events |
+| POST | `/videoAnalyticEvents:deepSearchGroupByResource` | Deep search grouped by resource |
+| POST | `/videoAnalyticEvents:deepSearchGroupByTime` | Deep search grouped by time |
+| POST | `/videoAnalyticEvents:listFieldValues` | List video analytics field values |
+| GET | `/videoAnalyticEvents:listObjectValues` | List video analytics object values |
+| GET | `/videoAnalyticEvents/{id}` | Get video analytics event by ID |
+
+## VEHICLE SURVEILLANCE - LPR Events (4 of 4 missing - entire section)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/lprEvents` | List LPR events |
+| GET | `/lprEvents/{id}` | Get LPR event by ID |
+| GET | `/lprEvents:summary` | Get LPR events summary |
+| GET | `/lprEvents:listFieldValues` | List LPR event field values |
+
+## VEHICLE SURVEILLANCE - LPR Alert Condition Rules (6 of 6 missing - entire section)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/lprAlertConditionRules` | List LPR alert condition rules |
+| POST | `/lprAlertConditionRules` | Create LPR alert condition rule |
+| GET | `/lprAlertConditionRules:listFieldValues` | List LPR rule field values |
+| GET | `/lprAlertConditionRules/{id}` | Get LPR alert condition rule |
+| PATCH | `/lprAlertConditionRules/{id}` | Update LPR alert condition rule |
+| DELETE | `/lprAlertConditionRules/{id}` | Delete LPR alert condition rule |
+
+## VEHICLE SURVEILLANCE - LPR Vehicle Lists (14 of 14 missing - entire section)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/lprVehicleLists` | List vehicle lists |
+| POST | `/lprVehicleLists` | Create vehicle list |
+| GET | `/lprVehicleLists:listFields` | List vehicle list fields |
+| GET | `/lprVehicleLists:listFieldValues` | List vehicle list field values |
+| GET | `/lprVehicleLists/{id}` | Get vehicle list by ID |
+| PATCH | `/lprVehicleLists/{id}` | Update vehicle list |
+| DELETE | `/lprVehicleLists/{id}` | Delete vehicle list |
+| GET | `/lprVehicleLists/{id}/vehicles` | List vehicles in a list |
+| POST | `/lprVehicleLists/{id}/vehicles` | Add vehicle to list |
+| POST | `/lprVehicleLists/{id}/vehicles:bulkCreate` | Bulk add vehicles |
+| GET | `/lprVehicleLists/{id}/vehicles/{recordId}` | Get vehicle by ID |
+| PATCH | `/lprVehicleLists/{id}/vehicles/{recordId}` | Update a vehicle |
+| DELETE | `/lprVehicleLists/{id}/vehicles/{recordId}` | Delete a vehicle |
+| GET | `/lprVehicleLists:search` | Search vehicle lists |
+
+## USER & ACCOUNTS - Users (6 of 9 missing)
+
+Implemented: GET list, GET by ID, GET self
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/users` | Create a user |
+| PATCH | `/users/{userId}` | Update a user |
+| DELETE | `/users/{userId}` | Delete a user |
+| PATCH | `/users/self` | Update current user |
+| GET | `/users/self/trustedClients` | List trusted OAuth clients |
+| DELETE | `/users/self/trustedClients/{trustedClientId}` | Delete trusted client |
+
+## USER & ACCOUNTS - Accounts (2 of 2 missing - entire section)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/accounts` | List accounts |
+| DELETE | `/accounts/{id}/credentials/{credentialId}` | Delete account credential |
+
+## USER & ACCOUNTS - Roles (8 of 8 missing - entire section)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/roles` | List roles |
+| POST | `/roles` | Create a role |
+| GET | `/roles/{roleId}` | Get role by ID |
+| PATCH | `/roles/{roleId}` | Update a role |
+| DELETE | `/roles/{roleId}` | Delete a role |
+| GET | `/roleAssignments` | List role assignments |
+| POST | `/roleAssignments:bulkcreate` | Bulk create role assignments |
+| POST | `/roleAssignments:bulkdelete` | Bulk delete role assignments |
+
+## USER & ACCOUNTS - Audit Log (1 of 1 missing)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/auditLogs` | List audit logs |
+
+## USER & ACCOUNTS - Resource Grants (3 of 3 missing - entire section)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/resourceGrants` | List resource grants |
+| POST | `/resourceGrants:bulkCreate` | Bulk create resource grants |
+| POST | `/resourceGrants:bulkDelete` | Bulk delete resource grants |
+
+## USER & ACCOUNTS - Editions (2 of 2 missing - entire section)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/editions` | List editions |
+| GET | `/editions/{id}` | Get edition by ID |
+
+## RESELLERS - Authorization Tokens (1 of 1 missing)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/authorizationTokens` | Create authorization token |
+
+## ACCOUNT SETTINGS - SSO (2 of 2 missing - entire section)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/accounts/self/ssoAuthSettings` | Get SSO auth settings |
+| PATCH | `/accounts/self/ssoAuthSettings` | Update SSO auth settings |
+
+## ACCOUNT SETTINGS - Client Settings (1 of 1 missing)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/clientSettings` | Get client settings |
+
+## SYSTEM - Applications (5 of 5 missing - entire section)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/applications` | List applications |
+| POST | `/applications` | Create an application |
+| GET | `/applications/{applicationId}` | Get application by ID |
+| PATCH | `/applications/{applicationId}` | Update an application |
+| DELETE | `/applications/{applicationId}` | Delete an application |
+
+## SYSTEM - OAuth Clients (5 of 5 missing - entire section)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/applications/{applicationId}/oauthClients` | List OAuth clients |
+| POST | `/applications/{applicationId}/oauthClients` | Create OAuth client |
+| GET | `/applications/{applicationId}/oauthClients/{clientId}` | Get OAuth client |
+| PATCH | `/applications/{applicationId}/oauthClients/{clientId}` | Update OAuth client |
+| DELETE | `/applications/{applicationId}/oauthClients/{clientId}` | Delete OAuth client |
+
+## SYSTEM - Reference Data (2 of 2 missing - entire section)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/languages` | List supported languages |
+| GET | `/timeZones` | List supported time zones |
+
+---
+
+## Summary
+
+| Status | Count |
+|--------|-------|
+| Implemented | 51 |
+| Missing | 160 |
+| **Total EEN API endpoints** | **211** |
+| **Coverage** | **24.2%** |
+
+### Missing by Category
+
+| Category | Missing | Total | Coverage |
+|----------|---------|-------|----------|
+| Cameras | 12 | 15 | 20% |
+| Bridges | 9 | 11 | 18% |
+| PTZ | 4 | 4 | 0% |
+| Speakers | 7 | 7 | 0% |
+| Device I/O | 6 | 6 | 0% |
+| Switches | 5 | 5 | 0% |
+| Multi Cameras | 6 | 6 | 0% |
+| Available Devices | 1 | 1 | 0% |
+| Layouts | 0 | 5 | 100% |
+| Tags | 1 | 1 | 0% |
+| Locations | 6 | 6 | 0% |
+| Floors | 6 | 6 | 0% |
+| Floor Plans | 3 | 3 | 0% |
+| Media | 1 | 5 | 80% |
+| Feeds | 0 | 1 | 100% |
+| Exports | 1 | 2 | 50% |
+| Jobs | 0 | 3 | 100% |
+| Files | 6 | 11 | 45% |
+| Downloads | 1 | 4 | 75% |
+| Events | 2 | 5 | 60% |
+| Event Types | 0 | 1 | 100% |
+| Event Metrics | 0 | 1 | 100% |
+| Event Subscriptions | 4 | 8 | 50% |
+| Alerts | 0 | 3 | 100% |
+| Notifications | 1 | 3 | 67% |
+| Event Alert Condition Rules | 3 | 6 | 50% |
+| Alert Action Rules | 3 | 5 | 40% |
+| Alert Actions | 3 | 5 | 40% |
+| Video Analytic Events | 7 | 7 | 0% |
+| LPR Events | 4 | 4 | 0% |
+| LPR Alert Condition Rules | 6 | 6 | 0% |
+| LPR Vehicle Lists | 14 | 14 | 0% |
+| Users | 6 | 9 | 33% |
+| Accounts | 2 | 2 | 0% |
+| Roles | 8 | 8 | 0% |
+| Audit Log | 1 | 1 | 0% |
+| Resource Grants | 3 | 3 | 0% |
+| Editions | 2 | 2 | 0% |
+| Authorization Tokens | 1 | 1 | 0% |
+| SSO | 2 | 2 | 0% |
+| Client Settings | 1 | 1 | 0% |
+| Applications | 5 | 5 | 0% |
+| OAuth Clients | 5 | 5 | 0% |
+| Reference Data | 2 | 2 | 0% |
+
+### Fully Implemented Sections
+
+- Layouts (5/5)
+- Feeds (1/1)
+- Jobs (3/3)
+- Event Types (1/1)
+- Event Metrics (1/1)
+- Alerts (3/3)
+
+### Entirely Missing Sections (0% coverage)
+
+- PTZ, Speakers, Device I/O, Switches, Multi Cameras, Available Devices
+- Tags, Locations, Floors, Floor Plans
+- Video Analytic Events, LPR Events, LPR Alert Condition Rules, LPR Vehicle Lists
+- Accounts, Roles, Audit Log, Resource Grants, Editions
+- Authorization Tokens, SSO, Client Settings
+- Applications, OAuth Clients, Reference Data

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.82",
+  "version": "0.3.83",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit",
-      "version": "0.3.82",
+      "version": "0.3.83",
       "license": "MIT",
       "bin": {
         "een-setup-agents": "scripts/setup-agents.ts"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.84",
+  "version": "0.3.85",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit",
-      "version": "0.3.84",
+      "version": "0.3.85",
       "license": "MIT",
       "bin": {
         "een-setup-agents": "scripts/setup-agents.ts"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.83",
+  "version": "0.3.84",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit",
-      "version": "0.3.83",
+      "version": "0.3.84",
       "license": "MIT",
       "bin": {
         "een-setup-agents": "scripts/setup-agents.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.84",
+  "version": "0.3.85",
   "description": "EEN Video platform API v3.0 library for Vue 3",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.83",
+  "version": "0.3.84",
   "description": "EEN Video platform API v3.0 library for Vue 3",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.82",
+  "version": "0.3.83",
   "description": "EEN Video platform API v3.0 library for Vue 3",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

- Add four EEN API v3.0 coverage documents comparing all 211 API endpoints against the 51 implemented in the toolkit (24.2% coverage)
- Create `een-api-coverage-agent` for on-demand regeneration of coverage docs
- Add EEN API Coverage section to README.md linking to all coverage documents

## Coverage Documents

| Document | Description |
|----------|-------------|
| `docs/een-api-all-endpoints.md` | Complete reference of all 211 EEN API v3.0 endpoints |
| `docs/een-api-implemented.md` | 51 implemented endpoints with toolkit function names |
| `docs/een-api-missing.md` | 160 missing endpoints with per-category coverage % |
| `docs/een-api-coverage.html` | Interactive HTML table with filtering, sorting, and stats |

## Test Results

- **Lint**: Passed (1 warning - existing)
- **Unit tests**: 644 passed
- **Build**: Succeeded
- **E2E tests**: 236 passed across all 11 example apps
- **Security review**: No vulnerabilities (documentation-only changes)
- **Confidential data scan**: Clean - no secrets or credentials in docs

## Version

v0.3.83

🤖 Generated with [Claude Code](https://claude.com/claude-code)