### PR TITLE
fix: use floating v1 tag for claude-code-action

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,8 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip Dependabot PRs - they don't have access to repository secrets
+    if: github.actor != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:
@@ -33,7 +30,12 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@23ed4cb53d6eacddbc22ec16652c98bcc54e0476 # v1.0.48
+        # Uses the v1 floating tag to auto-update with new releases.
+        # Unlike other actions which are SHA-pinned, claude-code-action uses a tag
+        # because: (1) it's an official Anthropic action with trusted releases,
+        # (2) SHA pinning triggers Dependabot PRs that fail CI since Dependabot
+        # workflows cannot access repository secrets (ANTHROPIC_API_KEY).
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -353,6 +353,13 @@ All actions are pinned to immutable commit SHAs to prevent supply chain attacks.
 2. Update the version comment (e.g., `# v6.0.2`) to match the new version
 3. Review the action's release notes for breaking changes
 
+**Exception**: `anthropics/claude-code-action` uses the `@v1` floating tag instead of a pinned SHA. This is intentional because:
+- It is an official Anthropic action with trusted releases
+- SHA pinning triggers Dependabot PRs that fail CI, since Dependabot workflows cannot access repository secrets (`ANTHROPIC_API_KEY`)
+- The `@v1` tag auto-updates to the latest v1.x release
+
+The Claude Code Review workflow also skips Dependabot PRs (`if: github.actor != 'dependabot[bot]'`) because Dependabot cannot access the `ANTHROPIC_API_KEY` secret needed to run the review.
+
 ## Code Review
 
 - GitHub Actions workflow uses Claude for code review


### PR DESCRIPTION
## Summary
- Switch `claude-code-action` from SHA-pinned `@23ed4cb...` to floating `@v1` tag for automatic updates
- Skip Claude review on Dependabot PRs since they cannot access repository secrets (`ANTHROPIC_API_KEY`)
- Document the SHA pinning exception in CLAUDE.md

## Context
PR #116 (Dependabot) failed because Dependabot workflows don't have access to repository secrets. Using `@v1` eliminates the need for Dependabot to manage this dependency, and the skip condition prevents future failures on other Dependabot PRs.

## Test plan
- [ ] Verify Claude review workflow runs on non-Dependabot PRs
- [ ] Verify Claude review is skipped on Dependabot PRs
- [ ] Close Dependabot PR #116 after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)