### PR TITLE
Release v0.3.96: PTZ fisheye exclusion and API coverage docs

### DIFF
--- a/.claude/agents/api-coverage-agent.md
+++ b/.claude/agents/api-coverage-agent.md
@@ -205,40 +205,82 @@ Implemented: [brief list of what IS implemented]
 
 #### Document 4: `docs/een-api-coverage.html`
 
-Generate a self-contained HTML file with:
+Generate a self-contained HTML file matching this exact visual style:
 
-**Header section**:
-- Title: "Eagle Eye Networks API v3.0 - Toolkit Coverage"
-- Generation date
-- Summary stat cards: Total endpoints, Implemented, Missing, Coverage percentage with progress bar
+**Global reset and body**:
+- `*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }`
+- Font: `-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, sans-serif`
+- Background: `#f5f7fa`, color: `#1a202c`
 
-**Filter bar**:
-- Status filter dropdown (All / Implemented / Missing)
-- Category filter dropdown (All + each category)
-- Method filter dropdown (All / GET / POST / PATCH / DELETE / PUT)
-- Text search input for path/function/description
+**Header** (`<header>`):
+- Dark navy background: `#1a365d`, white text
+- Padding: `24px 32px`
+- `<h1>` at `1.5rem` bold: "Eagle Eye Networks API v3.0 — Toolkit Coverage"
+- `<p>` at `0.875rem`, color `#bee3f8`: generation date and source info
 
-**Data table**:
-- Columns: #, Category, Subcategory, Method, Path, Description, Status, Toolkit Function
-- Sortable by clicking column headers
-- Color-coded method badges (GET=blue, POST=green, PATCH=yellow, DELETE=red, PUT=indigo)
-- Status badges (Implemented=green, Missing=red)
-- Monospace font for function names
+**Container**: `max-width: 100%` (use full page width), centered, padding `24px 32px`
 
-**Styling**:
-- Clean, modern CSS with system font stack
-- Light background (#f5f7fa)
-- White card-style table with subtle shadows
-- Responsive layout
-- All styles inline (self-contained, no external dependencies)
+**Stat cards** (`.stats` grid):
+- `grid-template-columns: repeat(auto-fit, minmax(180px, 1fr))`, gap `16px`
+- Each card: white background, `border-radius: 8px`, padding `20px`, `box-shadow: 0 1px 3px rgba(0,0,0,.08)`
+- Colored `border-top: 4px solid` — blue (`#4299e1`) for Total, green (`#48bb78`) for Implemented, red (`#fc8181`) for Missing, indigo (`#667eea`) for Coverage
+- Label: `0.75rem` uppercase, `letter-spacing: .05em`, color `#718096`
+- Value: `2rem` bold, color `#2d3748`
+- Sub text: `0.8rem`, color `#718096`
+
+**Progress bar** (`.progress-wrap`):
+- White card with same shadow/radius as stat cards
+- Label row: flex with `justify-content: space-between`, `0.875rem`, color `#4a5568`
+- Bar background: `#e2e8f0`, `border-radius: 9999px`, height `12px`
+- Fill: `linear-gradient(90deg, #48bb78, #38a169)`, same radius, `transition: width .4s ease`
+
+**Filter bar** (`.filter-bar`):
+- White card, flex with `flex-wrap: wrap`, gap `12px`
+- Labels: `0.8rem`, color `#718096`
+- Inputs/selects: border `1px solid #e2e8f0`, `border-radius: 6px`, padding `6px 10px`, `0.875rem`
+- Focus: `border-color: #4299e1`, `box-shadow: 0 0 0 3px rgba(66,153,225,.15)`
+- Text input width: `220px`
+- Filter count: `margin-left: auto`, `0.8rem`, color `#718096`
+- Dropdowns: Status (All/Implemented/Missing), Category (All + each category), Method (All/GET/POST/PATCH/DELETE/PUT)
+- Text search placeholder: "path, function, description..."
+
+**Table** (`.table-wrap`):
+- White card with `overflow-x: auto` for horizontal scrollbar on narrow viewports
+- The `<table>` element must have `min-width: 1200px` so content is never clipped — the scrollbar activates instead of truncating columns
+- `<thead>`: dark background `#2d3748`, white text, uppercase `0.75rem`, `letter-spacing: .05em`
+- Headers clickable (cursor pointer) with sort icon `⇅`, changing to `▲`/`▼` when sorted
+- `<tbody>` rows: `border-bottom: 1px solid #edf2f7`, hover `#f7fafc`
+- Cell padding: `10px 14px`
+- Column classes:
+  - `.td-num`: color `#a0aec0`, `0.75rem`, width `44px`
+  - `.td-cat`: color `#4a5568`, `font-weight: 500`
+  - `.td-sub`: color `#718096`
+  - `.td-path`: monospace (`'SFMono-Regular', Consolas, monospace`), `0.8rem`, color `#2d3748`
+  - `.td-desc`: color `#4a5568`, `max-width: 280px`
+  - `.td-func`: monospace, `0.78rem`, color `#553c9a`
+
+**Badges** (`.badge`):
+- `display: inline-flex`, padding `2px 8px`, `border-radius: 4px`, `0.72rem` bold uppercase
+- Method colors: GET (`#ebf8ff`/`#2b6cb0`), POST (`#f0fff4`/`#276749`), PATCH (`#fffff0`/`#975a16`), DELETE (`#fff5f5`/`#c53030`), PUT (`#f0e6ff`/`#553c9a`)
+- Status colors: Implemented (`#f0fff4`/`#276749`), Missing (`#fff5f5`/`#c53030`)
+
+**Empty state**: centered, padding `48px`, color `#a0aec0`, with a search SVG icon
+
+**Footer**: centered, padding `24px`, color `#a0aec0`, `0.8rem`
+
+**Columns**: #, Category, Subcategory, Method, Path, Description, Status, Toolkit Function (8 columns)
 
 **JavaScript**:
 - All endpoint data in a `const endpoints = [...]` array with objects: `{cat, sub, method, path, desc, status, func}`
+- Endpoints grouped by category/subcategory with `// ─── Category - Subcategory ───` comment dividers
 - `status` values: `"impl"` for implemented, `"miss"` for missing
 - `func` is empty string for missing endpoints
-- `renderTable(data)` function to populate tbody
-- `filterTable()` function combining all filter inputs
-- `sortTable(colIndex)` function with toggle direction
+- `methodBadge(m)` and `statusBadge(s)` helper functions
+- `renderTable(data)` function to populate tbody and update filter count
+- `filterTable()` function combining all four filter inputs (status, category, method, text search across path+func+desc+sub)
+- `sortTable(colIndex)` function with toggle direction, updating header sort icons
+- `sortCol`/`sortAsc` state variables
+- Initial call to `renderTable(endpoints)` at the end
 - All code inline (no external dependencies)
 
 ## Important Guidelines

--- a/.claude/agents/een-ptz-agent.md
+++ b/.claude/agents/een-ptz-agent.md
@@ -224,12 +224,11 @@ nested `capabilities.ptz.capable` field. The structure is:
 NOT at `capabilities.ptzCapable` (flat). Always use `capabilities?.ptz?.capable` to check.
 
 **IMPORTANT:** Fisheye cameras report `capabilities.ptz.capable: true` but are NOT true PTZ cameras.
-Always exclude fisheye cameras by checking `capabilities.ptz.fisheye !== true`. The `fisheye` field
-is not in the toolkit's TypeScript type definitions, so cast when accessing it:
+Always exclude fisheye cameras by checking `capabilities.ptz.fisheye !== true`:
 
 ```typescript
 const isPtzCapable = computed(() => {
-  const ptz = camera.capabilities?.ptz as { capable?: boolean; fisheye?: boolean } | undefined
+  const ptz = camera.capabilities?.ptz
   return ptz?.capable === true && ptz?.fisheye !== true
 })
 ```

--- a/.claude/agents/een-ptz-agent.md
+++ b/.claude/agents/een-ptz-agent.md
@@ -221,14 +221,14 @@ nested `capabilities.ptz.capable` field. The structure is:
 ```
 
 **IMPORTANT:** The PTZ capability is at `capabilities.ptz.capable` (nested under a `ptz` object),
-NOT at `capabilities.ptzCapable` (flat). Always use `capabilities?.ptz?.capable` to check.
-
-**IMPORTANT:** Fisheye cameras report `capabilities.ptz.capable: true` but are NOT true PTZ cameras.
-Always exclude fisheye cameras by checking `capabilities.ptz.fisheye !== true`:
+NOT at `capabilities.ptzCapable` (flat). Fisheye cameras report `capabilities.ptz.capable: true`
+but are NOT true PTZ cameras — always exclude them. Use this pattern:
 
 ```typescript
+import { computed } from 'vue'
+
 const isPtzCapable = computed(() => {
-  const ptz = camera.capabilities?.ptz
+  const ptz = camera.value?.capabilities?.ptz
   return ptz?.capable === true && ptz?.fisheye !== true
 })
 ```

--- a/.claude/agents/een-ptz-agent.md
+++ b/.claude/agents/een-ptz-agent.md
@@ -223,12 +223,23 @@ nested `capabilities.ptz.capable` field. The structure is:
 **IMPORTANT:** The PTZ capability is at `capabilities.ptz.capable` (nested under a `ptz` object),
 NOT at `capabilities.ptzCapable` (flat). Always use `capabilities?.ptz?.capable` to check.
 
+**IMPORTANT:** Fisheye cameras report `capabilities.ptz.capable: true` but are NOT true PTZ cameras.
+Always exclude fisheye cameras by checking `capabilities.ptz.fisheye !== true`. The `fisheye` field
+is not in the toolkit's TypeScript type definitions, so cast when accessing it:
+
+```typescript
+const isPtzCapable = computed(() => {
+  const ptz = camera.capabilities?.ptz as { capable?: boolean; fisheye?: boolean } | undefined
+  return ptz?.capable === true && ptz?.fisheye !== true
+})
+```
+
 Also check `effectivePermissions.controlPTZ` to verify the user has permission to move the camera,
 and `effectivePermissions.editPTZStations` for managing presets.
 
 ## Constraints
 - Always check authentication before API calls
-- Verify camera has PTZ capability (`capabilities.ptz.capable`) before showing controls
+- Verify camera has PTZ capability (`capabilities.ptz.capable`) and is not fisheye (`capabilities.ptz.fisheye !== true`) before showing controls
 - Check user permissions (`effectivePermissions.controlPTZ`) before enabling movement
 - Poll position periodically (every 5s) for position display
 - Handle 204 responses for PUT/PATCH (no response body)

--- a/docs/AI-CONTEXT.md
+++ b/docs/AI-CONTEXT.md
@@ -1,6 +1,6 @@
 # EEN API Toolkit - AI Reference
 
-> **Version:** 0.3.95
+> **Version:** 0.3.96
 >
 > This documentation is optimized for AI assistants. It provides focused, domain-specific
 > references to help you understand and use the een-api-toolkit efficiently.

--- a/docs/AI-CONTEXT.md
+++ b/docs/AI-CONTEXT.md
@@ -1,6 +1,6 @@
 # EEN API Toolkit - AI Reference
 
-> **Version:** 0.3.91
+> **Version:** 0.3.92
 >
 > This documentation is optimized for AI assistants. It provides focused, domain-specific
 > references to help you understand and use the een-api-toolkit efficiently.

--- a/docs/AI-CONTEXT.md
+++ b/docs/AI-CONTEXT.md
@@ -1,6 +1,6 @@
 # EEN API Toolkit - AI Reference
 
-> **Version:** 0.3.93
+> **Version:** 0.3.94
 >
 > This documentation is optimized for AI assistants. It provides focused, domain-specific
 > references to help you understand and use the een-api-toolkit efficiently.

--- a/docs/AI-CONTEXT.md
+++ b/docs/AI-CONTEXT.md
@@ -1,6 +1,6 @@
 # EEN API Toolkit - AI Reference
 
-> **Version:** 0.3.92
+> **Version:** 0.3.93
 >
 > This documentation is optimized for AI assistants. It provides focused, domain-specific
 > references to help you understand and use the een-api-toolkit efficiently.

--- a/docs/AI-CONTEXT.md
+++ b/docs/AI-CONTEXT.md
@@ -1,6 +1,6 @@
 # EEN API Toolkit - AI Reference
 
-> **Version:** 0.3.96
+> **Version:** 0.3.97
 >
 > This documentation is optimized for AI assistants. It provides focused, domain-specific
 > references to help you understand and use the een-api-toolkit efficiently.

--- a/docs/AI-CONTEXT.md
+++ b/docs/AI-CONTEXT.md
@@ -1,6 +1,6 @@
 # EEN API Toolkit - AI Reference
 
-> **Version:** 0.3.94
+> **Version:** 0.3.95
 >
 > This documentation is optimized for AI assistants. It provides focused, domain-specific
 > references to help you understand and use the een-api-toolkit efficiently.

--- a/docs/ai-reference/AI-AUTH.md
+++ b/docs/ai-reference/AI-AUTH.md
@@ -1,6 +1,6 @@
 # Authentication - EEN API Toolkit
 
-> **Version:** 0.3.93
+> **Version:** 0.3.94
 >
 > OAuth flow implementation, token management, and session handling.
 > Load this document when implementing login, logout, or auth guards.

--- a/docs/ai-reference/AI-AUTH.md
+++ b/docs/ai-reference/AI-AUTH.md
@@ -1,6 +1,6 @@
 # Authentication - EEN API Toolkit
 
-> **Version:** 0.3.95
+> **Version:** 0.3.96
 >
 > OAuth flow implementation, token management, and session handling.
 > Load this document when implementing login, logout, or auth guards.

--- a/docs/ai-reference/AI-AUTH.md
+++ b/docs/ai-reference/AI-AUTH.md
@@ -1,6 +1,6 @@
 # Authentication - EEN API Toolkit
 
-> **Version:** 0.3.92
+> **Version:** 0.3.93
 >
 > OAuth flow implementation, token management, and session handling.
 > Load this document when implementing login, logout, or auth guards.

--- a/docs/ai-reference/AI-AUTH.md
+++ b/docs/ai-reference/AI-AUTH.md
@@ -1,6 +1,6 @@
 # Authentication - EEN API Toolkit
 
-> **Version:** 0.3.96
+> **Version:** 0.3.97
 >
 > OAuth flow implementation, token management, and session handling.
 > Load this document when implementing login, logout, or auth guards.

--- a/docs/ai-reference/AI-AUTH.md
+++ b/docs/ai-reference/AI-AUTH.md
@@ -1,6 +1,6 @@
 # Authentication - EEN API Toolkit
 
-> **Version:** 0.3.91
+> **Version:** 0.3.92
 >
 > OAuth flow implementation, token management, and session handling.
 > Load this document when implementing login, logout, or auth guards.

--- a/docs/ai-reference/AI-AUTH.md
+++ b/docs/ai-reference/AI-AUTH.md
@@ -1,6 +1,6 @@
 # Authentication - EEN API Toolkit
 
-> **Version:** 0.3.94
+> **Version:** 0.3.95
 >
 > OAuth flow implementation, token management, and session handling.
 > Load this document when implementing login, logout, or auth guards.

--- a/docs/ai-reference/AI-AUTOMATIONS.md
+++ b/docs/ai-reference/AI-AUTOMATIONS.md
@@ -1,6 +1,6 @@
 # Automations API - EEN API Toolkit
 
-> **Version:** 0.3.94
+> **Version:** 0.3.95
 >
 > Complete reference for automation rules and alert actions.
 > Load this document when working with automated alert workflows.

--- a/docs/ai-reference/AI-AUTOMATIONS.md
+++ b/docs/ai-reference/AI-AUTOMATIONS.md
@@ -1,6 +1,6 @@
 # Automations API - EEN API Toolkit
 
-> **Version:** 0.3.95
+> **Version:** 0.3.96
 >
 > Complete reference for automation rules and alert actions.
 > Load this document when working with automated alert workflows.

--- a/docs/ai-reference/AI-AUTOMATIONS.md
+++ b/docs/ai-reference/AI-AUTOMATIONS.md
@@ -1,6 +1,6 @@
 # Automations API - EEN API Toolkit
 
-> **Version:** 0.3.93
+> **Version:** 0.3.94
 >
 > Complete reference for automation rules and alert actions.
 > Load this document when working with automated alert workflows.

--- a/docs/ai-reference/AI-AUTOMATIONS.md
+++ b/docs/ai-reference/AI-AUTOMATIONS.md
@@ -1,6 +1,6 @@
 # Automations API - EEN API Toolkit
 
-> **Version:** 0.3.91
+> **Version:** 0.3.92
 >
 > Complete reference for automation rules and alert actions.
 > Load this document when working with automated alert workflows.

--- a/docs/ai-reference/AI-AUTOMATIONS.md
+++ b/docs/ai-reference/AI-AUTOMATIONS.md
@@ -1,6 +1,6 @@
 # Automations API - EEN API Toolkit
 
-> **Version:** 0.3.96
+> **Version:** 0.3.97
 >
 > Complete reference for automation rules and alert actions.
 > Load this document when working with automated alert workflows.

--- a/docs/ai-reference/AI-AUTOMATIONS.md
+++ b/docs/ai-reference/AI-AUTOMATIONS.md
@@ -1,6 +1,6 @@
 # Automations API - EEN API Toolkit
 
-> **Version:** 0.3.92
+> **Version:** 0.3.93
 >
 > Complete reference for automation rules and alert actions.
 > Load this document when working with automated alert workflows.

--- a/docs/ai-reference/AI-DEVICES.md
+++ b/docs/ai-reference/AI-DEVICES.md
@@ -1,6 +1,6 @@
 # Cameras & Bridges API - EEN API Toolkit
 
-> **Version:** 0.3.92
+> **Version:** 0.3.93
 >
 > Complete reference for camera and bridge management.
 > Load this document when working with devices.

--- a/docs/ai-reference/AI-DEVICES.md
+++ b/docs/ai-reference/AI-DEVICES.md
@@ -1,6 +1,6 @@
 # Cameras & Bridges API - EEN API Toolkit
 
-> **Version:** 0.3.96
+> **Version:** 0.3.97
 >
 > Complete reference for camera and bridge management.
 > Load this document when working with devices.

--- a/docs/ai-reference/AI-DEVICES.md
+++ b/docs/ai-reference/AI-DEVICES.md
@@ -1,6 +1,6 @@
 # Cameras & Bridges API - EEN API Toolkit
 
-> **Version:** 0.3.91
+> **Version:** 0.3.92
 >
 > Complete reference for camera and bridge management.
 > Load this document when working with devices.

--- a/docs/ai-reference/AI-DEVICES.md
+++ b/docs/ai-reference/AI-DEVICES.md
@@ -1,6 +1,6 @@
 # Cameras & Bridges API - EEN API Toolkit
 
-> **Version:** 0.3.95
+> **Version:** 0.3.96
 >
 > Complete reference for camera and bridge management.
 > Load this document when working with devices.

--- a/docs/ai-reference/AI-DEVICES.md
+++ b/docs/ai-reference/AI-DEVICES.md
@@ -1,6 +1,6 @@
 # Cameras & Bridges API - EEN API Toolkit
 
-> **Version:** 0.3.94
+> **Version:** 0.3.95
 >
 > Complete reference for camera and bridge management.
 > Load this document when working with devices.
@@ -33,6 +33,17 @@ interface Camera {
   deviceInfo?: CameraDeviceInfo
   shareDetails?: CameraShareDetails
   devicePosition?: CameraDevicePosition
+  capabilities?: {
+    ptz?: {
+      capable?: boolean
+      fisheye?: boolean
+      panTilt?: boolean
+      zoom?: boolean
+      positionMove?: boolean
+      directionMove?: boolean
+      centerOnMove?: boolean
+    }
+  }
   createdAt?: string
   updatedAt?: string
 }

--- a/docs/ai-reference/AI-DEVICES.md
+++ b/docs/ai-reference/AI-DEVICES.md
@@ -1,6 +1,6 @@
 # Cameras & Bridges API - EEN API Toolkit
 
-> **Version:** 0.3.93
+> **Version:** 0.3.94
 >
 > Complete reference for camera and bridge management.
 > Load this document when working with devices.

--- a/docs/ai-reference/AI-EVENT-DATA-SCHEMAS.md
+++ b/docs/ai-reference/AI-EVENT-DATA-SCHEMAS.md
@@ -1,6 +1,6 @@
 # Event Type to Data Schemas Mapping - EEN API Toolkit
 
-> **Version:** 0.3.92
+> **Version:** 0.3.93
 >
 > Complete reference for event type to data schema mappings.
 > Load this document when building dynamic event queries with the `include` parameter.

--- a/docs/ai-reference/AI-EVENT-DATA-SCHEMAS.md
+++ b/docs/ai-reference/AI-EVENT-DATA-SCHEMAS.md
@@ -1,6 +1,6 @@
 # Event Type to Data Schemas Mapping - EEN API Toolkit
 
-> **Version:** 0.3.96
+> **Version:** 0.3.97
 >
 > Complete reference for event type to data schema mappings.
 > Load this document when building dynamic event queries with the `include` parameter.

--- a/docs/ai-reference/AI-EVENT-DATA-SCHEMAS.md
+++ b/docs/ai-reference/AI-EVENT-DATA-SCHEMAS.md
@@ -1,6 +1,6 @@
 # Event Type to Data Schemas Mapping - EEN API Toolkit
 
-> **Version:** 0.3.93
+> **Version:** 0.3.94
 >
 > Complete reference for event type to data schema mappings.
 > Load this document when building dynamic event queries with the `include` parameter.

--- a/docs/ai-reference/AI-EVENT-DATA-SCHEMAS.md
+++ b/docs/ai-reference/AI-EVENT-DATA-SCHEMAS.md
@@ -1,6 +1,6 @@
 # Event Type to Data Schemas Mapping - EEN API Toolkit
 
-> **Version:** 0.3.95
+> **Version:** 0.3.96
 >
 > Complete reference for event type to data schema mappings.
 > Load this document when building dynamic event queries with the `include` parameter.

--- a/docs/ai-reference/AI-EVENT-DATA-SCHEMAS.md
+++ b/docs/ai-reference/AI-EVENT-DATA-SCHEMAS.md
@@ -1,6 +1,6 @@
 # Event Type to Data Schemas Mapping - EEN API Toolkit
 
-> **Version:** 0.3.91
+> **Version:** 0.3.92
 >
 > Complete reference for event type to data schema mappings.
 > Load this document when building dynamic event queries with the `include` parameter.

--- a/docs/ai-reference/AI-EVENT-DATA-SCHEMAS.md
+++ b/docs/ai-reference/AI-EVENT-DATA-SCHEMAS.md
@@ -1,6 +1,6 @@
 # Event Type to Data Schemas Mapping - EEN API Toolkit
 
-> **Version:** 0.3.94
+> **Version:** 0.3.95
 >
 > Complete reference for event type to data schema mappings.
 > Load this document when building dynamic event queries with the `include` parameter.

--- a/docs/ai-reference/AI-EVENTS.md
+++ b/docs/ai-reference/AI-EVENTS.md
@@ -1,6 +1,6 @@
 # Events, Alerts & Real-Time Streaming - EEN API Toolkit
 
-> **Version:** 0.3.93
+> **Version:** 0.3.94
 >
 > Complete reference for events, alerts, metrics, and SSE subscriptions.
 > Load this document when implementing event-driven features.

--- a/docs/ai-reference/AI-EVENTS.md
+++ b/docs/ai-reference/AI-EVENTS.md
@@ -1,6 +1,6 @@
 # Events, Alerts & Real-Time Streaming - EEN API Toolkit
 
-> **Version:** 0.3.96
+> **Version:** 0.3.97
 >
 > Complete reference for events, alerts, metrics, and SSE subscriptions.
 > Load this document when implementing event-driven features.

--- a/docs/ai-reference/AI-EVENTS.md
+++ b/docs/ai-reference/AI-EVENTS.md
@@ -1,6 +1,6 @@
 # Events, Alerts & Real-Time Streaming - EEN API Toolkit
 
-> **Version:** 0.3.91
+> **Version:** 0.3.92
 >
 > Complete reference for events, alerts, metrics, and SSE subscriptions.
 > Load this document when implementing event-driven features.

--- a/docs/ai-reference/AI-EVENTS.md
+++ b/docs/ai-reference/AI-EVENTS.md
@@ -1,6 +1,6 @@
 # Events, Alerts & Real-Time Streaming - EEN API Toolkit
 
-> **Version:** 0.3.95
+> **Version:** 0.3.96
 >
 > Complete reference for events, alerts, metrics, and SSE subscriptions.
 > Load this document when implementing event-driven features.

--- a/docs/ai-reference/AI-EVENTS.md
+++ b/docs/ai-reference/AI-EVENTS.md
@@ -1,6 +1,6 @@
 # Events, Alerts & Real-Time Streaming - EEN API Toolkit
 
-> **Version:** 0.3.94
+> **Version:** 0.3.95
 >
 > Complete reference for events, alerts, metrics, and SSE subscriptions.
 > Load this document when implementing event-driven features.

--- a/docs/ai-reference/AI-EVENTS.md
+++ b/docs/ai-reference/AI-EVENTS.md
@@ -1,6 +1,6 @@
 # Events, Alerts & Real-Time Streaming - EEN API Toolkit
 
-> **Version:** 0.3.92
+> **Version:** 0.3.93
 >
 > Complete reference for events, alerts, metrics, and SSE subscriptions.
 > Load this document when implementing event-driven features.

--- a/docs/ai-reference/AI-GROUPING.md
+++ b/docs/ai-reference/AI-GROUPING.md
@@ -1,6 +1,6 @@
 # Layouts API - EEN API Toolkit
 
-> **Version:** 0.3.92
+> **Version:** 0.3.93
 >
 > Complete reference for layout management (camera grouping).
 > Load this document when working with layouts.

--- a/docs/ai-reference/AI-GROUPING.md
+++ b/docs/ai-reference/AI-GROUPING.md
@@ -1,6 +1,6 @@
 # Layouts API - EEN API Toolkit
 
-> **Version:** 0.3.96
+> **Version:** 0.3.97
 >
 > Complete reference for layout management (camera grouping).
 > Load this document when working with layouts.

--- a/docs/ai-reference/AI-GROUPING.md
+++ b/docs/ai-reference/AI-GROUPING.md
@@ -1,6 +1,6 @@
 # Layouts API - EEN API Toolkit
 
-> **Version:** 0.3.95
+> **Version:** 0.3.96
 >
 > Complete reference for layout management (camera grouping).
 > Load this document when working with layouts.

--- a/docs/ai-reference/AI-GROUPING.md
+++ b/docs/ai-reference/AI-GROUPING.md
@@ -1,6 +1,6 @@
 # Layouts API - EEN API Toolkit
 
-> **Version:** 0.3.94
+> **Version:** 0.3.95
 >
 > Complete reference for layout management (camera grouping).
 > Load this document when working with layouts.

--- a/docs/ai-reference/AI-GROUPING.md
+++ b/docs/ai-reference/AI-GROUPING.md
@@ -1,6 +1,6 @@
 # Layouts API - EEN API Toolkit
 
-> **Version:** 0.3.93
+> **Version:** 0.3.94
 >
 > Complete reference for layout management (camera grouping).
 > Load this document when working with layouts.

--- a/docs/ai-reference/AI-GROUPING.md
+++ b/docs/ai-reference/AI-GROUPING.md
@@ -1,6 +1,6 @@
 # Layouts API - EEN API Toolkit
 
-> **Version:** 0.3.91
+> **Version:** 0.3.92
 >
 > Complete reference for layout management (camera grouping).
 > Load this document when working with layouts.

--- a/docs/ai-reference/AI-JOBS.md
+++ b/docs/ai-reference/AI-JOBS.md
@@ -1,6 +1,6 @@
 # Jobs, Exports, Files & Downloads - EEN API Toolkit
 
-> **Version:** 0.3.96
+> **Version:** 0.3.97
 >
 > Complete reference for async jobs, video exports, and file management.
 > Load this document when implementing export workflows or file downloads.

--- a/docs/ai-reference/AI-JOBS.md
+++ b/docs/ai-reference/AI-JOBS.md
@@ -1,6 +1,6 @@
 # Jobs, Exports, Files & Downloads - EEN API Toolkit
 
-> **Version:** 0.3.95
+> **Version:** 0.3.96
 >
 > Complete reference for async jobs, video exports, and file management.
 > Load this document when implementing export workflows or file downloads.

--- a/docs/ai-reference/AI-JOBS.md
+++ b/docs/ai-reference/AI-JOBS.md
@@ -1,6 +1,6 @@
 # Jobs, Exports, Files & Downloads - EEN API Toolkit
 
-> **Version:** 0.3.92
+> **Version:** 0.3.93
 >
 > Complete reference for async jobs, video exports, and file management.
 > Load this document when implementing export workflows or file downloads.

--- a/docs/ai-reference/AI-JOBS.md
+++ b/docs/ai-reference/AI-JOBS.md
@@ -1,6 +1,6 @@
 # Jobs, Exports, Files & Downloads - EEN API Toolkit
 
-> **Version:** 0.3.94
+> **Version:** 0.3.95
 >
 > Complete reference for async jobs, video exports, and file management.
 > Load this document when implementing export workflows or file downloads.

--- a/docs/ai-reference/AI-JOBS.md
+++ b/docs/ai-reference/AI-JOBS.md
@@ -1,6 +1,6 @@
 # Jobs, Exports, Files & Downloads - EEN API Toolkit
 
-> **Version:** 0.3.91
+> **Version:** 0.3.92
 >
 > Complete reference for async jobs, video exports, and file management.
 > Load this document when implementing export workflows or file downloads.

--- a/docs/ai-reference/AI-JOBS.md
+++ b/docs/ai-reference/AI-JOBS.md
@@ -1,6 +1,6 @@
 # Jobs, Exports, Files & Downloads - EEN API Toolkit
 
-> **Version:** 0.3.93
+> **Version:** 0.3.94
 >
 > Complete reference for async jobs, video exports, and file management.
 > Load this document when implementing export workflows or file downloads.

--- a/docs/ai-reference/AI-MEDIA.md
+++ b/docs/ai-reference/AI-MEDIA.md
@@ -1,6 +1,6 @@
 # Media & Live Video - EEN API Toolkit
 
-> **Version:** 0.3.92
+> **Version:** 0.3.93
 >
 > Complete reference for media retrieval, live streaming, and video playback.
 > Load this document when implementing video features.

--- a/docs/ai-reference/AI-MEDIA.md
+++ b/docs/ai-reference/AI-MEDIA.md
@@ -1,6 +1,6 @@
 # Media & Live Video - EEN API Toolkit
 
-> **Version:** 0.3.93
+> **Version:** 0.3.94
 >
 > Complete reference for media retrieval, live streaming, and video playback.
 > Load this document when implementing video features.

--- a/docs/ai-reference/AI-MEDIA.md
+++ b/docs/ai-reference/AI-MEDIA.md
@@ -1,6 +1,6 @@
 # Media & Live Video - EEN API Toolkit
 
-> **Version:** 0.3.96
+> **Version:** 0.3.97
 >
 > Complete reference for media retrieval, live streaming, and video playback.
 > Load this document when implementing video features.

--- a/docs/ai-reference/AI-MEDIA.md
+++ b/docs/ai-reference/AI-MEDIA.md
@@ -1,6 +1,6 @@
 # Media & Live Video - EEN API Toolkit
 
-> **Version:** 0.3.91
+> **Version:** 0.3.92
 >
 > Complete reference for media retrieval, live streaming, and video playback.
 > Load this document when implementing video features.

--- a/docs/ai-reference/AI-MEDIA.md
+++ b/docs/ai-reference/AI-MEDIA.md
@@ -1,6 +1,6 @@
 # Media & Live Video - EEN API Toolkit
 
-> **Version:** 0.3.94
+> **Version:** 0.3.95
 >
 > Complete reference for media retrieval, live streaming, and video playback.
 > Load this document when implementing video features.

--- a/docs/ai-reference/AI-MEDIA.md
+++ b/docs/ai-reference/AI-MEDIA.md
@@ -1,6 +1,6 @@
 # Media & Live Video - EEN API Toolkit
 
-> **Version:** 0.3.95
+> **Version:** 0.3.96
 >
 > Complete reference for media retrieval, live streaming, and video playback.
 > Load this document when implementing video features.

--- a/docs/ai-reference/AI-PTZ.md
+++ b/docs/ai-reference/AI-PTZ.md
@@ -1,6 +1,6 @@
 # PTZ Camera Controls
 
-> **Version:** 0.3.92
+> **Version:** 0.3.93
 >
 > Pan/Tilt/Zoom camera control: position, movement, presets, and automation.
 

--- a/docs/ai-reference/AI-PTZ.md
+++ b/docs/ai-reference/AI-PTZ.md
@@ -1,6 +1,6 @@
 # PTZ Camera Controls
 
-> **Version:** 0.3.91
+> **Version:** 0.3.92
 >
 > Pan/Tilt/Zoom camera control: position, movement, presets, and automation.
 

--- a/docs/ai-reference/AI-PTZ.md
+++ b/docs/ai-reference/AI-PTZ.md
@@ -1,6 +1,6 @@
 # PTZ Camera Controls
 
-> **Version:** 0.3.94
+> **Version:** 0.3.95
 >
 > Pan/Tilt/Zoom camera control: position, movement, presets, and automation.
 
@@ -148,8 +148,10 @@ function handleVideoClick(event: MouseEvent) {
 Always exclude fisheye cameras when checking PTZ capability:
 
 ```typescript
+import { computed } from 'vue'
+
 const isPtzCapable = computed(() => {
-  const ptz = camera.capabilities?.ptz
+  const ptz = camera.value?.capabilities?.ptz
   return ptz?.capable === true && ptz?.fisheye !== true
 })
 ```

--- a/docs/ai-reference/AI-PTZ.md
+++ b/docs/ai-reference/AI-PTZ.md
@@ -1,6 +1,6 @@
 # PTZ Camera Controls
 
-> **Version:** 0.3.93
+> **Version:** 0.3.94
 >
 > Pan/Tilt/Zoom camera control: position, movement, presets, and automation.
 
@@ -141,6 +141,20 @@ function handleVideoClick(event: MouseEvent) {
 | NOT_FOUND | Camera not found or no PTZ | Show message |
 | FORBIDDEN | No permission | Show access denied |
 | VALIDATION_ERROR | Empty camera ID | Fix input |
+
+## Fisheye Camera Exclusion
+
+**IMPORTANT:** Fisheye cameras report `capabilities.ptz.capable: true` but are NOT true PTZ cameras.
+Always exclude fisheye cameras when checking PTZ capability:
+
+```typescript
+const isPtzCapable = computed(() => {
+  const ptz = camera.capabilities?.ptz
+  return ptz?.capable === true && ptz?.fisheye !== true
+})
+```
+
+Also check `effectivePermissions.controlPTZ` to verify the user has permission to move the camera.
 
 ---
 

--- a/docs/ai-reference/AI-PTZ.md
+++ b/docs/ai-reference/AI-PTZ.md
@@ -1,6 +1,6 @@
 # PTZ Camera Controls
 
-> **Version:** 0.3.96
+> **Version:** 0.3.97
 >
 > Pan/Tilt/Zoom camera control: position, movement, presets, and automation.
 

--- a/docs/ai-reference/AI-PTZ.md
+++ b/docs/ai-reference/AI-PTZ.md
@@ -1,6 +1,6 @@
 # PTZ Camera Controls
 
-> **Version:** 0.3.95
+> **Version:** 0.3.96
 >
 > Pan/Tilt/Zoom camera control: position, movement, presets, and automation.
 

--- a/docs/ai-reference/AI-SETUP.md
+++ b/docs/ai-reference/AI-SETUP.md
@@ -1,6 +1,6 @@
 # Vue 3 Application Setup - EEN API Toolkit
 
-> **Version:** 0.3.94
+> **Version:** 0.3.95
 >
 > Complete guide for setting up a Vue 3 application with the een-api-toolkit.
 > Load this document when creating a new project or troubleshooting setup issues.

--- a/docs/ai-reference/AI-SETUP.md
+++ b/docs/ai-reference/AI-SETUP.md
@@ -1,6 +1,6 @@
 # Vue 3 Application Setup - EEN API Toolkit
 
-> **Version:** 0.3.93
+> **Version:** 0.3.94
 >
 > Complete guide for setting up a Vue 3 application with the een-api-toolkit.
 > Load this document when creating a new project or troubleshooting setup issues.

--- a/docs/ai-reference/AI-SETUP.md
+++ b/docs/ai-reference/AI-SETUP.md
@@ -1,6 +1,6 @@
 # Vue 3 Application Setup - EEN API Toolkit
 
-> **Version:** 0.3.91
+> **Version:** 0.3.92
 >
 > Complete guide for setting up a Vue 3 application with the een-api-toolkit.
 > Load this document when creating a new project or troubleshooting setup issues.

--- a/docs/ai-reference/AI-SETUP.md
+++ b/docs/ai-reference/AI-SETUP.md
@@ -1,6 +1,6 @@
 # Vue 3 Application Setup - EEN API Toolkit
 
-> **Version:** 0.3.92
+> **Version:** 0.3.93
 >
 > Complete guide for setting up a Vue 3 application with the een-api-toolkit.
 > Load this document when creating a new project or troubleshooting setup issues.

--- a/docs/ai-reference/AI-SETUP.md
+++ b/docs/ai-reference/AI-SETUP.md
@@ -1,6 +1,6 @@
 # Vue 3 Application Setup - EEN API Toolkit
 
-> **Version:** 0.3.95
+> **Version:** 0.3.96
 >
 > Complete guide for setting up a Vue 3 application with the een-api-toolkit.
 > Load this document when creating a new project or troubleshooting setup issues.

--- a/docs/ai-reference/AI-SETUP.md
+++ b/docs/ai-reference/AI-SETUP.md
@@ -1,6 +1,6 @@
 # Vue 3 Application Setup - EEN API Toolkit
 
-> **Version:** 0.3.96
+> **Version:** 0.3.97
 >
 > Complete guide for setting up a Vue 3 application with the een-api-toolkit.
 > Load this document when creating a new project or troubleshooting setup issues.

--- a/docs/ai-reference/AI-USERS.md
+++ b/docs/ai-reference/AI-USERS.md
@@ -1,6 +1,6 @@
 # Users API - EEN API Toolkit
 
-> **Version:** 0.3.96
+> **Version:** 0.3.97
 >
 > Complete reference for user management.
 > Load this document when working with user data.

--- a/docs/ai-reference/AI-USERS.md
+++ b/docs/ai-reference/AI-USERS.md
@@ -1,6 +1,6 @@
 # Users API - EEN API Toolkit
 
-> **Version:** 0.3.91
+> **Version:** 0.3.92
 >
 > Complete reference for user management.
 > Load this document when working with user data.

--- a/docs/ai-reference/AI-USERS.md
+++ b/docs/ai-reference/AI-USERS.md
@@ -1,6 +1,6 @@
 # Users API - EEN API Toolkit
 
-> **Version:** 0.3.95
+> **Version:** 0.3.96
 >
 > Complete reference for user management.
 > Load this document when working with user data.

--- a/docs/ai-reference/AI-USERS.md
+++ b/docs/ai-reference/AI-USERS.md
@@ -1,6 +1,6 @@
 # Users API - EEN API Toolkit
 
-> **Version:** 0.3.92
+> **Version:** 0.3.93
 >
 > Complete reference for user management.
 > Load this document when working with user data.

--- a/docs/ai-reference/AI-USERS.md
+++ b/docs/ai-reference/AI-USERS.md
@@ -1,6 +1,6 @@
 # Users API - EEN API Toolkit
 
-> **Version:** 0.3.93
+> **Version:** 0.3.94
 >
 > Complete reference for user management.
 > Load this document when working with user data.

--- a/docs/ai-reference/AI-USERS.md
+++ b/docs/ai-reference/AI-USERS.md
@@ -1,6 +1,6 @@
 # Users API - EEN API Toolkit
 
-> **Version:** 0.3.94
+> **Version:** 0.3.95
 >
 > Complete reference for user management.
 > Load this document when working with user data.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,8 +1,8 @@
-**EEN API Toolkit v0.3.93**
+**EEN API Toolkit v0.3.94**
 
 ***
 
-# EEN API Toolkit v0.3.93
+# EEN API Toolkit v0.3.94
 
 ## Interfaces
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,8 +1,8 @@
-**EEN API Toolkit v0.3.92**
+**EEN API Toolkit v0.3.93**
 
 ***
 
-# EEN API Toolkit v0.3.92
+# EEN API Toolkit v0.3.93
 
 ## Interfaces
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,8 +1,8 @@
-**EEN API Toolkit v0.3.96**
+**EEN API Toolkit v0.3.97**
 
 ***
 
-# EEN API Toolkit v0.3.96
+# EEN API Toolkit v0.3.97
 
 ## Interfaces
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,8 +1,8 @@
-**EEN API Toolkit v0.3.91**
+**EEN API Toolkit v0.3.92**
 
 ***
 
-# EEN API Toolkit v0.3.91
+# EEN API Toolkit v0.3.92
 
 ## Interfaces
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,8 +1,8 @@
-**EEN API Toolkit v0.3.94**
+**EEN API Toolkit v0.3.95**
 
 ***
 
-# EEN API Toolkit v0.3.94
+# EEN API Toolkit v0.3.95
 
 ## Interfaces
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,8 +1,8 @@
-**EEN API Toolkit v0.3.95**
+**EEN API Toolkit v0.3.96**
 
 ***
 
-# EEN API Toolkit v0.3.95
+# EEN API Toolkit v0.3.96
 
 ## Interfaces
 

--- a/docs/api/functions/addFile.md
+++ b/docs/api/functions/addFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/addFile.md
+++ b/docs/api/functions/addFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/addFile.md
+++ b/docs/api/functions/addFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/addFile.md
+++ b/docs/api/functions/addFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/addFile.md
+++ b/docs/api/functions/addFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/addFile.md
+++ b/docs/api/functions/addFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/connectToEventSubscription.md
+++ b/docs/api/functions/connectToEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/connectToEventSubscription.md
+++ b/docs/api/functions/connectToEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/connectToEventSubscription.md
+++ b/docs/api/functions/connectToEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/connectToEventSubscription.md
+++ b/docs/api/functions/connectToEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/connectToEventSubscription.md
+++ b/docs/api/functions/connectToEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/connectToEventSubscription.md
+++ b/docs/api/functions/connectToEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/createEventSubscription.md
+++ b/docs/api/functions/createEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/createEventSubscription.md
+++ b/docs/api/functions/createEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/createEventSubscription.md
+++ b/docs/api/functions/createEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/createEventSubscription.md
+++ b/docs/api/functions/createEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/createEventSubscription.md
+++ b/docs/api/functions/createEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/createEventSubscription.md
+++ b/docs/api/functions/createEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/createExportJob.md
+++ b/docs/api/functions/createExportJob.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/createExportJob.md
+++ b/docs/api/functions/createExportJob.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/createExportJob.md
+++ b/docs/api/functions/createExportJob.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/createExportJob.md
+++ b/docs/api/functions/createExportJob.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/createExportJob.md
+++ b/docs/api/functions/createExportJob.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/createExportJob.md
+++ b/docs/api/functions/createExportJob.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/createLayout.md
+++ b/docs/api/functions/createLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/createLayout.md
+++ b/docs/api/functions/createLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/createLayout.md
+++ b/docs/api/functions/createLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/createLayout.md
+++ b/docs/api/functions/createLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/createLayout.md
+++ b/docs/api/functions/createLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/createLayout.md
+++ b/docs/api/functions/createLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteEventSubscription.md
+++ b/docs/api/functions/deleteEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteEventSubscription.md
+++ b/docs/api/functions/deleteEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteEventSubscription.md
+++ b/docs/api/functions/deleteEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteEventSubscription.md
+++ b/docs/api/functions/deleteEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteEventSubscription.md
+++ b/docs/api/functions/deleteEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteEventSubscription.md
+++ b/docs/api/functions/deleteEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteFile.md
+++ b/docs/api/functions/deleteFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteFile.md
+++ b/docs/api/functions/deleteFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteFile.md
+++ b/docs/api/functions/deleteFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteFile.md
+++ b/docs/api/functions/deleteFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteFile.md
+++ b/docs/api/functions/deleteFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteFile.md
+++ b/docs/api/functions/deleteFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteJob.md
+++ b/docs/api/functions/deleteJob.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteJob.md
+++ b/docs/api/functions/deleteJob.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteJob.md
+++ b/docs/api/functions/deleteJob.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteJob.md
+++ b/docs/api/functions/deleteJob.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteJob.md
+++ b/docs/api/functions/deleteJob.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteJob.md
+++ b/docs/api/functions/deleteJob.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteLayout.md
+++ b/docs/api/functions/deleteLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteLayout.md
+++ b/docs/api/functions/deleteLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteLayout.md
+++ b/docs/api/functions/deleteLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteLayout.md
+++ b/docs/api/functions/deleteLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteLayout.md
+++ b/docs/api/functions/deleteLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/deleteLayout.md
+++ b/docs/api/functions/deleteLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/downloadDownload.md
+++ b/docs/api/functions/downloadDownload.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/downloadDownload.md
+++ b/docs/api/functions/downloadDownload.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/downloadDownload.md
+++ b/docs/api/functions/downloadDownload.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/downloadDownload.md
+++ b/docs/api/functions/downloadDownload.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/downloadDownload.md
+++ b/docs/api/functions/downloadDownload.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/downloadDownload.md
+++ b/docs/api/functions/downloadDownload.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/downloadFile.md
+++ b/docs/api/functions/downloadFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/downloadFile.md
+++ b/docs/api/functions/downloadFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/downloadFile.md
+++ b/docs/api/functions/downloadFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/downloadFile.md
+++ b/docs/api/functions/downloadFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/downloadFile.md
+++ b/docs/api/functions/downloadFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/downloadFile.md
+++ b/docs/api/functions/downloadFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/eventTypeHasDataSchemas.md
+++ b/docs/api/functions/eventTypeHasDataSchemas.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/eventTypeHasDataSchemas.md
+++ b/docs/api/functions/eventTypeHasDataSchemas.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/eventTypeHasDataSchemas.md
+++ b/docs/api/functions/eventTypeHasDataSchemas.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/eventTypeHasDataSchemas.md
+++ b/docs/api/functions/eventTypeHasDataSchemas.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/eventTypeHasDataSchemas.md
+++ b/docs/api/functions/eventTypeHasDataSchemas.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/eventTypeHasDataSchemas.md
+++ b/docs/api/functions/eventTypeHasDataSchemas.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/formatTimestamp.md
+++ b/docs/api/functions/formatTimestamp.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/formatTimestamp.md
+++ b/docs/api/functions/formatTimestamp.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/formatTimestamp.md
+++ b/docs/api/functions/formatTimestamp.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/formatTimestamp.md
+++ b/docs/api/functions/formatTimestamp.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/formatTimestamp.md
+++ b/docs/api/functions/formatTimestamp.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/formatTimestamp.md
+++ b/docs/api/functions/formatTimestamp.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAccessToken.md
+++ b/docs/api/functions/getAccessToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAccessToken.md
+++ b/docs/api/functions/getAccessToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAccessToken.md
+++ b/docs/api/functions/getAccessToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAccessToken.md
+++ b/docs/api/functions/getAccessToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAccessToken.md
+++ b/docs/api/functions/getAccessToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAccessToken.md
+++ b/docs/api/functions/getAccessToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlert.md
+++ b/docs/api/functions/getAlert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlert.md
+++ b/docs/api/functions/getAlert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlert.md
+++ b/docs/api/functions/getAlert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlert.md
+++ b/docs/api/functions/getAlert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlert.md
+++ b/docs/api/functions/getAlert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlert.md
+++ b/docs/api/functions/getAlert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlertAction.md
+++ b/docs/api/functions/getAlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlertAction.md
+++ b/docs/api/functions/getAlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlertAction.md
+++ b/docs/api/functions/getAlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlertAction.md
+++ b/docs/api/functions/getAlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlertAction.md
+++ b/docs/api/functions/getAlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlertAction.md
+++ b/docs/api/functions/getAlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlertActionRule.md
+++ b/docs/api/functions/getAlertActionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlertActionRule.md
+++ b/docs/api/functions/getAlertActionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlertActionRule.md
+++ b/docs/api/functions/getAlertActionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlertActionRule.md
+++ b/docs/api/functions/getAlertActionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlertActionRule.md
+++ b/docs/api/functions/getAlertActionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlertActionRule.md
+++ b/docs/api/functions/getAlertActionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlertConditionRule.md
+++ b/docs/api/functions/getAlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlertConditionRule.md
+++ b/docs/api/functions/getAlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlertConditionRule.md
+++ b/docs/api/functions/getAlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlertConditionRule.md
+++ b/docs/api/functions/getAlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlertConditionRule.md
+++ b/docs/api/functions/getAlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAlertConditionRule.md
+++ b/docs/api/functions/getAlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAllDataSchemas.md
+++ b/docs/api/functions/getAllDataSchemas.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAllDataSchemas.md
+++ b/docs/api/functions/getAllDataSchemas.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAllDataSchemas.md
+++ b/docs/api/functions/getAllDataSchemas.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAllDataSchemas.md
+++ b/docs/api/functions/getAllDataSchemas.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAllDataSchemas.md
+++ b/docs/api/functions/getAllDataSchemas.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAllDataSchemas.md
+++ b/docs/api/functions/getAllDataSchemas.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAllKnownEventTypes.md
+++ b/docs/api/functions/getAllKnownEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAllKnownEventTypes.md
+++ b/docs/api/functions/getAllKnownEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAllKnownEventTypes.md
+++ b/docs/api/functions/getAllKnownEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAllKnownEventTypes.md
+++ b/docs/api/functions/getAllKnownEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAllKnownEventTypes.md
+++ b/docs/api/functions/getAllKnownEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAllKnownEventTypes.md
+++ b/docs/api/functions/getAllKnownEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAuthUrl.md
+++ b/docs/api/functions/getAuthUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAuthUrl.md
+++ b/docs/api/functions/getAuthUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAuthUrl.md
+++ b/docs/api/functions/getAuthUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAuthUrl.md
+++ b/docs/api/functions/getAuthUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAuthUrl.md
+++ b/docs/api/functions/getAuthUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getAuthUrl.md
+++ b/docs/api/functions/getAuthUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridge.md
+++ b/docs/api/functions/getBridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridge.md
+++ b/docs/api/functions/getBridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridge.md
+++ b/docs/api/functions/getBridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridge.md
+++ b/docs/api/functions/getBridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridge.md
+++ b/docs/api/functions/getBridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridge.md
+++ b/docs/api/functions/getBridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridges.md
+++ b/docs/api/functions/getBridges.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridges.md
+++ b/docs/api/functions/getBridges.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridges.md
+++ b/docs/api/functions/getBridges.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridges.md
+++ b/docs/api/functions/getBridges.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridges.md
+++ b/docs/api/functions/getBridges.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getBridges.md
+++ b/docs/api/functions/getBridges.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCamera.md
+++ b/docs/api/functions/getCamera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCamera.md
+++ b/docs/api/functions/getCamera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCamera.md
+++ b/docs/api/functions/getCamera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCamera.md
+++ b/docs/api/functions/getCamera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCamera.md
+++ b/docs/api/functions/getCamera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCamera.md
+++ b/docs/api/functions/getCamera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameraSettings.md
+++ b/docs/api/functions/getCameraSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameraSettings.md
+++ b/docs/api/functions/getCameraSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameraSettings.md
+++ b/docs/api/functions/getCameraSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameraSettings.md
+++ b/docs/api/functions/getCameraSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameraSettings.md
+++ b/docs/api/functions/getCameraSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameraSettings.md
+++ b/docs/api/functions/getCameraSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameraStatusString.md
+++ b/docs/api/functions/getCameraStatusString.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameraStatusString.md
+++ b/docs/api/functions/getCameraStatusString.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameraStatusString.md
+++ b/docs/api/functions/getCameraStatusString.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameraStatusString.md
+++ b/docs/api/functions/getCameraStatusString.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameraStatusString.md
+++ b/docs/api/functions/getCameraStatusString.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameraStatusString.md
+++ b/docs/api/functions/getCameraStatusString.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameras.md
+++ b/docs/api/functions/getCameras.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameras.md
+++ b/docs/api/functions/getCameras.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameras.md
+++ b/docs/api/functions/getCameras.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameras.md
+++ b/docs/api/functions/getCameras.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameras.md
+++ b/docs/api/functions/getCameras.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCameras.md
+++ b/docs/api/functions/getCameras.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getClientId.md
+++ b/docs/api/functions/getClientId.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getClientId.md
+++ b/docs/api/functions/getClientId.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getClientId.md
+++ b/docs/api/functions/getClientId.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getClientId.md
+++ b/docs/api/functions/getClientId.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getClientId.md
+++ b/docs/api/functions/getClientId.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getClientId.md
+++ b/docs/api/functions/getClientId.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getConfig.md
+++ b/docs/api/functions/getConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getConfig.md
+++ b/docs/api/functions/getConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getConfig.md
+++ b/docs/api/functions/getConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getConfig.md
+++ b/docs/api/functions/getConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getConfig.md
+++ b/docs/api/functions/getConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getConfig.md
+++ b/docs/api/functions/getConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCurrentUser.md
+++ b/docs/api/functions/getCurrentUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCurrentUser.md
+++ b/docs/api/functions/getCurrentUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCurrentUser.md
+++ b/docs/api/functions/getCurrentUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCurrentUser.md
+++ b/docs/api/functions/getCurrentUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCurrentUser.md
+++ b/docs/api/functions/getCurrentUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getCurrentUser.md
+++ b/docs/api/functions/getCurrentUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getDataSchemasForEventType.md
+++ b/docs/api/functions/getDataSchemasForEventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getDataSchemasForEventType.md
+++ b/docs/api/functions/getDataSchemasForEventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getDataSchemasForEventType.md
+++ b/docs/api/functions/getDataSchemasForEventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getDataSchemasForEventType.md
+++ b/docs/api/functions/getDataSchemasForEventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getDataSchemasForEventType.md
+++ b/docs/api/functions/getDataSchemasForEventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getDataSchemasForEventType.md
+++ b/docs/api/functions/getDataSchemasForEventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getDownload.md
+++ b/docs/api/functions/getDownload.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getDownload.md
+++ b/docs/api/functions/getDownload.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getDownload.md
+++ b/docs/api/functions/getDownload.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getDownload.md
+++ b/docs/api/functions/getDownload.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getDownload.md
+++ b/docs/api/functions/getDownload.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getDownload.md
+++ b/docs/api/functions/getDownload.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEvent.md
+++ b/docs/api/functions/getEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEvent.md
+++ b/docs/api/functions/getEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEvent.md
+++ b/docs/api/functions/getEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEvent.md
+++ b/docs/api/functions/getEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEvent.md
+++ b/docs/api/functions/getEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEvent.md
+++ b/docs/api/functions/getEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventAlertConditionRule.md
+++ b/docs/api/functions/getEventAlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventAlertConditionRule.md
+++ b/docs/api/functions/getEventAlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventAlertConditionRule.md
+++ b/docs/api/functions/getEventAlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventAlertConditionRule.md
+++ b/docs/api/functions/getEventAlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventAlertConditionRule.md
+++ b/docs/api/functions/getEventAlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventAlertConditionRule.md
+++ b/docs/api/functions/getEventAlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventAlertConditionRuleFieldValues.md
+++ b/docs/api/functions/getEventAlertConditionRuleFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventAlertConditionRuleFieldValues.md
+++ b/docs/api/functions/getEventAlertConditionRuleFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventAlertConditionRuleFieldValues.md
+++ b/docs/api/functions/getEventAlertConditionRuleFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventAlertConditionRuleFieldValues.md
+++ b/docs/api/functions/getEventAlertConditionRuleFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventAlertConditionRuleFieldValues.md
+++ b/docs/api/functions/getEventAlertConditionRuleFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventAlertConditionRuleFieldValues.md
+++ b/docs/api/functions/getEventAlertConditionRuleFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventMetrics.md
+++ b/docs/api/functions/getEventMetrics.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventMetrics.md
+++ b/docs/api/functions/getEventMetrics.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventMetrics.md
+++ b/docs/api/functions/getEventMetrics.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventMetrics.md
+++ b/docs/api/functions/getEventMetrics.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventMetrics.md
+++ b/docs/api/functions/getEventMetrics.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventMetrics.md
+++ b/docs/api/functions/getEventMetrics.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventSubscription.md
+++ b/docs/api/functions/getEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventSubscription.md
+++ b/docs/api/functions/getEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventSubscription.md
+++ b/docs/api/functions/getEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventSubscription.md
+++ b/docs/api/functions/getEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventSubscription.md
+++ b/docs/api/functions/getEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventSubscription.md
+++ b/docs/api/functions/getEventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventTypesForDataSchema.md
+++ b/docs/api/functions/getEventTypesForDataSchema.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventTypesForDataSchema.md
+++ b/docs/api/functions/getEventTypesForDataSchema.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventTypesForDataSchema.md
+++ b/docs/api/functions/getEventTypesForDataSchema.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventTypesForDataSchema.md
+++ b/docs/api/functions/getEventTypesForDataSchema.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventTypesForDataSchema.md
+++ b/docs/api/functions/getEventTypesForDataSchema.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getEventTypesForDataSchema.md
+++ b/docs/api/functions/getEventTypesForDataSchema.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getFile.md
+++ b/docs/api/functions/getFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getFile.md
+++ b/docs/api/functions/getFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getFile.md
+++ b/docs/api/functions/getFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getFile.md
+++ b/docs/api/functions/getFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getFile.md
+++ b/docs/api/functions/getFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getFile.md
+++ b/docs/api/functions/getFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getIncludeParameterForEventTypes.md
+++ b/docs/api/functions/getIncludeParameterForEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getIncludeParameterForEventTypes.md
+++ b/docs/api/functions/getIncludeParameterForEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getIncludeParameterForEventTypes.md
+++ b/docs/api/functions/getIncludeParameterForEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getIncludeParameterForEventTypes.md
+++ b/docs/api/functions/getIncludeParameterForEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getIncludeParameterForEventTypes.md
+++ b/docs/api/functions/getIncludeParameterForEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getIncludeParameterForEventTypes.md
+++ b/docs/api/functions/getIncludeParameterForEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getJob.md
+++ b/docs/api/functions/getJob.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getJob.md
+++ b/docs/api/functions/getJob.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getJob.md
+++ b/docs/api/functions/getJob.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getJob.md
+++ b/docs/api/functions/getJob.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getJob.md
+++ b/docs/api/functions/getJob.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getJob.md
+++ b/docs/api/functions/getJob.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayout.md
+++ b/docs/api/functions/getLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayout.md
+++ b/docs/api/functions/getLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayout.md
+++ b/docs/api/functions/getLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayout.md
+++ b/docs/api/functions/getLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayout.md
+++ b/docs/api/functions/getLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayout.md
+++ b/docs/api/functions/getLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayouts.md
+++ b/docs/api/functions/getLayouts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayouts.md
+++ b/docs/api/functions/getLayouts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayouts.md
+++ b/docs/api/functions/getLayouts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayouts.md
+++ b/docs/api/functions/getLayouts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayouts.md
+++ b/docs/api/functions/getLayouts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLayouts.md
+++ b/docs/api/functions/getLayouts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLiveImage.md
+++ b/docs/api/functions/getLiveImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLiveImage.md
+++ b/docs/api/functions/getLiveImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLiveImage.md
+++ b/docs/api/functions/getLiveImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLiveImage.md
+++ b/docs/api/functions/getLiveImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLiveImage.md
+++ b/docs/api/functions/getLiveImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getLiveImage.md
+++ b/docs/api/functions/getLiveImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getMediaSession.md
+++ b/docs/api/functions/getMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getMediaSession.md
+++ b/docs/api/functions/getMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getMediaSession.md
+++ b/docs/api/functions/getMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getMediaSession.md
+++ b/docs/api/functions/getMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getMediaSession.md
+++ b/docs/api/functions/getMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getMediaSession.md
+++ b/docs/api/functions/getMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getNotification.md
+++ b/docs/api/functions/getNotification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getNotification.md
+++ b/docs/api/functions/getNotification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getNotification.md
+++ b/docs/api/functions/getNotification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getNotification.md
+++ b/docs/api/functions/getNotification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getNotification.md
+++ b/docs/api/functions/getNotification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getNotification.md
+++ b/docs/api/functions/getNotification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getProxyUrl.md
+++ b/docs/api/functions/getProxyUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getProxyUrl.md
+++ b/docs/api/functions/getProxyUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getProxyUrl.md
+++ b/docs/api/functions/getProxyUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getProxyUrl.md
+++ b/docs/api/functions/getProxyUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getProxyUrl.md
+++ b/docs/api/functions/getProxyUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getProxyUrl.md
+++ b/docs/api/functions/getProxyUrl.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getPtzPosition.md
+++ b/docs/api/functions/getPtzPosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getPtzPosition.md
+++ b/docs/api/functions/getPtzPosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getPtzPosition.md
+++ b/docs/api/functions/getPtzPosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getPtzPosition.md
+++ b/docs/api/functions/getPtzPosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getPtzPosition.md
+++ b/docs/api/functions/getPtzPosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getPtzPosition.md
+++ b/docs/api/functions/getPtzPosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getPtzSettings.md
+++ b/docs/api/functions/getPtzSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getPtzSettings.md
+++ b/docs/api/functions/getPtzSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getPtzSettings.md
+++ b/docs/api/functions/getPtzSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getPtzSettings.md
+++ b/docs/api/functions/getPtzSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getPtzSettings.md
+++ b/docs/api/functions/getPtzSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getPtzSettings.md
+++ b/docs/api/functions/getPtzSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRecordedImage.md
+++ b/docs/api/functions/getRecordedImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRecordedImage.md
+++ b/docs/api/functions/getRecordedImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRecordedImage.md
+++ b/docs/api/functions/getRecordedImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRecordedImage.md
+++ b/docs/api/functions/getRecordedImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRecordedImage.md
+++ b/docs/api/functions/getRecordedImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRecordedImage.md
+++ b/docs/api/functions/getRecordedImage.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRedirectUri.md
+++ b/docs/api/functions/getRedirectUri.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRedirectUri.md
+++ b/docs/api/functions/getRedirectUri.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRedirectUri.md
+++ b/docs/api/functions/getRedirectUri.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRedirectUri.md
+++ b/docs/api/functions/getRedirectUri.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRedirectUri.md
+++ b/docs/api/functions/getRedirectUri.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getRedirectUri.md
+++ b/docs/api/functions/getRedirectUri.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getStorageStrategy.md
+++ b/docs/api/functions/getStorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getStorageStrategy.md
+++ b/docs/api/functions/getStorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getStorageStrategy.md
+++ b/docs/api/functions/getStorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getStorageStrategy.md
+++ b/docs/api/functions/getStorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getStorageStrategy.md
+++ b/docs/api/functions/getStorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getStorageStrategy.md
+++ b/docs/api/functions/getStorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUser.md
+++ b/docs/api/functions/getUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUser.md
+++ b/docs/api/functions/getUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUser.md
+++ b/docs/api/functions/getUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUser.md
+++ b/docs/api/functions/getUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUser.md
+++ b/docs/api/functions/getUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUser.md
+++ b/docs/api/functions/getUser.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUsers.md
+++ b/docs/api/functions/getUsers.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUsers.md
+++ b/docs/api/functions/getUsers.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUsers.md
+++ b/docs/api/functions/getUsers.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUsers.md
+++ b/docs/api/functions/getUsers.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUsers.md
+++ b/docs/api/functions/getUsers.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/getUsers.md
+++ b/docs/api/functions/getUsers.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/handleAuthCallback.md
+++ b/docs/api/functions/handleAuthCallback.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/handleAuthCallback.md
+++ b/docs/api/functions/handleAuthCallback.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/handleAuthCallback.md
+++ b/docs/api/functions/handleAuthCallback.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/handleAuthCallback.md
+++ b/docs/api/functions/handleAuthCallback.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/handleAuthCallback.md
+++ b/docs/api/functions/handleAuthCallback.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/handleAuthCallback.md
+++ b/docs/api/functions/handleAuthCallback.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/initEenToolkit.md
+++ b/docs/api/functions/initEenToolkit.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/initEenToolkit.md
+++ b/docs/api/functions/initEenToolkit.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/initEenToolkit.md
+++ b/docs/api/functions/initEenToolkit.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/initEenToolkit.md
+++ b/docs/api/functions/initEenToolkit.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/initEenToolkit.md
+++ b/docs/api/functions/initEenToolkit.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/initEenToolkit.md
+++ b/docs/api/functions/initEenToolkit.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/initMediaSession.md
+++ b/docs/api/functions/initMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/initMediaSession.md
+++ b/docs/api/functions/initMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/initMediaSession.md
+++ b/docs/api/functions/initMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/initMediaSession.md
+++ b/docs/api/functions/initMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/initMediaSession.md
+++ b/docs/api/functions/initMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/initMediaSession.md
+++ b/docs/api/functions/initMediaSession.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/isStatusObject.md
+++ b/docs/api/functions/isStatusObject.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/isStatusObject.md
+++ b/docs/api/functions/isStatusObject.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/isStatusObject.md
+++ b/docs/api/functions/isStatusObject.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/isStatusObject.md
+++ b/docs/api/functions/isStatusObject.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/isStatusObject.md
+++ b/docs/api/functions/isStatusObject.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/isStatusObject.md
+++ b/docs/api/functions/isStatusObject.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertActionRules.md
+++ b/docs/api/functions/listAlertActionRules.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertActionRules.md
+++ b/docs/api/functions/listAlertActionRules.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertActionRules.md
+++ b/docs/api/functions/listAlertActionRules.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertActionRules.md
+++ b/docs/api/functions/listAlertActionRules.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertActionRules.md
+++ b/docs/api/functions/listAlertActionRules.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertActionRules.md
+++ b/docs/api/functions/listAlertActionRules.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertActions.md
+++ b/docs/api/functions/listAlertActions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertActions.md
+++ b/docs/api/functions/listAlertActions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertActions.md
+++ b/docs/api/functions/listAlertActions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertActions.md
+++ b/docs/api/functions/listAlertActions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertActions.md
+++ b/docs/api/functions/listAlertActions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertActions.md
+++ b/docs/api/functions/listAlertActions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertConditionRules.md
+++ b/docs/api/functions/listAlertConditionRules.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertConditionRules.md
+++ b/docs/api/functions/listAlertConditionRules.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertConditionRules.md
+++ b/docs/api/functions/listAlertConditionRules.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertConditionRules.md
+++ b/docs/api/functions/listAlertConditionRules.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertConditionRules.md
+++ b/docs/api/functions/listAlertConditionRules.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertConditionRules.md
+++ b/docs/api/functions/listAlertConditionRules.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertTypes.md
+++ b/docs/api/functions/listAlertTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertTypes.md
+++ b/docs/api/functions/listAlertTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertTypes.md
+++ b/docs/api/functions/listAlertTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertTypes.md
+++ b/docs/api/functions/listAlertTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertTypes.md
+++ b/docs/api/functions/listAlertTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlertTypes.md
+++ b/docs/api/functions/listAlertTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlerts.md
+++ b/docs/api/functions/listAlerts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlerts.md
+++ b/docs/api/functions/listAlerts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlerts.md
+++ b/docs/api/functions/listAlerts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlerts.md
+++ b/docs/api/functions/listAlerts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlerts.md
+++ b/docs/api/functions/listAlerts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/listAlerts.md
+++ b/docs/api/functions/listAlerts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/listDownloads.md
+++ b/docs/api/functions/listDownloads.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/listDownloads.md
+++ b/docs/api/functions/listDownloads.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/listDownloads.md
+++ b/docs/api/functions/listDownloads.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/listDownloads.md
+++ b/docs/api/functions/listDownloads.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/listDownloads.md
+++ b/docs/api/functions/listDownloads.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/listDownloads.md
+++ b/docs/api/functions/listDownloads.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventAlertConditionRules.md
+++ b/docs/api/functions/listEventAlertConditionRules.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventAlertConditionRules.md
+++ b/docs/api/functions/listEventAlertConditionRules.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventAlertConditionRules.md
+++ b/docs/api/functions/listEventAlertConditionRules.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventAlertConditionRules.md
+++ b/docs/api/functions/listEventAlertConditionRules.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventAlertConditionRules.md
+++ b/docs/api/functions/listEventAlertConditionRules.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventAlertConditionRules.md
+++ b/docs/api/functions/listEventAlertConditionRules.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventFieldValues.md
+++ b/docs/api/functions/listEventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventFieldValues.md
+++ b/docs/api/functions/listEventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventFieldValues.md
+++ b/docs/api/functions/listEventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventFieldValues.md
+++ b/docs/api/functions/listEventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventFieldValues.md
+++ b/docs/api/functions/listEventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventFieldValues.md
+++ b/docs/api/functions/listEventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventSubscriptions.md
+++ b/docs/api/functions/listEventSubscriptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventSubscriptions.md
+++ b/docs/api/functions/listEventSubscriptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventSubscriptions.md
+++ b/docs/api/functions/listEventSubscriptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventSubscriptions.md
+++ b/docs/api/functions/listEventSubscriptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventSubscriptions.md
+++ b/docs/api/functions/listEventSubscriptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventSubscriptions.md
+++ b/docs/api/functions/listEventSubscriptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventTypes.md
+++ b/docs/api/functions/listEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventTypes.md
+++ b/docs/api/functions/listEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventTypes.md
+++ b/docs/api/functions/listEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventTypes.md
+++ b/docs/api/functions/listEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventTypes.md
+++ b/docs/api/functions/listEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEventTypes.md
+++ b/docs/api/functions/listEventTypes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEvents.md
+++ b/docs/api/functions/listEvents.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEvents.md
+++ b/docs/api/functions/listEvents.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEvents.md
+++ b/docs/api/functions/listEvents.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEvents.md
+++ b/docs/api/functions/listEvents.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEvents.md
+++ b/docs/api/functions/listEvents.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/listEvents.md
+++ b/docs/api/functions/listEvents.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/listFeeds.md
+++ b/docs/api/functions/listFeeds.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/listFeeds.md
+++ b/docs/api/functions/listFeeds.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/listFeeds.md
+++ b/docs/api/functions/listFeeds.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/listFeeds.md
+++ b/docs/api/functions/listFeeds.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/listFeeds.md
+++ b/docs/api/functions/listFeeds.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/listFeeds.md
+++ b/docs/api/functions/listFeeds.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/listFiles.md
+++ b/docs/api/functions/listFiles.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/listFiles.md
+++ b/docs/api/functions/listFiles.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/listFiles.md
+++ b/docs/api/functions/listFiles.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/listFiles.md
+++ b/docs/api/functions/listFiles.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/listFiles.md
+++ b/docs/api/functions/listFiles.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/listFiles.md
+++ b/docs/api/functions/listFiles.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/listJobs.md
+++ b/docs/api/functions/listJobs.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/listJobs.md
+++ b/docs/api/functions/listJobs.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/listJobs.md
+++ b/docs/api/functions/listJobs.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/listJobs.md
+++ b/docs/api/functions/listJobs.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/listJobs.md
+++ b/docs/api/functions/listJobs.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/listJobs.md
+++ b/docs/api/functions/listJobs.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/listMedia.md
+++ b/docs/api/functions/listMedia.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/listMedia.md
+++ b/docs/api/functions/listMedia.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/listMedia.md
+++ b/docs/api/functions/listMedia.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/listMedia.md
+++ b/docs/api/functions/listMedia.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/listMedia.md
+++ b/docs/api/functions/listMedia.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/listMedia.md
+++ b/docs/api/functions/listMedia.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/listNotifications.md
+++ b/docs/api/functions/listNotifications.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/listNotifications.md
+++ b/docs/api/functions/listNotifications.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/listNotifications.md
+++ b/docs/api/functions/listNotifications.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/listNotifications.md
+++ b/docs/api/functions/listNotifications.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/listNotifications.md
+++ b/docs/api/functions/listNotifications.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/listNotifications.md
+++ b/docs/api/functions/listNotifications.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/movePtz.md
+++ b/docs/api/functions/movePtz.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/movePtz.md
+++ b/docs/api/functions/movePtz.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/movePtz.md
+++ b/docs/api/functions/movePtz.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/movePtz.md
+++ b/docs/api/functions/movePtz.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/movePtz.md
+++ b/docs/api/functions/movePtz.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/movePtz.md
+++ b/docs/api/functions/movePtz.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/refreshToken.md
+++ b/docs/api/functions/refreshToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/refreshToken.md
+++ b/docs/api/functions/refreshToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/refreshToken.md
+++ b/docs/api/functions/refreshToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/refreshToken.md
+++ b/docs/api/functions/refreshToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/refreshToken.md
+++ b/docs/api/functions/refreshToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/refreshToken.md
+++ b/docs/api/functions/refreshToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/revokeToken.md
+++ b/docs/api/functions/revokeToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/revokeToken.md
+++ b/docs/api/functions/revokeToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/revokeToken.md
+++ b/docs/api/functions/revokeToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/revokeToken.md
+++ b/docs/api/functions/revokeToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/revokeToken.md
+++ b/docs/api/functions/revokeToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/revokeToken.md
+++ b/docs/api/functions/revokeToken.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/updateLayout.md
+++ b/docs/api/functions/updateLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/updateLayout.md
+++ b/docs/api/functions/updateLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/updateLayout.md
+++ b/docs/api/functions/updateLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/updateLayout.md
+++ b/docs/api/functions/updateLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/updateLayout.md
+++ b/docs/api/functions/updateLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/updateLayout.md
+++ b/docs/api/functions/updateLayout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/functions/updatePtzSettings.md
+++ b/docs/api/functions/updatePtzSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/functions/updatePtzSettings.md
+++ b/docs/api/functions/updatePtzSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/functions/updatePtzSettings.md
+++ b/docs/api/functions/updatePtzSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/functions/updatePtzSettings.md
+++ b/docs/api/functions/updatePtzSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/functions/updatePtzSettings.md
+++ b/docs/api/functions/updatePtzSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/functions/updatePtzSettings.md
+++ b/docs/api/functions/updatePtzSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Alert.md
+++ b/docs/api/interfaces/Alert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Alert.md
+++ b/docs/api/interfaces/Alert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Alert.md
+++ b/docs/api/interfaces/Alert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Alert.md
+++ b/docs/api/interfaces/Alert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Alert.md
+++ b/docs/api/interfaces/Alert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Alert.md
+++ b/docs/api/interfaces/Alert.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertAction.md
+++ b/docs/api/interfaces/AlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertAction.md
+++ b/docs/api/interfaces/AlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertAction.md
+++ b/docs/api/interfaces/AlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertAction.md
+++ b/docs/api/interfaces/AlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertAction.md
+++ b/docs/api/interfaces/AlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertAction.md
+++ b/docs/api/interfaces/AlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertActionRule.md
+++ b/docs/api/interfaces/AlertActionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertActionRule.md
+++ b/docs/api/interfaces/AlertActionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertActionRule.md
+++ b/docs/api/interfaces/AlertActionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertActionRule.md
+++ b/docs/api/interfaces/AlertActionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertActionRule.md
+++ b/docs/api/interfaces/AlertActionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertActionRule.md
+++ b/docs/api/interfaces/AlertActionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRule.md
+++ b/docs/api/interfaces/AlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRule.md
+++ b/docs/api/interfaces/AlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRule.md
+++ b/docs/api/interfaces/AlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRule.md
+++ b/docs/api/interfaces/AlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRule.md
+++ b/docs/api/interfaces/AlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRule.md
+++ b/docs/api/interfaces/AlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRuleAction.md
+++ b/docs/api/interfaces/AlertConditionRuleAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRuleAction.md
+++ b/docs/api/interfaces/AlertConditionRuleAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRuleAction.md
+++ b/docs/api/interfaces/AlertConditionRuleAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRuleAction.md
+++ b/docs/api/interfaces/AlertConditionRuleAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRuleAction.md
+++ b/docs/api/interfaces/AlertConditionRuleAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRuleAction.md
+++ b/docs/api/interfaces/AlertConditionRuleAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRuleActor.md
+++ b/docs/api/interfaces/AlertConditionRuleActor.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRuleActor.md
+++ b/docs/api/interfaces/AlertConditionRuleActor.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRuleActor.md
+++ b/docs/api/interfaces/AlertConditionRuleActor.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRuleActor.md
+++ b/docs/api/interfaces/AlertConditionRuleActor.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRuleActor.md
+++ b/docs/api/interfaces/AlertConditionRuleActor.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRuleActor.md
+++ b/docs/api/interfaces/AlertConditionRuleActor.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRuleInsights.md
+++ b/docs/api/interfaces/AlertConditionRuleInsights.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRuleInsights.md
+++ b/docs/api/interfaces/AlertConditionRuleInsights.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRuleInsights.md
+++ b/docs/api/interfaces/AlertConditionRuleInsights.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRuleInsights.md
+++ b/docs/api/interfaces/AlertConditionRuleInsights.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRuleInsights.md
+++ b/docs/api/interfaces/AlertConditionRuleInsights.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertConditionRuleInsights.md
+++ b/docs/api/interfaces/AlertConditionRuleInsights.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertType.md
+++ b/docs/api/interfaces/AlertType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertType.md
+++ b/docs/api/interfaces/AlertType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertType.md
+++ b/docs/api/interfaces/AlertType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertType.md
+++ b/docs/api/interfaces/AlertType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertType.md
+++ b/docs/api/interfaces/AlertType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AlertType.md
+++ b/docs/api/interfaces/AlertType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AutomationAlertAction.md
+++ b/docs/api/interfaces/AutomationAlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AutomationAlertAction.md
+++ b/docs/api/interfaces/AutomationAlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AutomationAlertAction.md
+++ b/docs/api/interfaces/AutomationAlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AutomationAlertAction.md
+++ b/docs/api/interfaces/AutomationAlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AutomationAlertAction.md
+++ b/docs/api/interfaces/AutomationAlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/AutomationAlertAction.md
+++ b/docs/api/interfaces/AutomationAlertAction.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Bridge.md
+++ b/docs/api/interfaces/Bridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Bridge.md
+++ b/docs/api/interfaces/Bridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Bridge.md
+++ b/docs/api/interfaces/Bridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Bridge.md
+++ b/docs/api/interfaces/Bridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Bridge.md
+++ b/docs/api/interfaces/Bridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Bridge.md
+++ b/docs/api/interfaces/Bridge.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDeviceInfo.md
+++ b/docs/api/interfaces/BridgeDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDeviceInfo.md
+++ b/docs/api/interfaces/BridgeDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDeviceInfo.md
+++ b/docs/api/interfaces/BridgeDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDeviceInfo.md
+++ b/docs/api/interfaces/BridgeDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDeviceInfo.md
+++ b/docs/api/interfaces/BridgeDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDeviceInfo.md
+++ b/docs/api/interfaces/BridgeDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDevicePosition.md
+++ b/docs/api/interfaces/BridgeDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDevicePosition.md
+++ b/docs/api/interfaces/BridgeDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDevicePosition.md
+++ b/docs/api/interfaces/BridgeDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDevicePosition.md
+++ b/docs/api/interfaces/BridgeDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDevicePosition.md
+++ b/docs/api/interfaces/BridgeDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeDevicePosition.md
+++ b/docs/api/interfaces/BridgeDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeNetworkInfo.md
+++ b/docs/api/interfaces/BridgeNetworkInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeNetworkInfo.md
+++ b/docs/api/interfaces/BridgeNetworkInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeNetworkInfo.md
+++ b/docs/api/interfaces/BridgeNetworkInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeNetworkInfo.md
+++ b/docs/api/interfaces/BridgeNetworkInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeNetworkInfo.md
+++ b/docs/api/interfaces/BridgeNetworkInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/BridgeNetworkInfo.md
+++ b/docs/api/interfaces/BridgeNetworkInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Camera.md
+++ b/docs/api/interfaces/Camera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Camera.md
+++ b/docs/api/interfaces/Camera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Camera.md
+++ b/docs/api/interfaces/Camera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Camera.md
+++ b/docs/api/interfaces/Camera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Camera.md
+++ b/docs/api/interfaces/Camera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 
@@ -263,13 +263,49 @@ Capabilities of the camera (returned when `include: ['capabilities']` is request
 
 Whether this camera supports PTZ controls
 
+##### ptz.fisheye?
+
+> `optional` **fisheye**: `boolean`
+
+Whether this is a fisheye camera (not a true PTZ camera)
+
+##### ptz.panTilt?
+
+> `optional` **panTilt**: `boolean`
+
+Whether the camera supports pan/tilt movements
+
+##### ptz.zoom?
+
+> `optional` **zoom**: `boolean`
+
+Whether the camera supports zoom
+
+##### ptz.positionMove?
+
+> `optional` **positionMove**: `boolean`
+
+Whether the camera supports absolute position moves
+
+##### ptz.directionMove?
+
+> `optional` **directionMove**: `boolean`
+
+Whether the camera supports directional moves
+
+##### ptz.centerOnMove?
+
+> `optional` **centerOnMove**: `boolean`
+
+Whether the camera supports center-on moves
+
 ***
 
 ### enabledAnalytics?
 
 > `optional` **enabledAnalytics**: `string`[]
 
-Defined in: [types/camera.ts:235](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L235)
+Defined in: [types/camera.ts:247](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L247)
 
 List of enabled analytics on this camera
 
@@ -279,7 +315,7 @@ List of enabled analytics on this camera
 
 > `optional` **recordingModes**: [`CameraRecordingModes`](CameraRecordingModes.md)
 
-Defined in: [types/camera.ts:237](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L237)
+Defined in: [types/camera.ts:249](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L249)
 
 Recording mode settings
 
@@ -289,7 +325,7 @@ Recording mode settings
 
 > `optional` **createdAt**: `string`
 
-Defined in: [types/camera.ts:239](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L239)
+Defined in: [types/camera.ts:251](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L251)
 
 ISO 8601 timestamp when the camera was created
 
@@ -299,6 +335,6 @@ ISO 8601 timestamp when the camera was created
 
 > `optional` **updatedAt**: `string`
 
-Defined in: [types/camera.ts:241](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L241)
+Defined in: [types/camera.ts:253](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L253)
 
 ISO 8601 timestamp when the camera was last updated

--- a/docs/api/interfaces/Camera.md
+++ b/docs/api/interfaces/Camera.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDeviceInfo.md
+++ b/docs/api/interfaces/CameraDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDeviceInfo.md
+++ b/docs/api/interfaces/CameraDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDeviceInfo.md
+++ b/docs/api/interfaces/CameraDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDeviceInfo.md
+++ b/docs/api/interfaces/CameraDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDeviceInfo.md
+++ b/docs/api/interfaces/CameraDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDeviceInfo.md
+++ b/docs/api/interfaces/CameraDeviceInfo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDevicePosition.md
+++ b/docs/api/interfaces/CameraDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDevicePosition.md
+++ b/docs/api/interfaces/CameraDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDevicePosition.md
+++ b/docs/api/interfaces/CameraDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDevicePosition.md
+++ b/docs/api/interfaces/CameraDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDevicePosition.md
+++ b/docs/api/interfaces/CameraDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraDevicePosition.md
+++ b/docs/api/interfaces/CameraDevicePosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRecordingModes.md
+++ b/docs/api/interfaces/CameraRecordingModes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRecordingModes.md
+++ b/docs/api/interfaces/CameraRecordingModes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRecordingModes.md
+++ b/docs/api/interfaces/CameraRecordingModes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRecordingModes.md
+++ b/docs/api/interfaces/CameraRecordingModes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRecordingModes.md
+++ b/docs/api/interfaces/CameraRecordingModes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRecordingModes.md
+++ b/docs/api/interfaces/CameraRecordingModes.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRtspConnectionSettings.md
+++ b/docs/api/interfaces/CameraRtspConnectionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRtspConnectionSettings.md
+++ b/docs/api/interfaces/CameraRtspConnectionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRtspConnectionSettings.md
+++ b/docs/api/interfaces/CameraRtspConnectionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRtspConnectionSettings.md
+++ b/docs/api/interfaces/CameraRtspConnectionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRtspConnectionSettings.md
+++ b/docs/api/interfaces/CameraRtspConnectionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraRtspConnectionSettings.md
+++ b/docs/api/interfaces/CameraRtspConnectionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettings.md
+++ b/docs/api/interfaces/CameraSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettings.md
+++ b/docs/api/interfaces/CameraSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettings.md
+++ b/docs/api/interfaces/CameraSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettings.md
+++ b/docs/api/interfaces/CameraSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: CameraSettings
 
-Defined in: [types/camera.ts:659](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L659)
+Defined in: [types/camera.ts:671](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L671)
 
 Top-level camera settings response from EEN API v3.0.
 
@@ -37,7 +37,7 @@ if (data) {
 
 > **data**: [`CameraSettingsData`](CameraSettingsData.md)
 
-Defined in: [types/camera.ts:661](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L661)
+Defined in: [types/camera.ts:673](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L673)
 
 The camera settings data
 
@@ -47,7 +47,7 @@ The camera settings data
 
 > `optional` **schema**: `object`
 
-Defined in: [types/camera.ts:663](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L663)
+Defined in: [types/camera.ts:675](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L675)
 
 JSON Schema describing all settings fields (when include contains 'schema')
 
@@ -57,6 +57,6 @@ JSON Schema describing all settings fields (when include contains 'schema')
 
 > `optional` **proposedValues**: `object`
 
-Defined in: [types/camera.ts:665](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L665)
+Defined in: [types/camera.ts:677](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L677)
 
 Proposed/recommended values (when include contains 'proposedValues')

--- a/docs/api/interfaces/CameraSettings.md
+++ b/docs/api/interfaces/CameraSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettings.md
+++ b/docs/api/interfaces/CameraSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsAnalog.md
+++ b/docs/api/interfaces/CameraSettingsAnalog.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsAnalog.md
+++ b/docs/api/interfaces/CameraSettingsAnalog.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsAnalog.md
+++ b/docs/api/interfaces/CameraSettingsAnalog.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsAnalog.md
+++ b/docs/api/interfaces/CameraSettingsAnalog.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: CameraSettingsAnalog
 
-Defined in: [types/camera.ts:521](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L521)
+Defined in: [types/camera.ts:533](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L533)
 
 Camera analog video settings.
 
@@ -20,7 +20,7 @@ Settings specific to analog cameras connected via encoders.
 
 > `optional` **videoStandard**: `string`
 
-Defined in: [types/camera.ts:523](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L523)
+Defined in: [types/camera.ts:535](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L535)
 
 Video standard (e.g., "NTSC", "PAL")
 
@@ -30,7 +30,7 @@ Video standard (e.g., "NTSC", "PAL")
 
 > `optional` **badSignalProtection**: `boolean`
 
-Defined in: [types/camera.ts:525](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L525)
+Defined in: [types/camera.ts:537](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L537)
 
 Whether bad signal protection is enabled
 
@@ -40,6 +40,6 @@ Whether bad signal protection is enabled
 
 > `optional` **badSignalDetected**: `boolean`
 
-Defined in: [types/camera.ts:527](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L527)
+Defined in: [types/camera.ts:539](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L539)
 
 Whether a bad signal has been detected

--- a/docs/api/interfaces/CameraSettingsAnalog.md
+++ b/docs/api/interfaces/CameraSettingsAnalog.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsAnalog.md
+++ b/docs/api/interfaces/CameraSettingsAnalog.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsAudio.md
+++ b/docs/api/interfaces/CameraSettingsAudio.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsAudio.md
+++ b/docs/api/interfaces/CameraSettingsAudio.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsAudio.md
+++ b/docs/api/interfaces/CameraSettingsAudio.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsAudio.md
+++ b/docs/api/interfaces/CameraSettingsAudio.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsAudio.md
+++ b/docs/api/interfaces/CameraSettingsAudio.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: CameraSettingsAudio
 
-Defined in: [types/camera.ts:462](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L462)
+Defined in: [types/camera.ts:474](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L474)
 
 Camera audio settings.
 
@@ -20,7 +20,7 @@ Controls microphone and audio input configuration.
 
 > `optional` **microphoneEnabled**: `boolean`
 
-Defined in: [types/camera.ts:464](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L464)
+Defined in: [types/camera.ts:476](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L476)
 
 Whether the microphone is enabled
 
@@ -30,6 +30,6 @@ Whether the microphone is enabled
 
 > `optional` **inputSourceId**: `string`
 
-Defined in: [types/camera.ts:466](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L466)
+Defined in: [types/camera.ts:478](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L478)
 
 Audio input source identifier

--- a/docs/api/interfaces/CameraSettingsAudio.md
+++ b/docs/api/interfaces/CameraSettingsAudio.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsCredentials.md
+++ b/docs/api/interfaces/CameraSettingsCredentials.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsCredentials.md
+++ b/docs/api/interfaces/CameraSettingsCredentials.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsCredentials.md
+++ b/docs/api/interfaces/CameraSettingsCredentials.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsCredentials.md
+++ b/docs/api/interfaces/CameraSettingsCredentials.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: CameraSettingsCredentials
 
-Defined in: [types/camera.ts:585](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L585)
+Defined in: [types/camera.ts:597](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L597)
 
 Camera credentials settings.
 
@@ -20,7 +20,7 @@ Credentials used to authenticate with the camera device.
 
 > `optional` **username**: `string`
 
-Defined in: [types/camera.ts:587](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L587)
+Defined in: [types/camera.ts:599](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L599)
 
 Username for camera authentication
 
@@ -30,6 +30,6 @@ Username for camera authentication
 
 > `optional` **password**: `string`
 
-Defined in: [types/camera.ts:589](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L589)
+Defined in: [types/camera.ts:601](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L601)
 
 Password for camera authentication (write-only, may not be returned)

--- a/docs/api/interfaces/CameraSettingsCredentials.md
+++ b/docs/api/interfaces/CameraSettingsCredentials.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsCredentials.md
+++ b/docs/api/interfaces/CameraSettingsCredentials.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsData.md
+++ b/docs/api/interfaces/CameraSettingsData.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsData.md
+++ b/docs/api/interfaces/CameraSettingsData.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsData.md
+++ b/docs/api/interfaces/CameraSettingsData.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsData.md
+++ b/docs/api/interfaces/CameraSettingsData.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsData.md
+++ b/docs/api/interfaces/CameraSettingsData.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: CameraSettingsData
 
-Defined in: [types/camera.ts:612](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L612)
+Defined in: [types/camera.ts:624](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L624)
 
 Aggregated camera settings data.
 
@@ -33,7 +33,7 @@ if (data) {
 
 > `optional` **timeZone**: `string`
 
-Defined in: [types/camera.ts:614](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L614)
+Defined in: [types/camera.ts:626](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L626)
 
 Camera timezone (IANA timezone name)
 
@@ -43,7 +43,7 @@ Camera timezone (IANA timezone name)
 
 > `optional` **rtsp**: [`CameraRtspConnectionSettings`](CameraRtspConnectionSettings.md)
 
-Defined in: [types/camera.ts:616](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L616)
+Defined in: [types/camera.ts:628](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L628)
 
 RTSP connection settings
 
@@ -53,7 +53,7 @@ RTSP connection settings
 
 > `optional` **credentials**: [`CameraSettingsCredentials`](CameraSettingsCredentials.md)
 
-Defined in: [types/camera.ts:618](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L618)
+Defined in: [types/camera.ts:630](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L630)
 
 Camera device credentials
 
@@ -63,7 +63,7 @@ Camera device credentials
 
 > `optional` **retention**: [`CameraSettingsRetention`](CameraSettingsRetention.md)
 
-Defined in: [types/camera.ts:620](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L620)
+Defined in: [types/camera.ts:632](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L632)
 
 Retention settings
 
@@ -73,7 +73,7 @@ Retention settings
 
 > `optional` **audio**: [`CameraSettingsAudio`](CameraSettingsAudio.md)
 
-Defined in: [types/camera.ts:622](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L622)
+Defined in: [types/camera.ts:634](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L634)
 
 Audio settings
 
@@ -83,7 +83,7 @@ Audio settings
 
 > `optional` **previewVideo**: [`CameraSettingsPreviewVideo`](CameraSettingsPreviewVideo.md)
 
-Defined in: [types/camera.ts:624](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L624)
+Defined in: [types/camera.ts:636](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L636)
 
 Preview video stream settings
 
@@ -93,7 +93,7 @@ Preview video stream settings
 
 > `optional` **mainVideo**: [`CameraSettingsMainVideo`](CameraSettingsMainVideo.md)
 
-Defined in: [types/camera.ts:626](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L626)
+Defined in: [types/camera.ts:638](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L638)
 
 Main video stream settings
 
@@ -103,7 +103,7 @@ Main video stream settings
 
 > `optional` **analog**: [`CameraSettingsAnalog`](CameraSettingsAnalog.md)
 
-Defined in: [types/camera.ts:628](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L628)
+Defined in: [types/camera.ts:640](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L640)
 
 Analog video settings
 
@@ -113,7 +113,7 @@ Analog video settings
 
 > `optional` **operatingSettings**: [`CameraSettingsOperating`](CameraSettingsOperating.md)
 
-Defined in: [types/camera.ts:630](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L630)
+Defined in: [types/camera.ts:642](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L642)
 
 Operating on/off settings
 
@@ -123,6 +123,6 @@ Operating on/off settings
 
 > `optional` **talkdown**: [`CameraSettingsTalkdown`](CameraSettingsTalkdown.md)
 
-Defined in: [types/camera.ts:632](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L632)
+Defined in: [types/camera.ts:644](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L644)
 
 Talkdown (two-way audio) settings

--- a/docs/api/interfaces/CameraSettingsData.md
+++ b/docs/api/interfaces/CameraSettingsData.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsMainVideo.md
+++ b/docs/api/interfaces/CameraSettingsMainVideo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsMainVideo.md
+++ b/docs/api/interfaces/CameraSettingsMainVideo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsMainVideo.md
+++ b/docs/api/interfaces/CameraSettingsMainVideo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsMainVideo.md
+++ b/docs/api/interfaces/CameraSettingsMainVideo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsMainVideo.md
+++ b/docs/api/interfaces/CameraSettingsMainVideo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: CameraSettingsMainVideo
 
-Defined in: [types/camera.ts:498](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L498)
+Defined in: [types/camera.ts:510](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L510)
 
 Camera main video settings.
 
@@ -20,7 +20,7 @@ Configuration for the full-resolution main stream.
 
 > `optional` **transmitMode**: `string`
 
-Defined in: [types/camera.ts:500](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L500)
+Defined in: [types/camera.ts:512](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L512)
 
 Transmit mode (e.g., "always", "event")
 
@@ -30,7 +30,7 @@ Transmit mode (e.g., "always", "event")
 
 > `optional` **resolution**: `string`
 
-Defined in: [types/camera.ts:502](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L502)
+Defined in: [types/camera.ts:514](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L514)
 
 Resolution of the main stream
 
@@ -40,7 +40,7 @@ Resolution of the main stream
 
 > `optional` **quality**: `string`
 
-Defined in: [types/camera.ts:504](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L504)
+Defined in: [types/camera.ts:516](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L516)
 
 Quality setting for main stream
 
@@ -50,7 +50,7 @@ Quality setting for main stream
 
 > `optional` **kbpsFactor**: `number`
 
-Defined in: [types/camera.ts:506](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L506)
+Defined in: [types/camera.ts:518](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L518)
 
 Bitrate factor in kbps
 
@@ -60,7 +60,7 @@ Bitrate factor in kbps
 
 > `optional` **captureMode**: `string`
 
-Defined in: [types/camera.ts:508](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L508)
+Defined in: [types/camera.ts:520](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L520)
 
 Capture mode
 
@@ -70,6 +70,6 @@ Capture mode
 
 > `optional` **supportedResolutions**: `string`[]
 
-Defined in: [types/camera.ts:510](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L510)
+Defined in: [types/camera.ts:522](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L522)
 
 List of supported resolutions

--- a/docs/api/interfaces/CameraSettingsMainVideo.md
+++ b/docs/api/interfaces/CameraSettingsMainVideo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsOperating.md
+++ b/docs/api/interfaces/CameraSettingsOperating.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsOperating.md
+++ b/docs/api/interfaces/CameraSettingsOperating.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: CameraSettingsOperating
 
-Defined in: [types/camera.ts:553](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L553)
+Defined in: [types/camera.ts:565](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L565)
 
 Camera operating settings.
 
@@ -20,7 +20,7 @@ Controls whether the camera is on or off, with optional scheduled overrides.
 
 > `optional` **on**: `boolean`
 
-Defined in: [types/camera.ts:555](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L555)
+Defined in: [types/camera.ts:567](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L567)
 
 Whether the camera is currently on
 
@@ -30,6 +30,6 @@ Whether the camera is currently on
 
 > `optional` **scheduledOverride**: [`CameraSettingsScheduledOverride`](CameraSettingsScheduledOverride.md) \| `null`
 
-Defined in: [types/camera.ts:557](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L557)
+Defined in: [types/camera.ts:569](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L569)
 
 Optional scheduled override for on/off state

--- a/docs/api/interfaces/CameraSettingsOperating.md
+++ b/docs/api/interfaces/CameraSettingsOperating.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsOperating.md
+++ b/docs/api/interfaces/CameraSettingsOperating.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsOperating.md
+++ b/docs/api/interfaces/CameraSettingsOperating.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsOperating.md
+++ b/docs/api/interfaces/CameraSettingsOperating.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsPreviewVideo.md
+++ b/docs/api/interfaces/CameraSettingsPreviewVideo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsPreviewVideo.md
+++ b/docs/api/interfaces/CameraSettingsPreviewVideo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsPreviewVideo.md
+++ b/docs/api/interfaces/CameraSettingsPreviewVideo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsPreviewVideo.md
+++ b/docs/api/interfaces/CameraSettingsPreviewVideo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsPreviewVideo.md
+++ b/docs/api/interfaces/CameraSettingsPreviewVideo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsPreviewVideo.md
+++ b/docs/api/interfaces/CameraSettingsPreviewVideo.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: CameraSettingsPreviewVideo
 
-Defined in: [types/camera.ts:477](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L477)
+Defined in: [types/camera.ts:489](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L489)
 
 Camera preview video settings.
 
@@ -20,7 +20,7 @@ Configuration for the lower-resolution preview stream.
 
 > `optional` **transmitMode**: `string`
 
-Defined in: [types/camera.ts:479](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L479)
+Defined in: [types/camera.ts:491](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L491)
 
 Transmit mode (e.g., "always", "event")
 
@@ -30,7 +30,7 @@ Transmit mode (e.g., "always", "event")
 
 > `optional` **resolution**: `string`
 
-Defined in: [types/camera.ts:481](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L481)
+Defined in: [types/camera.ts:493](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L493)
 
 Resolution of the preview stream
 
@@ -40,7 +40,7 @@ Resolution of the preview stream
 
 > `optional` **intervalMs**: `number`
 
-Defined in: [types/camera.ts:483](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L483)
+Defined in: [types/camera.ts:495](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L495)
 
 Interval between preview frames in milliseconds
 
@@ -50,7 +50,7 @@ Interval between preview frames in milliseconds
 
 > `optional` **quality**: `string`
 
-Defined in: [types/camera.ts:485](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L485)
+Defined in: [types/camera.ts:497](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L497)
 
 Quality setting for preview stream
 
@@ -60,6 +60,6 @@ Quality setting for preview stream
 
 > `optional` **supportedResolutions**: `string`[]
 
-Defined in: [types/camera.ts:487](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L487)
+Defined in: [types/camera.ts:499](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L499)
 
 List of supported resolutions

--- a/docs/api/interfaces/CameraSettingsRetention.md
+++ b/docs/api/interfaces/CameraSettingsRetention.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsRetention.md
+++ b/docs/api/interfaces/CameraSettingsRetention.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsRetention.md
+++ b/docs/api/interfaces/CameraSettingsRetention.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsRetention.md
+++ b/docs/api/interfaces/CameraSettingsRetention.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsRetention.md
+++ b/docs/api/interfaces/CameraSettingsRetention.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsRetention.md
+++ b/docs/api/interfaces/CameraSettingsRetention.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: CameraSettingsRetention
 
-Defined in: [types/camera.ts:441](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L441)
+Defined in: [types/camera.ts:453](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L453)
 
 Camera retention settings.
 
@@ -20,7 +20,7 @@ Controls how long video data is retained in cloud and on-premise storage.
 
 > `optional` **cloudDays**: `number`
 
-Defined in: [types/camera.ts:443](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L443)
+Defined in: [types/camera.ts:455](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L455)
 
 Number of days to retain recordings in cloud
 
@@ -30,7 +30,7 @@ Number of days to retain recordings in cloud
 
 > `optional` **cloudPreviewOnly**: `boolean`
 
-Defined in: [types/camera.ts:445](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L445)
+Defined in: [types/camera.ts:457](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L457)
 
 Whether cloud stores only preview (lower resolution) video
 
@@ -40,7 +40,7 @@ Whether cloud stores only preview (lower resolution) video
 
 > `optional` **minimumOnPremiseDays**: `number`
 
-Defined in: [types/camera.ts:447](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L447)
+Defined in: [types/camera.ts:459](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L459)
 
 Minimum days to retain on the bridge
 
@@ -50,7 +50,7 @@ Minimum days to retain on the bridge
 
 > `optional` **maximumOnPremiseDays**: `number`
 
-Defined in: [types/camera.ts:449](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L449)
+Defined in: [types/camera.ts:461](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L461)
 
 Maximum days to retain on the bridge
 
@@ -60,6 +60,6 @@ Maximum days to retain on the bridge
 
 > `optional` **alwaysRecordingDays**: `number`
 
-Defined in: [types/camera.ts:451](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L451)
+Defined in: [types/camera.ts:463](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L463)
 
 Number of days to always record (regardless of motion)

--- a/docs/api/interfaces/CameraSettingsScheduledOverride.md
+++ b/docs/api/interfaces/CameraSettingsScheduledOverride.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsScheduledOverride.md
+++ b/docs/api/interfaces/CameraSettingsScheduledOverride.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsScheduledOverride.md
+++ b/docs/api/interfaces/CameraSettingsScheduledOverride.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsScheduledOverride.md
+++ b/docs/api/interfaces/CameraSettingsScheduledOverride.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsScheduledOverride.md
+++ b/docs/api/interfaces/CameraSettingsScheduledOverride.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: CameraSettingsScheduledOverride
 
-Defined in: [types/camera.ts:538](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L538)
+Defined in: [types/camera.ts:550](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L550)
 
 Scheduled override for camera operating settings.
 
@@ -20,7 +20,7 @@ Allows the camera to be turned on/off on a schedule.
 
 > `optional` **on**: `boolean`
 
-Defined in: [types/camera.ts:540](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L540)
+Defined in: [types/camera.ts:552](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L552)
 
 Whether the scheduled override is active
 
@@ -30,6 +30,6 @@ Whether the scheduled override is active
 
 > `optional` **schedule**: `string`
 
-Defined in: [types/camera.ts:542](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L542)
+Defined in: [types/camera.ts:554](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L554)
 
 Schedule definition

--- a/docs/api/interfaces/CameraSettingsScheduledOverride.md
+++ b/docs/api/interfaces/CameraSettingsScheduledOverride.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsTalkdown.md
+++ b/docs/api/interfaces/CameraSettingsTalkdown.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsTalkdown.md
+++ b/docs/api/interfaces/CameraSettingsTalkdown.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsTalkdown.md
+++ b/docs/api/interfaces/CameraSettingsTalkdown.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsTalkdown.md
+++ b/docs/api/interfaces/CameraSettingsTalkdown.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraSettingsTalkdown.md
+++ b/docs/api/interfaces/CameraSettingsTalkdown.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: CameraSettingsTalkdown
 
-Defined in: [types/camera.ts:568](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L568)
+Defined in: [types/camera.ts:580](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L580)
 
 Camera talkdown (two-way audio) settings.
 
@@ -20,7 +20,7 @@ Configuration for cameras with speaker/talkdown capability.
 
 > `optional` **protocol**: `string`
 
-Defined in: [types/camera.ts:570](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L570)
+Defined in: [types/camera.ts:582](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L582)
 
 Communication protocol for talkdown
 
@@ -30,7 +30,7 @@ Communication protocol for talkdown
 
 > `optional` **audioMode**: `string`
 
-Defined in: [types/camera.ts:572](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L572)
+Defined in: [types/camera.ts:584](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L584)
 
 Audio mode for talkdown
 
@@ -40,6 +40,6 @@ Audio mode for talkdown
 
 > `optional` **sipCredentials**: `object`
 
-Defined in: [types/camera.ts:574](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L574)
+Defined in: [types/camera.ts:586](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L586)
 
 SIP credentials for talkdown, if applicable

--- a/docs/api/interfaces/CameraSettingsTalkdown.md
+++ b/docs/api/interfaces/CameraSettingsTalkdown.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraShareDetails.md
+++ b/docs/api/interfaces/CameraShareDetails.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraShareDetails.md
+++ b/docs/api/interfaces/CameraShareDetails.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraShareDetails.md
+++ b/docs/api/interfaces/CameraShareDetails.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraShareDetails.md
+++ b/docs/api/interfaces/CameraShareDetails.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraShareDetails.md
+++ b/docs/api/interfaces/CameraShareDetails.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraShareDetails.md
+++ b/docs/api/interfaces/CameraShareDetails.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStatusCounts.md
+++ b/docs/api/interfaces/CameraStatusCounts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStatusCounts.md
+++ b/docs/api/interfaces/CameraStatusCounts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStatusCounts.md
+++ b/docs/api/interfaces/CameraStatusCounts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStatusCounts.md
+++ b/docs/api/interfaces/CameraStatusCounts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStatusCounts.md
+++ b/docs/api/interfaces/CameraStatusCounts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStatusCounts.md
+++ b/docs/api/interfaces/CameraStatusCounts.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStreamUrls.md
+++ b/docs/api/interfaces/CameraStreamUrls.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStreamUrls.md
+++ b/docs/api/interfaces/CameraStreamUrls.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStreamUrls.md
+++ b/docs/api/interfaces/CameraStreamUrls.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStreamUrls.md
+++ b/docs/api/interfaces/CameraStreamUrls.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStreamUrls.md
+++ b/docs/api/interfaces/CameraStreamUrls.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CameraStreamUrls.md
+++ b/docs/api/interfaces/CameraStreamUrls.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateEventSubscriptionParams.md
+++ b/docs/api/interfaces/CreateEventSubscriptionParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateEventSubscriptionParams.md
+++ b/docs/api/interfaces/CreateEventSubscriptionParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateEventSubscriptionParams.md
+++ b/docs/api/interfaces/CreateEventSubscriptionParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateEventSubscriptionParams.md
+++ b/docs/api/interfaces/CreateEventSubscriptionParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateEventSubscriptionParams.md
+++ b/docs/api/interfaces/CreateEventSubscriptionParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateEventSubscriptionParams.md
+++ b/docs/api/interfaces/CreateEventSubscriptionParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateExportParams.md
+++ b/docs/api/interfaces/CreateExportParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateExportParams.md
+++ b/docs/api/interfaces/CreateExportParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateExportParams.md
+++ b/docs/api/interfaces/CreateExportParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateExportParams.md
+++ b/docs/api/interfaces/CreateExportParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateExportParams.md
+++ b/docs/api/interfaces/CreateExportParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateExportParams.md
+++ b/docs/api/interfaces/CreateExportParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateFileParams.md
+++ b/docs/api/interfaces/CreateFileParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateFileParams.md
+++ b/docs/api/interfaces/CreateFileParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateFileParams.md
+++ b/docs/api/interfaces/CreateFileParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateFileParams.md
+++ b/docs/api/interfaces/CreateFileParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateFileParams.md
+++ b/docs/api/interfaces/CreateFileParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateFileParams.md
+++ b/docs/api/interfaces/CreateFileParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateLayoutParams.md
+++ b/docs/api/interfaces/CreateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateLayoutParams.md
+++ b/docs/api/interfaces/CreateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateLayoutParams.md
+++ b/docs/api/interfaces/CreateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateLayoutParams.md
+++ b/docs/api/interfaces/CreateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateLayoutParams.md
+++ b/docs/api/interfaces/CreateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/CreateLayoutParams.md
+++ b/docs/api/interfaces/CreateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Download.md
+++ b/docs/api/interfaces/Download.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Download.md
+++ b/docs/api/interfaces/Download.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Download.md
+++ b/docs/api/interfaces/Download.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Download.md
+++ b/docs/api/interfaces/Download.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Download.md
+++ b/docs/api/interfaces/Download.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Download.md
+++ b/docs/api/interfaces/Download.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/DownloadFileResult.md
+++ b/docs/api/interfaces/DownloadFileResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/DownloadFileResult.md
+++ b/docs/api/interfaces/DownloadFileResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/DownloadFileResult.md
+++ b/docs/api/interfaces/DownloadFileResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/DownloadFileResult.md
+++ b/docs/api/interfaces/DownloadFileResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/DownloadFileResult.md
+++ b/docs/api/interfaces/DownloadFileResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/DownloadFileResult.md
+++ b/docs/api/interfaces/DownloadFileResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenError.md
+++ b/docs/api/interfaces/EenError.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenError.md
+++ b/docs/api/interfaces/EenError.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenError.md
+++ b/docs/api/interfaces/EenError.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenError.md
+++ b/docs/api/interfaces/EenError.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenError.md
+++ b/docs/api/interfaces/EenError.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenError.md
+++ b/docs/api/interfaces/EenError.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenFile.md
+++ b/docs/api/interfaces/EenFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenFile.md
+++ b/docs/api/interfaces/EenFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenFile.md
+++ b/docs/api/interfaces/EenFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenFile.md
+++ b/docs/api/interfaces/EenFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenFile.md
+++ b/docs/api/interfaces/EenFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenFile.md
+++ b/docs/api/interfaces/EenFile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenToolkitConfig.md
+++ b/docs/api/interfaces/EenToolkitConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenToolkitConfig.md
+++ b/docs/api/interfaces/EenToolkitConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenToolkitConfig.md
+++ b/docs/api/interfaces/EenToolkitConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenToolkitConfig.md
+++ b/docs/api/interfaces/EenToolkitConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenToolkitConfig.md
+++ b/docs/api/interfaces/EenToolkitConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EenToolkitConfig.md
+++ b/docs/api/interfaces/EenToolkitConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Event.md
+++ b/docs/api/interfaces/Event.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Event.md
+++ b/docs/api/interfaces/Event.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Event.md
+++ b/docs/api/interfaces/Event.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Event.md
+++ b/docs/api/interfaces/Event.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Event.md
+++ b/docs/api/interfaces/Event.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Event.md
+++ b/docs/api/interfaces/Event.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventAlertConditionRule.md
+++ b/docs/api/interfaces/EventAlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventAlertConditionRule.md
+++ b/docs/api/interfaces/EventAlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventAlertConditionRule.md
+++ b/docs/api/interfaces/EventAlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventAlertConditionRule.md
+++ b/docs/api/interfaces/EventAlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventAlertConditionRule.md
+++ b/docs/api/interfaces/EventAlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventAlertConditionRule.md
+++ b/docs/api/interfaces/EventAlertConditionRule.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventAlertConditionRuleFieldValues.md
+++ b/docs/api/interfaces/EventAlertConditionRuleFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventAlertConditionRuleFieldValues.md
+++ b/docs/api/interfaces/EventAlertConditionRuleFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventAlertConditionRuleFieldValues.md
+++ b/docs/api/interfaces/EventAlertConditionRuleFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventAlertConditionRuleFieldValues.md
+++ b/docs/api/interfaces/EventAlertConditionRuleFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventAlertConditionRuleFieldValues.md
+++ b/docs/api/interfaces/EventAlertConditionRuleFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventAlertConditionRuleFieldValues.md
+++ b/docs/api/interfaces/EventAlertConditionRuleFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventData.md
+++ b/docs/api/interfaces/EventData.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventData.md
+++ b/docs/api/interfaces/EventData.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventData.md
+++ b/docs/api/interfaces/EventData.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventData.md
+++ b/docs/api/interfaces/EventData.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventData.md
+++ b/docs/api/interfaces/EventData.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventData.md
+++ b/docs/api/interfaces/EventData.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventFieldValues.md
+++ b/docs/api/interfaces/EventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventFieldValues.md
+++ b/docs/api/interfaces/EventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventFieldValues.md
+++ b/docs/api/interfaces/EventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventFieldValues.md
+++ b/docs/api/interfaces/EventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventFieldValues.md
+++ b/docs/api/interfaces/EventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventFieldValues.md
+++ b/docs/api/interfaces/EventFieldValues.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventFilter.md
+++ b/docs/api/interfaces/EventFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventFilter.md
+++ b/docs/api/interfaces/EventFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventFilter.md
+++ b/docs/api/interfaces/EventFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventFilter.md
+++ b/docs/api/interfaces/EventFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventFilter.md
+++ b/docs/api/interfaces/EventFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventFilter.md
+++ b/docs/api/interfaces/EventFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventMetric.md
+++ b/docs/api/interfaces/EventMetric.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventMetric.md
+++ b/docs/api/interfaces/EventMetric.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventMetric.md
+++ b/docs/api/interfaces/EventMetric.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventMetric.md
+++ b/docs/api/interfaces/EventMetric.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventMetric.md
+++ b/docs/api/interfaces/EventMetric.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventMetric.md
+++ b/docs/api/interfaces/EventMetric.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventResourceFilter.md
+++ b/docs/api/interfaces/EventResourceFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventResourceFilter.md
+++ b/docs/api/interfaces/EventResourceFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventResourceFilter.md
+++ b/docs/api/interfaces/EventResourceFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventResourceFilter.md
+++ b/docs/api/interfaces/EventResourceFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventResourceFilter.md
+++ b/docs/api/interfaces/EventResourceFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventResourceFilter.md
+++ b/docs/api/interfaces/EventResourceFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscription.md
+++ b/docs/api/interfaces/EventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscription.md
+++ b/docs/api/interfaces/EventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscription.md
+++ b/docs/api/interfaces/EventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscription.md
+++ b/docs/api/interfaces/EventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscription.md
+++ b/docs/api/interfaces/EventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscription.md
+++ b/docs/api/interfaces/EventSubscription.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionConfig.md
+++ b/docs/api/interfaces/EventSubscriptionConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionConfig.md
+++ b/docs/api/interfaces/EventSubscriptionConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionConfig.md
+++ b/docs/api/interfaces/EventSubscriptionConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionConfig.md
+++ b/docs/api/interfaces/EventSubscriptionConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionConfig.md
+++ b/docs/api/interfaces/EventSubscriptionConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionConfig.md
+++ b/docs/api/interfaces/EventSubscriptionConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionFilter.md
+++ b/docs/api/interfaces/EventSubscriptionFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionFilter.md
+++ b/docs/api/interfaces/EventSubscriptionFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionFilter.md
+++ b/docs/api/interfaces/EventSubscriptionFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionFilter.md
+++ b/docs/api/interfaces/EventSubscriptionFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionFilter.md
+++ b/docs/api/interfaces/EventSubscriptionFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventSubscriptionFilter.md
+++ b/docs/api/interfaces/EventSubscriptionFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventType.md
+++ b/docs/api/interfaces/EventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventType.md
+++ b/docs/api/interfaces/EventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventType.md
+++ b/docs/api/interfaces/EventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventType.md
+++ b/docs/api/interfaces/EventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventType.md
+++ b/docs/api/interfaces/EventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventType.md
+++ b/docs/api/interfaces/EventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventTypeFilter.md
+++ b/docs/api/interfaces/EventTypeFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventTypeFilter.md
+++ b/docs/api/interfaces/EventTypeFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventTypeFilter.md
+++ b/docs/api/interfaces/EventTypeFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventTypeFilter.md
+++ b/docs/api/interfaces/EventTypeFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventTypeFilter.md
+++ b/docs/api/interfaces/EventTypeFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/EventTypeFilter.md
+++ b/docs/api/interfaces/EventTypeFilter.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Feed.md
+++ b/docs/api/interfaces/Feed.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Feed.md
+++ b/docs/api/interfaces/Feed.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Feed.md
+++ b/docs/api/interfaces/Feed.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Feed.md
+++ b/docs/api/interfaces/Feed.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Feed.md
+++ b/docs/api/interfaces/Feed.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Feed.md
+++ b/docs/api/interfaces/Feed.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/FilterCreate.md
+++ b/docs/api/interfaces/FilterCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/FilterCreate.md
+++ b/docs/api/interfaces/FilterCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/FilterCreate.md
+++ b/docs/api/interfaces/FilterCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/FilterCreate.md
+++ b/docs/api/interfaces/FilterCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/FilterCreate.md
+++ b/docs/api/interfaces/FilterCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/FilterCreate.md
+++ b/docs/api/interfaces/FilterCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetAlertConditionRuleParams.md
+++ b/docs/api/interfaces/GetAlertConditionRuleParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetAlertConditionRuleParams.md
+++ b/docs/api/interfaces/GetAlertConditionRuleParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetAlertConditionRuleParams.md
+++ b/docs/api/interfaces/GetAlertConditionRuleParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetAlertConditionRuleParams.md
+++ b/docs/api/interfaces/GetAlertConditionRuleParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetAlertConditionRuleParams.md
+++ b/docs/api/interfaces/GetAlertConditionRuleParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetAlertConditionRuleParams.md
+++ b/docs/api/interfaces/GetAlertConditionRuleParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetAlertParams.md
+++ b/docs/api/interfaces/GetAlertParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetAlertParams.md
+++ b/docs/api/interfaces/GetAlertParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetAlertParams.md
+++ b/docs/api/interfaces/GetAlertParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetAlertParams.md
+++ b/docs/api/interfaces/GetAlertParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetAlertParams.md
+++ b/docs/api/interfaces/GetAlertParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetAlertParams.md
+++ b/docs/api/interfaces/GetAlertParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetBridgeParams.md
+++ b/docs/api/interfaces/GetBridgeParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetBridgeParams.md
+++ b/docs/api/interfaces/GetBridgeParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetBridgeParams.md
+++ b/docs/api/interfaces/GetBridgeParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetBridgeParams.md
+++ b/docs/api/interfaces/GetBridgeParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetBridgeParams.md
+++ b/docs/api/interfaces/GetBridgeParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetBridgeParams.md
+++ b/docs/api/interfaces/GetBridgeParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetCameraParams.md
+++ b/docs/api/interfaces/GetCameraParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetCameraParams.md
+++ b/docs/api/interfaces/GetCameraParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetCameraParams.md
+++ b/docs/api/interfaces/GetCameraParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetCameraParams.md
+++ b/docs/api/interfaces/GetCameraParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: GetCameraParams
 
-Defined in: [types/camera.ts:388](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L388)
+Defined in: [types/camera.ts:400](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L400)
 
 Parameters for getting a single camera.
 
@@ -33,7 +33,7 @@ const { data } = await getCamera('camera-123', {
 
 > `optional` **include**: `string`[]
 
-Defined in: [types/camera.ts:397](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L397)
+Defined in: [types/camera.ts:409](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L409)
 
 Additional fields to include in the response.
 Valid values: bridge, account, status, locationSummary, deviceAddress,

--- a/docs/api/interfaces/GetCameraParams.md
+++ b/docs/api/interfaces/GetCameraParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetCameraParams.md
+++ b/docs/api/interfaces/GetCameraParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetCameraSettingsParams.md
+++ b/docs/api/interfaces/GetCameraSettingsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetCameraSettingsParams.md
+++ b/docs/api/interfaces/GetCameraSettingsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetCameraSettingsParams.md
+++ b/docs/api/interfaces/GetCameraSettingsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetCameraSettingsParams.md
+++ b/docs/api/interfaces/GetCameraSettingsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: GetCameraSettingsParams
 
-Defined in: [types/camera.ts:428](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L428)
+Defined in: [types/camera.ts:440](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L440)
 
 Parameters for getting camera settings.
 
@@ -30,6 +30,6 @@ const { data } = await getCameraSettings('camera-123', {
 
 > `optional` **include**: [`CameraSettingsInclude`](../type-aliases/CameraSettingsInclude.md)[]
 
-Defined in: [types/camera.ts:430](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L430)
+Defined in: [types/camera.ts:442](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L442)
 
 Additional data to include: 'schema' and/or 'proposedValues'

--- a/docs/api/interfaces/GetCameraSettingsParams.md
+++ b/docs/api/interfaces/GetCameraSettingsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetCameraSettingsParams.md
+++ b/docs/api/interfaces/GetCameraSettingsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetDownloadParams.md
+++ b/docs/api/interfaces/GetDownloadParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetDownloadParams.md
+++ b/docs/api/interfaces/GetDownloadParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetDownloadParams.md
+++ b/docs/api/interfaces/GetDownloadParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetDownloadParams.md
+++ b/docs/api/interfaces/GetDownloadParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetDownloadParams.md
+++ b/docs/api/interfaces/GetDownloadParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetDownloadParams.md
+++ b/docs/api/interfaces/GetDownloadParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventAlertConditionRuleFieldValuesParams.md
+++ b/docs/api/interfaces/GetEventAlertConditionRuleFieldValuesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventAlertConditionRuleFieldValuesParams.md
+++ b/docs/api/interfaces/GetEventAlertConditionRuleFieldValuesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventAlertConditionRuleFieldValuesParams.md
+++ b/docs/api/interfaces/GetEventAlertConditionRuleFieldValuesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventAlertConditionRuleFieldValuesParams.md
+++ b/docs/api/interfaces/GetEventAlertConditionRuleFieldValuesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventAlertConditionRuleFieldValuesParams.md
+++ b/docs/api/interfaces/GetEventAlertConditionRuleFieldValuesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventAlertConditionRuleFieldValuesParams.md
+++ b/docs/api/interfaces/GetEventAlertConditionRuleFieldValuesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventMetricsParams.md
+++ b/docs/api/interfaces/GetEventMetricsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventMetricsParams.md
+++ b/docs/api/interfaces/GetEventMetricsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventMetricsParams.md
+++ b/docs/api/interfaces/GetEventMetricsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventMetricsParams.md
+++ b/docs/api/interfaces/GetEventMetricsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventMetricsParams.md
+++ b/docs/api/interfaces/GetEventMetricsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventMetricsParams.md
+++ b/docs/api/interfaces/GetEventMetricsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventParams.md
+++ b/docs/api/interfaces/GetEventParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventParams.md
+++ b/docs/api/interfaces/GetEventParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventParams.md
+++ b/docs/api/interfaces/GetEventParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventParams.md
+++ b/docs/api/interfaces/GetEventParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventParams.md
+++ b/docs/api/interfaces/GetEventParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetEventParams.md
+++ b/docs/api/interfaces/GetEventParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetFileParams.md
+++ b/docs/api/interfaces/GetFileParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetFileParams.md
+++ b/docs/api/interfaces/GetFileParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetFileParams.md
+++ b/docs/api/interfaces/GetFileParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetFileParams.md
+++ b/docs/api/interfaces/GetFileParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetFileParams.md
+++ b/docs/api/interfaces/GetFileParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetFileParams.md
+++ b/docs/api/interfaces/GetFileParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetJobParams.md
+++ b/docs/api/interfaces/GetJobParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetJobParams.md
+++ b/docs/api/interfaces/GetJobParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetJobParams.md
+++ b/docs/api/interfaces/GetJobParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetJobParams.md
+++ b/docs/api/interfaces/GetJobParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetJobParams.md
+++ b/docs/api/interfaces/GetJobParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetJobParams.md
+++ b/docs/api/interfaces/GetJobParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLayoutParams.md
+++ b/docs/api/interfaces/GetLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLayoutParams.md
+++ b/docs/api/interfaces/GetLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLayoutParams.md
+++ b/docs/api/interfaces/GetLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLayoutParams.md
+++ b/docs/api/interfaces/GetLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLayoutParams.md
+++ b/docs/api/interfaces/GetLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLayoutParams.md
+++ b/docs/api/interfaces/GetLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLiveImageParams.md
+++ b/docs/api/interfaces/GetLiveImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLiveImageParams.md
+++ b/docs/api/interfaces/GetLiveImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLiveImageParams.md
+++ b/docs/api/interfaces/GetLiveImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLiveImageParams.md
+++ b/docs/api/interfaces/GetLiveImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLiveImageParams.md
+++ b/docs/api/interfaces/GetLiveImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetLiveImageParams.md
+++ b/docs/api/interfaces/GetLiveImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetRecordedImageParams.md
+++ b/docs/api/interfaces/GetRecordedImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetRecordedImageParams.md
+++ b/docs/api/interfaces/GetRecordedImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetRecordedImageParams.md
+++ b/docs/api/interfaces/GetRecordedImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetRecordedImageParams.md
+++ b/docs/api/interfaces/GetRecordedImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetRecordedImageParams.md
+++ b/docs/api/interfaces/GetRecordedImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetRecordedImageParams.md
+++ b/docs/api/interfaces/GetRecordedImageParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetUserParams.md
+++ b/docs/api/interfaces/GetUserParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetUserParams.md
+++ b/docs/api/interfaces/GetUserParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetUserParams.md
+++ b/docs/api/interfaces/GetUserParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetUserParams.md
+++ b/docs/api/interfaces/GetUserParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetUserParams.md
+++ b/docs/api/interfaces/GetUserParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/GetUserParams.md
+++ b/docs/api/interfaces/GetUserParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/HumanValidation.md
+++ b/docs/api/interfaces/HumanValidation.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/HumanValidation.md
+++ b/docs/api/interfaces/HumanValidation.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/HumanValidation.md
+++ b/docs/api/interfaces/HumanValidation.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/HumanValidation.md
+++ b/docs/api/interfaces/HumanValidation.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/HumanValidation.md
+++ b/docs/api/interfaces/HumanValidation.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/HumanValidation.md
+++ b/docs/api/interfaces/HumanValidation.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Job.md
+++ b/docs/api/interfaces/Job.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Job.md
+++ b/docs/api/interfaces/Job.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Job.md
+++ b/docs/api/interfaces/Job.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Job.md
+++ b/docs/api/interfaces/Job.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Job.md
+++ b/docs/api/interfaces/Job.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Job.md
+++ b/docs/api/interfaces/Job.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Layout.md
+++ b/docs/api/interfaces/Layout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Layout.md
+++ b/docs/api/interfaces/Layout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Layout.md
+++ b/docs/api/interfaces/Layout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Layout.md
+++ b/docs/api/interfaces/Layout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Layout.md
+++ b/docs/api/interfaces/Layout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Layout.md
+++ b/docs/api/interfaces/Layout.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPane.md
+++ b/docs/api/interfaces/LayoutPane.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPane.md
+++ b/docs/api/interfaces/LayoutPane.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPane.md
+++ b/docs/api/interfaces/LayoutPane.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPane.md
+++ b/docs/api/interfaces/LayoutPane.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPane.md
+++ b/docs/api/interfaces/LayoutPane.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPane.md
+++ b/docs/api/interfaces/LayoutPane.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPermissions.md
+++ b/docs/api/interfaces/LayoutPermissions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPermissions.md
+++ b/docs/api/interfaces/LayoutPermissions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPermissions.md
+++ b/docs/api/interfaces/LayoutPermissions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPermissions.md
+++ b/docs/api/interfaces/LayoutPermissions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPermissions.md
+++ b/docs/api/interfaces/LayoutPermissions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutPermissions.md
+++ b/docs/api/interfaces/LayoutPermissions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutSettings.md
+++ b/docs/api/interfaces/LayoutSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutSettings.md
+++ b/docs/api/interfaces/LayoutSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutSettings.md
+++ b/docs/api/interfaces/LayoutSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutSettings.md
+++ b/docs/api/interfaces/LayoutSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutSettings.md
+++ b/docs/api/interfaces/LayoutSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LayoutSettings.md
+++ b/docs/api/interfaces/LayoutSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertActionRulesParams.md
+++ b/docs/api/interfaces/ListAlertActionRulesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertActionRulesParams.md
+++ b/docs/api/interfaces/ListAlertActionRulesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertActionRulesParams.md
+++ b/docs/api/interfaces/ListAlertActionRulesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertActionRulesParams.md
+++ b/docs/api/interfaces/ListAlertActionRulesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertActionRulesParams.md
+++ b/docs/api/interfaces/ListAlertActionRulesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertActionRulesParams.md
+++ b/docs/api/interfaces/ListAlertActionRulesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertActionsParams.md
+++ b/docs/api/interfaces/ListAlertActionsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertActionsParams.md
+++ b/docs/api/interfaces/ListAlertActionsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertActionsParams.md
+++ b/docs/api/interfaces/ListAlertActionsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertActionsParams.md
+++ b/docs/api/interfaces/ListAlertActionsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertActionsParams.md
+++ b/docs/api/interfaces/ListAlertActionsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertActionsParams.md
+++ b/docs/api/interfaces/ListAlertActionsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertConditionRulesParams.md
+++ b/docs/api/interfaces/ListAlertConditionRulesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertConditionRulesParams.md
+++ b/docs/api/interfaces/ListAlertConditionRulesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertConditionRulesParams.md
+++ b/docs/api/interfaces/ListAlertConditionRulesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertConditionRulesParams.md
+++ b/docs/api/interfaces/ListAlertConditionRulesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertConditionRulesParams.md
+++ b/docs/api/interfaces/ListAlertConditionRulesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertConditionRulesParams.md
+++ b/docs/api/interfaces/ListAlertConditionRulesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertTypesParams.md
+++ b/docs/api/interfaces/ListAlertTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertTypesParams.md
+++ b/docs/api/interfaces/ListAlertTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertTypesParams.md
+++ b/docs/api/interfaces/ListAlertTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertTypesParams.md
+++ b/docs/api/interfaces/ListAlertTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertTypesParams.md
+++ b/docs/api/interfaces/ListAlertTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertTypesParams.md
+++ b/docs/api/interfaces/ListAlertTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertsParams.md
+++ b/docs/api/interfaces/ListAlertsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertsParams.md
+++ b/docs/api/interfaces/ListAlertsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertsParams.md
+++ b/docs/api/interfaces/ListAlertsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertsParams.md
+++ b/docs/api/interfaces/ListAlertsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertsParams.md
+++ b/docs/api/interfaces/ListAlertsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListAlertsParams.md
+++ b/docs/api/interfaces/ListAlertsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListBridgesParams.md
+++ b/docs/api/interfaces/ListBridgesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListBridgesParams.md
+++ b/docs/api/interfaces/ListBridgesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListBridgesParams.md
+++ b/docs/api/interfaces/ListBridgesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListBridgesParams.md
+++ b/docs/api/interfaces/ListBridgesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListBridgesParams.md
+++ b/docs/api/interfaces/ListBridgesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListBridgesParams.md
+++ b/docs/api/interfaces/ListBridgesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListCamerasParams.md
+++ b/docs/api/interfaces/ListCamerasParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListCamerasParams.md
+++ b/docs/api/interfaces/ListCamerasParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListCamerasParams.md
+++ b/docs/api/interfaces/ListCamerasParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListCamerasParams.md
+++ b/docs/api/interfaces/ListCamerasParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: ListCamerasParams
 
-Defined in: [types/camera.ts:280](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L280)
+Defined in: [types/camera.ts:292](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L292)
 
 Parameters for listing cameras.
 
@@ -49,7 +49,7 @@ const { data: filtered } = await getCameras({
 
 > `optional` **pageSize**: `number`
 
-Defined in: [types/camera.ts:283](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L283)
+Defined in: [types/camera.ts:295](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L295)
 
 Number of results per page (default: 100, max: 1000)
 
@@ -59,7 +59,7 @@ Number of results per page (default: 100, max: 1000)
 
 > `optional` **pageToken**: `string`
 
-Defined in: [types/camera.ts:285](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L285)
+Defined in: [types/camera.ts:297](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L297)
 
 Token for fetching a specific page
 
@@ -69,7 +69,7 @@ Token for fetching a specific page
 
 > `optional` **include**: `string`[]
 
-Defined in: [types/camera.ts:289](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L289)
+Defined in: [types/camera.ts:301](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L301)
 
 Additional fields to include in the response
 
@@ -79,7 +79,7 @@ Additional fields to include in the response
 
 > `optional` **sort**: `string`[]
 
-Defined in: [types/camera.ts:291](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L291)
+Defined in: [types/camera.ts:303](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L303)
 
 Fields to sort by (prefix with - for descending)
 
@@ -89,7 +89,7 @@ Fields to sort by (prefix with - for descending)
 
 > `optional` **locationId\_\_in**: `string`[]
 
-Defined in: [types/camera.ts:295](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L295)
+Defined in: [types/camera.ts:307](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L307)
 
 Filter by location IDs
 
@@ -99,7 +99,7 @@ Filter by location IDs
 
 > `optional` **bridgeId\_\_in**: `string`[]
 
-Defined in: [types/camera.ts:297](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L297)
+Defined in: [types/camera.ts:309](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L309)
 
 Filter by bridge IDs
 
@@ -109,7 +109,7 @@ Filter by bridge IDs
 
 > `optional` **multiCameraId**: `string`
 
-Defined in: [types/camera.ts:301](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L301)
+Defined in: [types/camera.ts:313](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L313)
 
 Filter by exact multi-camera ID
 
@@ -119,7 +119,7 @@ Filter by exact multi-camera ID
 
 > `optional` **multiCameraId\_\_ne**: `string`
 
-Defined in: [types/camera.ts:303](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L303)
+Defined in: [types/camera.ts:315](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L315)
 
 Filter by multi-camera ID not equal to
 
@@ -129,7 +129,7 @@ Filter by multi-camera ID not equal to
 
 > `optional` **multiCameraId\_\_in**: `string`[]
 
-Defined in: [types/camera.ts:305](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L305)
+Defined in: [types/camera.ts:317](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L317)
 
 Filter by multi-camera IDs (any match)
 
@@ -139,7 +139,7 @@ Filter by multi-camera IDs (any match)
 
 > `optional` **tags\_\_contains**: `string`[]
 
-Defined in: [types/camera.ts:309](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L309)
+Defined in: [types/camera.ts:321](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L321)
 
 Filter by tags (all tags must be present)
 
@@ -149,7 +149,7 @@ Filter by tags (all tags must be present)
 
 > `optional` **tags\_\_any**: `string`[]
 
-Defined in: [types/camera.ts:311](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L311)
+Defined in: [types/camera.ts:323](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L323)
 
 Filter by tags (any tag must be present)
 
@@ -159,7 +159,7 @@ Filter by tags (any tag must be present)
 
 > `optional` **packages\_\_contains**: `string`[]
 
-Defined in: [types/camera.ts:313](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L313)
+Defined in: [types/camera.ts:325](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L325)
 
 Filter by packages (all must be present)
 
@@ -169,7 +169,7 @@ Filter by packages (all must be present)
 
 > `optional` **name**: `string`
 
-Defined in: [types/camera.ts:317](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L317)
+Defined in: [types/camera.ts:329](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L329)
 
 Filter by exact name
 
@@ -179,7 +179,7 @@ Filter by exact name
 
 > `optional` **name\_\_contains**: `string`
 
-Defined in: [types/camera.ts:319](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L319)
+Defined in: [types/camera.ts:331](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L331)
 
 Filter by name containing substring (case-insensitive)
 
@@ -189,7 +189,7 @@ Filter by name containing substring (case-insensitive)
 
 > `optional` **name\_\_in**: `string`[]
 
-Defined in: [types/camera.ts:321](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L321)
+Defined in: [types/camera.ts:333](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L333)
 
 Filter by exact names (any match)
 
@@ -199,7 +199,7 @@ Filter by exact names (any match)
 
 > `optional` **id\_\_in**: `string`[]
 
-Defined in: [types/camera.ts:325](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L325)
+Defined in: [types/camera.ts:337](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L337)
 
 Filter by camera IDs
 
@@ -209,7 +209,7 @@ Filter by camera IDs
 
 > `optional` **id\_\_notIn**: `string`[]
 
-Defined in: [types/camera.ts:327](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L327)
+Defined in: [types/camera.ts:339](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L339)
 
 Exclude camera IDs
 
@@ -219,7 +219,7 @@ Exclude camera IDs
 
 > `optional` **id\_\_contains**: `string`
 
-Defined in: [types/camera.ts:329](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L329)
+Defined in: [types/camera.ts:341](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L341)
 
 Filter by ID containing substring
 
@@ -229,7 +229,7 @@ Filter by ID containing substring
 
 > `optional` **layoutId**: `string`
 
-Defined in: [types/camera.ts:333](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L333)
+Defined in: [types/camera.ts:345](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L345)
 
 Filter by layout ID
 
@@ -239,7 +239,7 @@ Filter by layout ID
 
 > `optional` **shared**: `boolean`
 
-Defined in: [types/camera.ts:337](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L337)
+Defined in: [types/camera.ts:349](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L349)
 
 Filter by shared status. Maps to `shareDetails.shared` in the API query.
 
@@ -249,7 +249,7 @@ Filter by shared status. Maps to `shareDetails.shared` in the API query.
 
 > `optional` **sharedCameraAccount**: `string`
 
-Defined in: [types/camera.ts:339](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L339)
+Defined in: [types/camera.ts:351](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L351)
 
 Filter by sharing account ID. Maps to `shareDetails.accountId` in the API query.
 
@@ -259,7 +259,7 @@ Filter by sharing account ID. Maps to `shareDetails.accountId` in the API query.
 
 > `optional` **firstResponder**: `boolean`
 
-Defined in: [types/camera.ts:341](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L341)
+Defined in: [types/camera.ts:353](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L353)
 
 Filter by first responder sharing. Maps to `shareDetails.firstResponder` in the API query.
 
@@ -269,7 +269,7 @@ Filter by first responder sharing. Maps to `shareDetails.firstResponder` in the 
 
 > `optional` **directToCloud**: `boolean`
 
-Defined in: [types/camera.ts:345](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L345)
+Defined in: [types/camera.ts:357](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L357)
 
 Filter by direct-to-cloud connection. Maps to `deviceInfo.directToCloud` in the API query.
 
@@ -279,7 +279,7 @@ Filter by direct-to-cloud connection. Maps to `deviceInfo.directToCloud` in the 
 
 > `optional` **speakerId\_\_in**: `string`[]
 
-Defined in: [types/camera.ts:349](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L349)
+Defined in: [types/camera.ts:361](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L361)
 
 Filter by speaker IDs
 
@@ -289,7 +289,7 @@ Filter by speaker IDs
 
 > `optional` **q**: `string`
 
-Defined in: [types/camera.ts:353](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L353)
+Defined in: [types/camera.ts:365](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L365)
 
 Full-text search query
 
@@ -299,7 +299,7 @@ Full-text search query
 
 > `optional` **qRelevance\_\_gte**: `number`
 
-Defined in: [types/camera.ts:355](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L355)
+Defined in: [types/camera.ts:367](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L367)
 
 Minimum search relevance score
 
@@ -309,7 +309,7 @@ Minimum search relevance score
 
 > `optional` **enabledAnalytics\_\_contains**: `string`[]
 
-Defined in: [types/camera.ts:359](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L359)
+Defined in: [types/camera.ts:371](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L371)
 
 Filter by enabled analytics (all must be present)
 
@@ -319,7 +319,7 @@ Filter by enabled analytics (all must be present)
 
 > `optional` **status\_\_in**: [`CameraStatus`](../type-aliases/CameraStatus.md)[]
 
-Defined in: [types/camera.ts:363](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L363)
+Defined in: [types/camera.ts:375](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L375)
 
 Filter by status values (any match)
 
@@ -329,6 +329,6 @@ Filter by status values (any match)
 
 > `optional` **status\_\_ne**: [`CameraStatus`](../type-aliases/CameraStatus.md)
 
-Defined in: [types/camera.ts:365](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L365)
+Defined in: [types/camera.ts:377](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L377)
 
 Filter by status not equal to

--- a/docs/api/interfaces/ListCamerasParams.md
+++ b/docs/api/interfaces/ListCamerasParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListCamerasParams.md
+++ b/docs/api/interfaces/ListCamerasParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListDownloadsParams.md
+++ b/docs/api/interfaces/ListDownloadsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListDownloadsParams.md
+++ b/docs/api/interfaces/ListDownloadsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListDownloadsParams.md
+++ b/docs/api/interfaces/ListDownloadsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListDownloadsParams.md
+++ b/docs/api/interfaces/ListDownloadsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListDownloadsParams.md
+++ b/docs/api/interfaces/ListDownloadsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListDownloadsParams.md
+++ b/docs/api/interfaces/ListDownloadsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventAlertConditionRulesParams.md
+++ b/docs/api/interfaces/ListEventAlertConditionRulesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventAlertConditionRulesParams.md
+++ b/docs/api/interfaces/ListEventAlertConditionRulesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventAlertConditionRulesParams.md
+++ b/docs/api/interfaces/ListEventAlertConditionRulesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventAlertConditionRulesParams.md
+++ b/docs/api/interfaces/ListEventAlertConditionRulesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventAlertConditionRulesParams.md
+++ b/docs/api/interfaces/ListEventAlertConditionRulesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventAlertConditionRulesParams.md
+++ b/docs/api/interfaces/ListEventAlertConditionRulesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventFieldValuesParams.md
+++ b/docs/api/interfaces/ListEventFieldValuesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventFieldValuesParams.md
+++ b/docs/api/interfaces/ListEventFieldValuesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventFieldValuesParams.md
+++ b/docs/api/interfaces/ListEventFieldValuesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventFieldValuesParams.md
+++ b/docs/api/interfaces/ListEventFieldValuesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventFieldValuesParams.md
+++ b/docs/api/interfaces/ListEventFieldValuesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventFieldValuesParams.md
+++ b/docs/api/interfaces/ListEventFieldValuesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventSubscriptionsParams.md
+++ b/docs/api/interfaces/ListEventSubscriptionsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventSubscriptionsParams.md
+++ b/docs/api/interfaces/ListEventSubscriptionsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventSubscriptionsParams.md
+++ b/docs/api/interfaces/ListEventSubscriptionsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventSubscriptionsParams.md
+++ b/docs/api/interfaces/ListEventSubscriptionsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventSubscriptionsParams.md
+++ b/docs/api/interfaces/ListEventSubscriptionsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventSubscriptionsParams.md
+++ b/docs/api/interfaces/ListEventSubscriptionsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventTypesParams.md
+++ b/docs/api/interfaces/ListEventTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventTypesParams.md
+++ b/docs/api/interfaces/ListEventTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventTypesParams.md
+++ b/docs/api/interfaces/ListEventTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventTypesParams.md
+++ b/docs/api/interfaces/ListEventTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventTypesParams.md
+++ b/docs/api/interfaces/ListEventTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventTypesParams.md
+++ b/docs/api/interfaces/ListEventTypesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventsParams.md
+++ b/docs/api/interfaces/ListEventsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventsParams.md
+++ b/docs/api/interfaces/ListEventsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventsParams.md
+++ b/docs/api/interfaces/ListEventsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventsParams.md
+++ b/docs/api/interfaces/ListEventsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventsParams.md
+++ b/docs/api/interfaces/ListEventsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListEventsParams.md
+++ b/docs/api/interfaces/ListEventsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsParams.md
+++ b/docs/api/interfaces/ListFeedsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsParams.md
+++ b/docs/api/interfaces/ListFeedsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsParams.md
+++ b/docs/api/interfaces/ListFeedsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsParams.md
+++ b/docs/api/interfaces/ListFeedsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsParams.md
+++ b/docs/api/interfaces/ListFeedsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsParams.md
+++ b/docs/api/interfaces/ListFeedsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsResult.md
+++ b/docs/api/interfaces/ListFeedsResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsResult.md
+++ b/docs/api/interfaces/ListFeedsResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsResult.md
+++ b/docs/api/interfaces/ListFeedsResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsResult.md
+++ b/docs/api/interfaces/ListFeedsResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsResult.md
+++ b/docs/api/interfaces/ListFeedsResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFeedsResult.md
+++ b/docs/api/interfaces/ListFeedsResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFilesParams.md
+++ b/docs/api/interfaces/ListFilesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFilesParams.md
+++ b/docs/api/interfaces/ListFilesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFilesParams.md
+++ b/docs/api/interfaces/ListFilesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFilesParams.md
+++ b/docs/api/interfaces/ListFilesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFilesParams.md
+++ b/docs/api/interfaces/ListFilesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListFilesParams.md
+++ b/docs/api/interfaces/ListFilesParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListJobsParams.md
+++ b/docs/api/interfaces/ListJobsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListJobsParams.md
+++ b/docs/api/interfaces/ListJobsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListJobsParams.md
+++ b/docs/api/interfaces/ListJobsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListJobsParams.md
+++ b/docs/api/interfaces/ListJobsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListJobsParams.md
+++ b/docs/api/interfaces/ListJobsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListJobsParams.md
+++ b/docs/api/interfaces/ListJobsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListLayoutsParams.md
+++ b/docs/api/interfaces/ListLayoutsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListLayoutsParams.md
+++ b/docs/api/interfaces/ListLayoutsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListLayoutsParams.md
+++ b/docs/api/interfaces/ListLayoutsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListLayoutsParams.md
+++ b/docs/api/interfaces/ListLayoutsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListLayoutsParams.md
+++ b/docs/api/interfaces/ListLayoutsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListLayoutsParams.md
+++ b/docs/api/interfaces/ListLayoutsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListMediaParams.md
+++ b/docs/api/interfaces/ListMediaParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListMediaParams.md
+++ b/docs/api/interfaces/ListMediaParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListMediaParams.md
+++ b/docs/api/interfaces/ListMediaParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListMediaParams.md
+++ b/docs/api/interfaces/ListMediaParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListMediaParams.md
+++ b/docs/api/interfaces/ListMediaParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListMediaParams.md
+++ b/docs/api/interfaces/ListMediaParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListNotificationsParams.md
+++ b/docs/api/interfaces/ListNotificationsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListNotificationsParams.md
+++ b/docs/api/interfaces/ListNotificationsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListNotificationsParams.md
+++ b/docs/api/interfaces/ListNotificationsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListNotificationsParams.md
+++ b/docs/api/interfaces/ListNotificationsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListNotificationsParams.md
+++ b/docs/api/interfaces/ListNotificationsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListNotificationsParams.md
+++ b/docs/api/interfaces/ListNotificationsParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListUsersParams.md
+++ b/docs/api/interfaces/ListUsersParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListUsersParams.md
+++ b/docs/api/interfaces/ListUsersParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListUsersParams.md
+++ b/docs/api/interfaces/ListUsersParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListUsersParams.md
+++ b/docs/api/interfaces/ListUsersParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListUsersParams.md
+++ b/docs/api/interfaces/ListUsersParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/ListUsersParams.md
+++ b/docs/api/interfaces/ListUsersParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LiveImageResult.md
+++ b/docs/api/interfaces/LiveImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LiveImageResult.md
+++ b/docs/api/interfaces/LiveImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LiveImageResult.md
+++ b/docs/api/interfaces/LiveImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LiveImageResult.md
+++ b/docs/api/interfaces/LiveImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LiveImageResult.md
+++ b/docs/api/interfaces/LiveImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/LiveImageResult.md
+++ b/docs/api/interfaces/LiveImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaInterval.md
+++ b/docs/api/interfaces/MediaInterval.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaInterval.md
+++ b/docs/api/interfaces/MediaInterval.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaInterval.md
+++ b/docs/api/interfaces/MediaInterval.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaInterval.md
+++ b/docs/api/interfaces/MediaInterval.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaInterval.md
+++ b/docs/api/interfaces/MediaInterval.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaInterval.md
+++ b/docs/api/interfaces/MediaInterval.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResponse.md
+++ b/docs/api/interfaces/MediaSessionResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResponse.md
+++ b/docs/api/interfaces/MediaSessionResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResponse.md
+++ b/docs/api/interfaces/MediaSessionResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResponse.md
+++ b/docs/api/interfaces/MediaSessionResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResponse.md
+++ b/docs/api/interfaces/MediaSessionResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResponse.md
+++ b/docs/api/interfaces/MediaSessionResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResult.md
+++ b/docs/api/interfaces/MediaSessionResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResult.md
+++ b/docs/api/interfaces/MediaSessionResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResult.md
+++ b/docs/api/interfaces/MediaSessionResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResult.md
+++ b/docs/api/interfaces/MediaSessionResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResult.md
+++ b/docs/api/interfaces/MediaSessionResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/MediaSessionResult.md
+++ b/docs/api/interfaces/MediaSessionResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Notification.md
+++ b/docs/api/interfaces/Notification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Notification.md
+++ b/docs/api/interfaces/Notification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Notification.md
+++ b/docs/api/interfaces/Notification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Notification.md
+++ b/docs/api/interfaces/Notification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Notification.md
+++ b/docs/api/interfaces/Notification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/Notification.md
+++ b/docs/api/interfaces/Notification.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/NotificationSettings.md
+++ b/docs/api/interfaces/NotificationSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/NotificationSettings.md
+++ b/docs/api/interfaces/NotificationSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/NotificationSettings.md
+++ b/docs/api/interfaces/NotificationSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/NotificationSettings.md
+++ b/docs/api/interfaces/NotificationSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/NotificationSettings.md
+++ b/docs/api/interfaces/NotificationSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/NotificationSettings.md
+++ b/docs/api/interfaces/NotificationSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/OutputPortSettings.md
+++ b/docs/api/interfaces/OutputPortSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/OutputPortSettings.md
+++ b/docs/api/interfaces/OutputPortSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/OutputPortSettings.md
+++ b/docs/api/interfaces/OutputPortSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/OutputPortSettings.md
+++ b/docs/api/interfaces/OutputPortSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/OutputPortSettings.md
+++ b/docs/api/interfaces/OutputPortSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/OutputPortSettings.md
+++ b/docs/api/interfaces/OutputPortSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginatedResult.md
+++ b/docs/api/interfaces/PaginatedResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginatedResult.md
+++ b/docs/api/interfaces/PaginatedResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginatedResult.md
+++ b/docs/api/interfaces/PaginatedResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginatedResult.md
+++ b/docs/api/interfaces/PaginatedResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginatedResult.md
+++ b/docs/api/interfaces/PaginatedResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginatedResult.md
+++ b/docs/api/interfaces/PaginatedResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginationParams.md
+++ b/docs/api/interfaces/PaginationParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginationParams.md
+++ b/docs/api/interfaces/PaginationParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginationParams.md
+++ b/docs/api/interfaces/PaginationParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginationParams.md
+++ b/docs/api/interfaces/PaginationParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginationParams.md
+++ b/docs/api/interfaces/PaginationParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PaginationParams.md
+++ b/docs/api/interfaces/PaginationParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PlaySpeakerAudioClipSettings.md
+++ b/docs/api/interfaces/PlaySpeakerAudioClipSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PlaySpeakerAudioClipSettings.md
+++ b/docs/api/interfaces/PlaySpeakerAudioClipSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PlaySpeakerAudioClipSettings.md
+++ b/docs/api/interfaces/PlaySpeakerAudioClipSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PlaySpeakerAudioClipSettings.md
+++ b/docs/api/interfaces/PlaySpeakerAudioClipSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PlaySpeakerAudioClipSettings.md
+++ b/docs/api/interfaces/PlaySpeakerAudioClipSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PlaySpeakerAudioClipSettings.md
+++ b/docs/api/interfaces/PlaySpeakerAudioClipSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzCenterOnMove.md
+++ b/docs/api/interfaces/PtzCenterOnMove.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzCenterOnMove.md
+++ b/docs/api/interfaces/PtzCenterOnMove.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzCenterOnMove.md
+++ b/docs/api/interfaces/PtzCenterOnMove.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzCenterOnMove.md
+++ b/docs/api/interfaces/PtzCenterOnMove.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzCenterOnMove.md
+++ b/docs/api/interfaces/PtzCenterOnMove.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzCenterOnMove.md
+++ b/docs/api/interfaces/PtzCenterOnMove.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzDirectionMove.md
+++ b/docs/api/interfaces/PtzDirectionMove.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzDirectionMove.md
+++ b/docs/api/interfaces/PtzDirectionMove.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzDirectionMove.md
+++ b/docs/api/interfaces/PtzDirectionMove.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzDirectionMove.md
+++ b/docs/api/interfaces/PtzDirectionMove.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzDirectionMove.md
+++ b/docs/api/interfaces/PtzDirectionMove.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzDirectionMove.md
+++ b/docs/api/interfaces/PtzDirectionMove.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzPosition.md
+++ b/docs/api/interfaces/PtzPosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzPosition.md
+++ b/docs/api/interfaces/PtzPosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzPosition.md
+++ b/docs/api/interfaces/PtzPosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzPosition.md
+++ b/docs/api/interfaces/PtzPosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzPosition.md
+++ b/docs/api/interfaces/PtzPosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzPosition.md
+++ b/docs/api/interfaces/PtzPosition.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzPositionMove.md
+++ b/docs/api/interfaces/PtzPositionMove.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzPositionMove.md
+++ b/docs/api/interfaces/PtzPositionMove.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzPositionMove.md
+++ b/docs/api/interfaces/PtzPositionMove.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzPositionMove.md
+++ b/docs/api/interfaces/PtzPositionMove.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzPositionMove.md
+++ b/docs/api/interfaces/PtzPositionMove.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzPositionMove.md
+++ b/docs/api/interfaces/PtzPositionMove.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzPositionResponse.md
+++ b/docs/api/interfaces/PtzPositionResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzPositionResponse.md
+++ b/docs/api/interfaces/PtzPositionResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzPositionResponse.md
+++ b/docs/api/interfaces/PtzPositionResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzPositionResponse.md
+++ b/docs/api/interfaces/PtzPositionResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzPositionResponse.md
+++ b/docs/api/interfaces/PtzPositionResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzPositionResponse.md
+++ b/docs/api/interfaces/PtzPositionResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzPreset.md
+++ b/docs/api/interfaces/PtzPreset.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzPreset.md
+++ b/docs/api/interfaces/PtzPreset.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzPreset.md
+++ b/docs/api/interfaces/PtzPreset.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzPreset.md
+++ b/docs/api/interfaces/PtzPreset.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzPreset.md
+++ b/docs/api/interfaces/PtzPreset.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzPreset.md
+++ b/docs/api/interfaces/PtzPreset.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzSettings.md
+++ b/docs/api/interfaces/PtzSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzSettings.md
+++ b/docs/api/interfaces/PtzSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzSettings.md
+++ b/docs/api/interfaces/PtzSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzSettings.md
+++ b/docs/api/interfaces/PtzSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzSettings.md
+++ b/docs/api/interfaces/PtzSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzSettings.md
+++ b/docs/api/interfaces/PtzSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzSettingsUpdate.md
+++ b/docs/api/interfaces/PtzSettingsUpdate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzSettingsUpdate.md
+++ b/docs/api/interfaces/PtzSettingsUpdate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzSettingsUpdate.md
+++ b/docs/api/interfaces/PtzSettingsUpdate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzSettingsUpdate.md
+++ b/docs/api/interfaces/PtzSettingsUpdate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzSettingsUpdate.md
+++ b/docs/api/interfaces/PtzSettingsUpdate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/PtzSettingsUpdate.md
+++ b/docs/api/interfaces/PtzSettingsUpdate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/RecordedImageResult.md
+++ b/docs/api/interfaces/RecordedImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/RecordedImageResult.md
+++ b/docs/api/interfaces/RecordedImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/RecordedImageResult.md
+++ b/docs/api/interfaces/RecordedImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/RecordedImageResult.md
+++ b/docs/api/interfaces/RecordedImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/RecordedImageResult.md
+++ b/docs/api/interfaces/RecordedImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/RecordedImageResult.md
+++ b/docs/api/interfaces/RecordedImageResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnection.md
+++ b/docs/api/interfaces/SSEConnection.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnection.md
+++ b/docs/api/interfaces/SSEConnection.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnection.md
+++ b/docs/api/interfaces/SSEConnection.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnection.md
+++ b/docs/api/interfaces/SSEConnection.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnection.md
+++ b/docs/api/interfaces/SSEConnection.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnection.md
+++ b/docs/api/interfaces/SSEConnection.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnectionOptions.md
+++ b/docs/api/interfaces/SSEConnectionOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnectionOptions.md
+++ b/docs/api/interfaces/SSEConnectionOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnectionOptions.md
+++ b/docs/api/interfaces/SSEConnectionOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnectionOptions.md
+++ b/docs/api/interfaces/SSEConnectionOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnectionOptions.md
+++ b/docs/api/interfaces/SSEConnectionOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEConnectionOptions.md
+++ b/docs/api/interfaces/SSEConnectionOptions.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfig.md
+++ b/docs/api/interfaces/SSEDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfig.md
+++ b/docs/api/interfaces/SSEDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfig.md
+++ b/docs/api/interfaces/SSEDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfig.md
+++ b/docs/api/interfaces/SSEDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfig.md
+++ b/docs/api/interfaces/SSEDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfig.md
+++ b/docs/api/interfaces/SSEDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfigCreate.md
+++ b/docs/api/interfaces/SSEDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfigCreate.md
+++ b/docs/api/interfaces/SSEDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfigCreate.md
+++ b/docs/api/interfaces/SSEDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfigCreate.md
+++ b/docs/api/interfaces/SSEDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfigCreate.md
+++ b/docs/api/interfaces/SSEDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEDeliveryConfigCreate.md
+++ b/docs/api/interfaces/SSEDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEEvent.md
+++ b/docs/api/interfaces/SSEEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEEvent.md
+++ b/docs/api/interfaces/SSEEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEEvent.md
+++ b/docs/api/interfaces/SSEEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEEvent.md
+++ b/docs/api/interfaces/SSEEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEEvent.md
+++ b/docs/api/interfaces/SSEEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SSEEvent.md
+++ b/docs/api/interfaces/SSEEvent.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SlackSettings.md
+++ b/docs/api/interfaces/SlackSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SlackSettings.md
+++ b/docs/api/interfaces/SlackSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SlackSettings.md
+++ b/docs/api/interfaces/SlackSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SlackSettings.md
+++ b/docs/api/interfaces/SlackSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SlackSettings.md
+++ b/docs/api/interfaces/SlackSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SlackSettings.md
+++ b/docs/api/interfaces/SlackSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SmsSettings.md
+++ b/docs/api/interfaces/SmsSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SmsSettings.md
+++ b/docs/api/interfaces/SmsSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SmsSettings.md
+++ b/docs/api/interfaces/SmsSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SmsSettings.md
+++ b/docs/api/interfaces/SmsSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SmsSettings.md
+++ b/docs/api/interfaces/SmsSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SmsSettings.md
+++ b/docs/api/interfaces/SmsSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SmtpSettings.md
+++ b/docs/api/interfaces/SmtpSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SmtpSettings.md
+++ b/docs/api/interfaces/SmtpSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SmtpSettings.md
+++ b/docs/api/interfaces/SmtpSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SmtpSettings.md
+++ b/docs/api/interfaces/SmtpSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SmtpSettings.md
+++ b/docs/api/interfaces/SmtpSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/SmtpSettings.md
+++ b/docs/api/interfaces/SmtpSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/TokenResponse.md
+++ b/docs/api/interfaces/TokenResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/TokenResponse.md
+++ b/docs/api/interfaces/TokenResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/TokenResponse.md
+++ b/docs/api/interfaces/TokenResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/TokenResponse.md
+++ b/docs/api/interfaces/TokenResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/TokenResponse.md
+++ b/docs/api/interfaces/TokenResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/TokenResponse.md
+++ b/docs/api/interfaces/TokenResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UpdateLayoutParams.md
+++ b/docs/api/interfaces/UpdateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UpdateLayoutParams.md
+++ b/docs/api/interfaces/UpdateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UpdateLayoutParams.md
+++ b/docs/api/interfaces/UpdateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UpdateLayoutParams.md
+++ b/docs/api/interfaces/UpdateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UpdateLayoutParams.md
+++ b/docs/api/interfaces/UpdateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UpdateLayoutParams.md
+++ b/docs/api/interfaces/UpdateLayoutParams.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/User.md
+++ b/docs/api/interfaces/User.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/User.md
+++ b/docs/api/interfaces/User.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/User.md
+++ b/docs/api/interfaces/User.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/User.md
+++ b/docs/api/interfaces/User.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/User.md
+++ b/docs/api/interfaces/User.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/User.md
+++ b/docs/api/interfaces/User.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UserProfile.md
+++ b/docs/api/interfaces/UserProfile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UserProfile.md
+++ b/docs/api/interfaces/UserProfile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UserProfile.md
+++ b/docs/api/interfaces/UserProfile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UserProfile.md
+++ b/docs/api/interfaces/UserProfile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UserProfile.md
+++ b/docs/api/interfaces/UserProfile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/UserProfile.md
+++ b/docs/api/interfaces/UserProfile.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfig.md
+++ b/docs/api/interfaces/WebhookDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfig.md
+++ b/docs/api/interfaces/WebhookDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfig.md
+++ b/docs/api/interfaces/WebhookDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfig.md
+++ b/docs/api/interfaces/WebhookDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfig.md
+++ b/docs/api/interfaces/WebhookDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfig.md
+++ b/docs/api/interfaces/WebhookDeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfigCreate.md
+++ b/docs/api/interfaces/WebhookDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfigCreate.md
+++ b/docs/api/interfaces/WebhookDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfigCreate.md
+++ b/docs/api/interfaces/WebhookDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfigCreate.md
+++ b/docs/api/interfaces/WebhookDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfigCreate.md
+++ b/docs/api/interfaces/WebhookDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookDeliveryConfigCreate.md
+++ b/docs/api/interfaces/WebhookDeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookSettings.md
+++ b/docs/api/interfaces/WebhookSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookSettings.md
+++ b/docs/api/interfaces/WebhookSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookSettings.md
+++ b/docs/api/interfaces/WebhookSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookSettings.md
+++ b/docs/api/interfaces/WebhookSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookSettings.md
+++ b/docs/api/interfaces/WebhookSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/interfaces/WebhookSettings.md
+++ b/docs/api/interfaces/WebhookSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ActorType.md
+++ b/docs/api/type-aliases/ActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ActorType.md
+++ b/docs/api/type-aliases/ActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ActorType.md
+++ b/docs/api/type-aliases/ActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ActorType.md
+++ b/docs/api/type-aliases/ActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ActorType.md
+++ b/docs/api/type-aliases/ActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ActorType.md
+++ b/docs/api/type-aliases/ActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionSettings.md
+++ b/docs/api/type-aliases/AlertActionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionSettings.md
+++ b/docs/api/type-aliases/AlertActionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionSettings.md
+++ b/docs/api/type-aliases/AlertActionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionSettings.md
+++ b/docs/api/type-aliases/AlertActionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionSettings.md
+++ b/docs/api/type-aliases/AlertActionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionSettings.md
+++ b/docs/api/type-aliases/AlertActionSettings.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionStatus.md
+++ b/docs/api/type-aliases/AlertActionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionStatus.md
+++ b/docs/api/type-aliases/AlertActionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionStatus.md
+++ b/docs/api/type-aliases/AlertActionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionStatus.md
+++ b/docs/api/type-aliases/AlertActionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionStatus.md
+++ b/docs/api/type-aliases/AlertActionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionStatus.md
+++ b/docs/api/type-aliases/AlertActionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionType.md
+++ b/docs/api/type-aliases/AlertActionType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionType.md
+++ b/docs/api/type-aliases/AlertActionType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionType.md
+++ b/docs/api/type-aliases/AlertActionType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionType.md
+++ b/docs/api/type-aliases/AlertActionType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionType.md
+++ b/docs/api/type-aliases/AlertActionType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertActionType.md
+++ b/docs/api/type-aliases/AlertActionType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertConditionRuleInclude.md
+++ b/docs/api/type-aliases/AlertConditionRuleInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertConditionRuleInclude.md
+++ b/docs/api/type-aliases/AlertConditionRuleInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertConditionRuleInclude.md
+++ b/docs/api/type-aliases/AlertConditionRuleInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertConditionRuleInclude.md
+++ b/docs/api/type-aliases/AlertConditionRuleInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertConditionRuleInclude.md
+++ b/docs/api/type-aliases/AlertConditionRuleInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertConditionRuleInclude.md
+++ b/docs/api/type-aliases/AlertConditionRuleInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertInclude.md
+++ b/docs/api/type-aliases/AlertInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertInclude.md
+++ b/docs/api/type-aliases/AlertInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertInclude.md
+++ b/docs/api/type-aliases/AlertInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertInclude.md
+++ b/docs/api/type-aliases/AlertInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertInclude.md
+++ b/docs/api/type-aliases/AlertInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertInclude.md
+++ b/docs/api/type-aliases/AlertInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertSort.md
+++ b/docs/api/type-aliases/AlertSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertSort.md
+++ b/docs/api/type-aliases/AlertSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertSort.md
+++ b/docs/api/type-aliases/AlertSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertSort.md
+++ b/docs/api/type-aliases/AlertSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertSort.md
+++ b/docs/api/type-aliases/AlertSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/AlertSort.md
+++ b/docs/api/type-aliases/AlertSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/BridgeStatus.md
+++ b/docs/api/type-aliases/BridgeStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/BridgeStatus.md
+++ b/docs/api/type-aliases/BridgeStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/BridgeStatus.md
+++ b/docs/api/type-aliases/BridgeStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/BridgeStatus.md
+++ b/docs/api/type-aliases/BridgeStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/BridgeStatus.md
+++ b/docs/api/type-aliases/BridgeStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/BridgeStatus.md
+++ b/docs/api/type-aliases/BridgeStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraAspectRatio.md
+++ b/docs/api/type-aliases/CameraAspectRatio.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraAspectRatio.md
+++ b/docs/api/type-aliases/CameraAspectRatio.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraAspectRatio.md
+++ b/docs/api/type-aliases/CameraAspectRatio.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraAspectRatio.md
+++ b/docs/api/type-aliases/CameraAspectRatio.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraAspectRatio.md
+++ b/docs/api/type-aliases/CameraAspectRatio.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraAspectRatio.md
+++ b/docs/api/type-aliases/CameraAspectRatio.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraSettingsInclude.md
+++ b/docs/api/type-aliases/CameraSettingsInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraSettingsInclude.md
+++ b/docs/api/type-aliases/CameraSettingsInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraSettingsInclude.md
+++ b/docs/api/type-aliases/CameraSettingsInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraSettingsInclude.md
+++ b/docs/api/type-aliases/CameraSettingsInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **CameraSettingsInclude** = `"schema"` \| `"proposedValues"`
 
-Defined in: [types/camera.ts:409](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L409)
+Defined in: [types/camera.ts:421](https://github.com/klaushofrichter/een-api-toolkit/blob/production/src/types/camera.ts#L421)
 
 Valid include values for the camera settings endpoint.
 

--- a/docs/api/type-aliases/CameraSettingsInclude.md
+++ b/docs/api/type-aliases/CameraSettingsInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraSettingsInclude.md
+++ b/docs/api/type-aliases/CameraSettingsInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraStatus.md
+++ b/docs/api/type-aliases/CameraStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraStatus.md
+++ b/docs/api/type-aliases/CameraStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraStatus.md
+++ b/docs/api/type-aliases/CameraStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraStatus.md
+++ b/docs/api/type-aliases/CameraStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraStatus.md
+++ b/docs/api/type-aliases/CameraStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/CameraStatus.md
+++ b/docs/api/type-aliases/CameraStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DataSchema.md
+++ b/docs/api/type-aliases/DataSchema.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DataSchema.md
+++ b/docs/api/type-aliases/DataSchema.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DataSchema.md
+++ b/docs/api/type-aliases/DataSchema.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DataSchema.md
+++ b/docs/api/type-aliases/DataSchema.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DataSchema.md
+++ b/docs/api/type-aliases/DataSchema.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DataSchema.md
+++ b/docs/api/type-aliases/DataSchema.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfig.md
+++ b/docs/api/type-aliases/DeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfig.md
+++ b/docs/api/type-aliases/DeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfig.md
+++ b/docs/api/type-aliases/DeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfig.md
+++ b/docs/api/type-aliases/DeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfig.md
+++ b/docs/api/type-aliases/DeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfig.md
+++ b/docs/api/type-aliases/DeliveryConfig.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfigCreate.md
+++ b/docs/api/type-aliases/DeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfigCreate.md
+++ b/docs/api/type-aliases/DeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfigCreate.md
+++ b/docs/api/type-aliases/DeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfigCreate.md
+++ b/docs/api/type-aliases/DeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfigCreate.md
+++ b/docs/api/type-aliases/DeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DeliveryConfigCreate.md
+++ b/docs/api/type-aliases/DeliveryConfigCreate.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DownloadDownloadResult.md
+++ b/docs/api/type-aliases/DownloadDownloadResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DownloadDownloadResult.md
+++ b/docs/api/type-aliases/DownloadDownloadResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DownloadDownloadResult.md
+++ b/docs/api/type-aliases/DownloadDownloadResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DownloadDownloadResult.md
+++ b/docs/api/type-aliases/DownloadDownloadResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DownloadDownloadResult.md
+++ b/docs/api/type-aliases/DownloadDownloadResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DownloadDownloadResult.md
+++ b/docs/api/type-aliases/DownloadDownloadResult.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DownloadStatus.md
+++ b/docs/api/type-aliases/DownloadStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DownloadStatus.md
+++ b/docs/api/type-aliases/DownloadStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DownloadStatus.md
+++ b/docs/api/type-aliases/DownloadStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DownloadStatus.md
+++ b/docs/api/type-aliases/DownloadStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DownloadStatus.md
+++ b/docs/api/type-aliases/DownloadStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/DownloadStatus.md
+++ b/docs/api/type-aliases/DownloadStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ErrorCode.md
+++ b/docs/api/type-aliases/ErrorCode.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ErrorCode.md
+++ b/docs/api/type-aliases/ErrorCode.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ErrorCode.md
+++ b/docs/api/type-aliases/ErrorCode.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ErrorCode.md
+++ b/docs/api/type-aliases/ErrorCode.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ErrorCode.md
+++ b/docs/api/type-aliases/ErrorCode.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ErrorCode.md
+++ b/docs/api/type-aliases/ErrorCode.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionDeliveryType.md
+++ b/docs/api/type-aliases/EventSubscriptionDeliveryType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionDeliveryType.md
+++ b/docs/api/type-aliases/EventSubscriptionDeliveryType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionDeliveryType.md
+++ b/docs/api/type-aliases/EventSubscriptionDeliveryType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionDeliveryType.md
+++ b/docs/api/type-aliases/EventSubscriptionDeliveryType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionDeliveryType.md
+++ b/docs/api/type-aliases/EventSubscriptionDeliveryType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionDeliveryType.md
+++ b/docs/api/type-aliases/EventSubscriptionDeliveryType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionLifecycle.md
+++ b/docs/api/type-aliases/EventSubscriptionLifecycle.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionLifecycle.md
+++ b/docs/api/type-aliases/EventSubscriptionLifecycle.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionLifecycle.md
+++ b/docs/api/type-aliases/EventSubscriptionLifecycle.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionLifecycle.md
+++ b/docs/api/type-aliases/EventSubscriptionLifecycle.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionLifecycle.md
+++ b/docs/api/type-aliases/EventSubscriptionLifecycle.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/EventSubscriptionLifecycle.md
+++ b/docs/api/type-aliases/EventSubscriptionLifecycle.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ExportJobResponse.md
+++ b/docs/api/type-aliases/ExportJobResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ExportJobResponse.md
+++ b/docs/api/type-aliases/ExportJobResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ExportJobResponse.md
+++ b/docs/api/type-aliases/ExportJobResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ExportJobResponse.md
+++ b/docs/api/type-aliases/ExportJobResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ExportJobResponse.md
+++ b/docs/api/type-aliases/ExportJobResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ExportJobResponse.md
+++ b/docs/api/type-aliases/ExportJobResponse.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ExportType.md
+++ b/docs/api/type-aliases/ExportType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ExportType.md
+++ b/docs/api/type-aliases/ExportType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ExportType.md
+++ b/docs/api/type-aliases/ExportType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ExportType.md
+++ b/docs/api/type-aliases/ExportType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ExportType.md
+++ b/docs/api/type-aliases/ExportType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ExportType.md
+++ b/docs/api/type-aliases/ExportType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedIncludeOption.md
+++ b/docs/api/type-aliases/FeedIncludeOption.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedIncludeOption.md
+++ b/docs/api/type-aliases/FeedIncludeOption.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedIncludeOption.md
+++ b/docs/api/type-aliases/FeedIncludeOption.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedIncludeOption.md
+++ b/docs/api/type-aliases/FeedIncludeOption.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedIncludeOption.md
+++ b/docs/api/type-aliases/FeedIncludeOption.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedIncludeOption.md
+++ b/docs/api/type-aliases/FeedIncludeOption.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedMediaType.md
+++ b/docs/api/type-aliases/FeedMediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedMediaType.md
+++ b/docs/api/type-aliases/FeedMediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedMediaType.md
+++ b/docs/api/type-aliases/FeedMediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedMediaType.md
+++ b/docs/api/type-aliases/FeedMediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedMediaType.md
+++ b/docs/api/type-aliases/FeedMediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedMediaType.md
+++ b/docs/api/type-aliases/FeedMediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedStreamType.md
+++ b/docs/api/type-aliases/FeedStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedStreamType.md
+++ b/docs/api/type-aliases/FeedStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedStreamType.md
+++ b/docs/api/type-aliases/FeedStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedStreamType.md
+++ b/docs/api/type-aliases/FeedStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedStreamType.md
+++ b/docs/api/type-aliases/FeedStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FeedStreamType.md
+++ b/docs/api/type-aliases/FeedStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FileIncludeField.md
+++ b/docs/api/type-aliases/FileIncludeField.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FileIncludeField.md
+++ b/docs/api/type-aliases/FileIncludeField.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FileIncludeField.md
+++ b/docs/api/type-aliases/FileIncludeField.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FileIncludeField.md
+++ b/docs/api/type-aliases/FileIncludeField.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FileIncludeField.md
+++ b/docs/api/type-aliases/FileIncludeField.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FileIncludeField.md
+++ b/docs/api/type-aliases/FileIncludeField.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FileType.md
+++ b/docs/api/type-aliases/FileType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FileType.md
+++ b/docs/api/type-aliases/FileType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FileType.md
+++ b/docs/api/type-aliases/FileType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FileType.md
+++ b/docs/api/type-aliases/FileType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FileType.md
+++ b/docs/api/type-aliases/FileType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/FileType.md
+++ b/docs/api/type-aliases/FileType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/GetLayoutInclude.md
+++ b/docs/api/type-aliases/GetLayoutInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/GetLayoutInclude.md
+++ b/docs/api/type-aliases/GetLayoutInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/GetLayoutInclude.md
+++ b/docs/api/type-aliases/GetLayoutInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/GetLayoutInclude.md
+++ b/docs/api/type-aliases/GetLayoutInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/GetLayoutInclude.md
+++ b/docs/api/type-aliases/GetLayoutInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/GetLayoutInclude.md
+++ b/docs/api/type-aliases/GetLayoutInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/JobState.md
+++ b/docs/api/type-aliases/JobState.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/JobState.md
+++ b/docs/api/type-aliases/JobState.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/JobState.md
+++ b/docs/api/type-aliases/JobState.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/JobState.md
+++ b/docs/api/type-aliases/JobState.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/JobState.md
+++ b/docs/api/type-aliases/JobState.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/JobState.md
+++ b/docs/api/type-aliases/JobState.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/KnownEventType.md
+++ b/docs/api/type-aliases/KnownEventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/KnownEventType.md
+++ b/docs/api/type-aliases/KnownEventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/KnownEventType.md
+++ b/docs/api/type-aliases/KnownEventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/KnownEventType.md
+++ b/docs/api/type-aliases/KnownEventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/KnownEventType.md
+++ b/docs/api/type-aliases/KnownEventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/KnownEventType.md
+++ b/docs/api/type-aliases/KnownEventType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneSize.md
+++ b/docs/api/type-aliases/LayoutPaneSize.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneSize.md
+++ b/docs/api/type-aliases/LayoutPaneSize.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneSize.md
+++ b/docs/api/type-aliases/LayoutPaneSize.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneSize.md
+++ b/docs/api/type-aliases/LayoutPaneSize.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneSize.md
+++ b/docs/api/type-aliases/LayoutPaneSize.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneSize.md
+++ b/docs/api/type-aliases/LayoutPaneSize.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneType.md
+++ b/docs/api/type-aliases/LayoutPaneType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneType.md
+++ b/docs/api/type-aliases/LayoutPaneType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneType.md
+++ b/docs/api/type-aliases/LayoutPaneType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneType.md
+++ b/docs/api/type-aliases/LayoutPaneType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneType.md
+++ b/docs/api/type-aliases/LayoutPaneType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/LayoutPaneType.md
+++ b/docs/api/type-aliases/LayoutPaneType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsInclude.md
+++ b/docs/api/type-aliases/ListLayoutsInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsInclude.md
+++ b/docs/api/type-aliases/ListLayoutsInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsInclude.md
+++ b/docs/api/type-aliases/ListLayoutsInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsInclude.md
+++ b/docs/api/type-aliases/ListLayoutsInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsInclude.md
+++ b/docs/api/type-aliases/ListLayoutsInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsInclude.md
+++ b/docs/api/type-aliases/ListLayoutsInclude.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsSort.md
+++ b/docs/api/type-aliases/ListLayoutsSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsSort.md
+++ b/docs/api/type-aliases/ListLayoutsSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsSort.md
+++ b/docs/api/type-aliases/ListLayoutsSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsSort.md
+++ b/docs/api/type-aliases/ListLayoutsSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsSort.md
+++ b/docs/api/type-aliases/ListLayoutsSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/ListLayoutsSort.md
+++ b/docs/api/type-aliases/ListLayoutsSort.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaStreamType.md
+++ b/docs/api/type-aliases/MediaStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaStreamType.md
+++ b/docs/api/type-aliases/MediaStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaStreamType.md
+++ b/docs/api/type-aliases/MediaStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaStreamType.md
+++ b/docs/api/type-aliases/MediaStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaStreamType.md
+++ b/docs/api/type-aliases/MediaStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaStreamType.md
+++ b/docs/api/type-aliases/MediaStreamType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaType.md
+++ b/docs/api/type-aliases/MediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaType.md
+++ b/docs/api/type-aliases/MediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaType.md
+++ b/docs/api/type-aliases/MediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaType.md
+++ b/docs/api/type-aliases/MediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaType.md
+++ b/docs/api/type-aliases/MediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MediaType.md
+++ b/docs/api/type-aliases/MediaType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricActorType.md
+++ b/docs/api/type-aliases/MetricActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricActorType.md
+++ b/docs/api/type-aliases/MetricActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricActorType.md
+++ b/docs/api/type-aliases/MetricActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricActorType.md
+++ b/docs/api/type-aliases/MetricActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricActorType.md
+++ b/docs/api/type-aliases/MetricActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricActorType.md
+++ b/docs/api/type-aliases/MetricActorType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricDataPoint.md
+++ b/docs/api/type-aliases/MetricDataPoint.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricDataPoint.md
+++ b/docs/api/type-aliases/MetricDataPoint.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricDataPoint.md
+++ b/docs/api/type-aliases/MetricDataPoint.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricDataPoint.md
+++ b/docs/api/type-aliases/MetricDataPoint.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricDataPoint.md
+++ b/docs/api/type-aliases/MetricDataPoint.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/MetricDataPoint.md
+++ b/docs/api/type-aliases/MetricDataPoint.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationCategory.md
+++ b/docs/api/type-aliases/NotificationCategory.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationCategory.md
+++ b/docs/api/type-aliases/NotificationCategory.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationCategory.md
+++ b/docs/api/type-aliases/NotificationCategory.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationCategory.md
+++ b/docs/api/type-aliases/NotificationCategory.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationCategory.md
+++ b/docs/api/type-aliases/NotificationCategory.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationCategory.md
+++ b/docs/api/type-aliases/NotificationCategory.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationStatus.md
+++ b/docs/api/type-aliases/NotificationStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationStatus.md
+++ b/docs/api/type-aliases/NotificationStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationStatus.md
+++ b/docs/api/type-aliases/NotificationStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationStatus.md
+++ b/docs/api/type-aliases/NotificationStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationStatus.md
+++ b/docs/api/type-aliases/NotificationStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/NotificationStatus.md
+++ b/docs/api/type-aliases/NotificationStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/PtzDirection.md
+++ b/docs/api/type-aliases/PtzDirection.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/PtzDirection.md
+++ b/docs/api/type-aliases/PtzDirection.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/PtzDirection.md
+++ b/docs/api/type-aliases/PtzDirection.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/PtzDirection.md
+++ b/docs/api/type-aliases/PtzDirection.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/PtzDirection.md
+++ b/docs/api/type-aliases/PtzDirection.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/PtzDirection.md
+++ b/docs/api/type-aliases/PtzDirection.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/PtzMode.md
+++ b/docs/api/type-aliases/PtzMode.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/PtzMode.md
+++ b/docs/api/type-aliases/PtzMode.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/PtzMode.md
+++ b/docs/api/type-aliases/PtzMode.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/PtzMode.md
+++ b/docs/api/type-aliases/PtzMode.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/PtzMode.md
+++ b/docs/api/type-aliases/PtzMode.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/PtzMode.md
+++ b/docs/api/type-aliases/PtzMode.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/PtzMove.md
+++ b/docs/api/type-aliases/PtzMove.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/PtzMove.md
+++ b/docs/api/type-aliases/PtzMove.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/PtzMove.md
+++ b/docs/api/type-aliases/PtzMove.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/PtzMove.md
+++ b/docs/api/type-aliases/PtzMove.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/PtzMove.md
+++ b/docs/api/type-aliases/PtzMove.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/PtzMove.md
+++ b/docs/api/type-aliases/PtzMove.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/PtzMoveType.md
+++ b/docs/api/type-aliases/PtzMoveType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/PtzMoveType.md
+++ b/docs/api/type-aliases/PtzMoveType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/PtzMoveType.md
+++ b/docs/api/type-aliases/PtzMoveType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/PtzMoveType.md
+++ b/docs/api/type-aliases/PtzMoveType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/PtzMoveType.md
+++ b/docs/api/type-aliases/PtzMoveType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/PtzMoveType.md
+++ b/docs/api/type-aliases/PtzMoveType.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/PtzStepSize.md
+++ b/docs/api/type-aliases/PtzStepSize.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/PtzStepSize.md
+++ b/docs/api/type-aliases/PtzStepSize.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/PtzStepSize.md
+++ b/docs/api/type-aliases/PtzStepSize.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/PtzStepSize.md
+++ b/docs/api/type-aliases/PtzStepSize.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/PtzStepSize.md
+++ b/docs/api/type-aliases/PtzStepSize.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/PtzStepSize.md
+++ b/docs/api/type-aliases/PtzStepSize.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/Result.md
+++ b/docs/api/type-aliases/Result.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/Result.md
+++ b/docs/api/type-aliases/Result.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/Result.md
+++ b/docs/api/type-aliases/Result.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/Result.md
+++ b/docs/api/type-aliases/Result.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/Result.md
+++ b/docs/api/type-aliases/Result.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/Result.md
+++ b/docs/api/type-aliases/Result.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/SSEConnectionStatus.md
+++ b/docs/api/type-aliases/SSEConnectionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/SSEConnectionStatus.md
+++ b/docs/api/type-aliases/SSEConnectionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/SSEConnectionStatus.md
+++ b/docs/api/type-aliases/SSEConnectionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/SSEConnectionStatus.md
+++ b/docs/api/type-aliases/SSEConnectionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/SSEConnectionStatus.md
+++ b/docs/api/type-aliases/SSEConnectionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/SSEConnectionStatus.md
+++ b/docs/api/type-aliases/SSEConnectionStatus.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/StorageStrategy.md
+++ b/docs/api/type-aliases/StorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/StorageStrategy.md
+++ b/docs/api/type-aliases/StorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/StorageStrategy.md
+++ b/docs/api/type-aliases/StorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/StorageStrategy.md
+++ b/docs/api/type-aliases/StorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/StorageStrategy.md
+++ b/docs/api/type-aliases/StorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/type-aliases/StorageStrategy.md
+++ b/docs/api/type-aliases/StorageStrategy.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/variables/EVENT_TYPE_DATA_SCHEMAS.md
+++ b/docs/api/variables/EVENT_TYPE_DATA_SCHEMAS.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/variables/EVENT_TYPE_DATA_SCHEMAS.md
+++ b/docs/api/variables/EVENT_TYPE_DATA_SCHEMAS.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/variables/EVENT_TYPE_DATA_SCHEMAS.md
+++ b/docs/api/variables/EVENT_TYPE_DATA_SCHEMAS.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/variables/EVENT_TYPE_DATA_SCHEMAS.md
+++ b/docs/api/variables/EVENT_TYPE_DATA_SCHEMAS.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/variables/EVENT_TYPE_DATA_SCHEMAS.md
+++ b/docs/api/variables/EVENT_TYPE_DATA_SCHEMAS.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/variables/EVENT_TYPE_DATA_SCHEMAS.md
+++ b/docs/api/variables/EVENT_TYPE_DATA_SCHEMAS.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
+++ b/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
+++ b/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
+++ b/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
+++ b/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
+++ b/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
+++ b/docs/api/variables/STORAGE_STRATEGY_DESCRIPTIONS.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/api/variables/useAuthStore.md
+++ b/docs/api/variables/useAuthStore.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.92**](../README.md)
+[**EEN API Toolkit v0.3.93**](../README.md)
 
 ***
 

--- a/docs/api/variables/useAuthStore.md
+++ b/docs/api/variables/useAuthStore.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.95**](../README.md)
+[**EEN API Toolkit v0.3.96**](../README.md)
 
 ***
 

--- a/docs/api/variables/useAuthStore.md
+++ b/docs/api/variables/useAuthStore.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.94**](../README.md)
+[**EEN API Toolkit v0.3.95**](../README.md)
 
 ***
 

--- a/docs/api/variables/useAuthStore.md
+++ b/docs/api/variables/useAuthStore.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.96**](../README.md)
+[**EEN API Toolkit v0.3.97**](../README.md)
 
 ***
 

--- a/docs/api/variables/useAuthStore.md
+++ b/docs/api/variables/useAuthStore.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.91**](../README.md)
+[**EEN API Toolkit v0.3.92**](../README.md)
 
 ***
 

--- a/docs/api/variables/useAuthStore.md
+++ b/docs/api/variables/useAuthStore.md
@@ -1,4 +1,4 @@
-[**EEN API Toolkit v0.3.93**](../README.md)
+[**EEN API Toolkit v0.3.94**](../README.md)
 
 ***
 

--- a/docs/een-api-all-endpoints.md
+++ b/docs/een-api-all-endpoints.md
@@ -1,442 +1,436 @@
 # Eagle Eye Networks REST API v3.0 - Complete Endpoint Reference
 
-> Generated: 2026-02-17
+> Generated: 2026-02-21
 > Source: [EEN Developer Portal](https://developer.eagleeyenetworks.com/reference/using-the-api) and [OpenAPI Specifications](https://github.com/EENCloud/VMS-Developer-Portal/tree/main/Open%20API%20Specifications)
 
 All paths are prefixed with `/api/v3.0` on the appropriate base URL (e.g., `https://c001.eagleeyenetworks.com`).
 
 ---
 
-## DEVICES - Cameras (15 endpoints)
+## Devices - Cameras (15 endpoints)
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/cameras` | List cameras |
-| POST | `/cameras` | Add a camera |
-| POST | `/cameras:bulkUpdate` | Bulk update cameras |
-| GET | `/cameras/{cameraId}` | Get camera by ID |
-| PATCH | `/cameras/{cameraId}` | Update a camera |
-| DELETE | `/cameras/{cameraId}` | Delete a camera |
-| PUT | `/cameras/{cameraId}/tunnel` | Create/update camera tunnel |
-| DELETE | `/cameras/{cameraId}/tunnel` | Delete camera tunnel |
-| GET | `/cameras/{cameraId}/metrics` | Get camera metrics |
-| PATCH | `/cameras/{cameraId}:swap` | Swap a camera |
+| GET | `/cameras` | List cameras with filtering, pagination, and include options |
+| POST | `/cameras` | Associate a camera with the account |
+| POST | `/cameras:bulkUpdate` | Update multiple cameras simultaneously |
+| GET | `/cameras/{cameraId}` | Retrieve specific camera details |
+| DELETE | `/cameras/{cameraId}` | Remove camera from account |
+| PATCH | `/cameras/{cameraId}` | Update camera information |
+| PUT | `/cameras/{cameraId}/tunnel` | Open camera tunnel for UI access |
+| DELETE | `/cameras/{cameraId}/tunnel` | Close camera tunnel |
+| GET | `/cameras/{cameraId}/metrics` | Retrieve camera metrics data |
+| PATCH | `/cameras/{cameraId}:swap` | Replace camera with new device |
 | GET | `/cameras/{cameraId}/io/ports` | List camera I/O ports |
-| GET | `/cameras/{cameraId}/io/ports/{portId}` | Get camera I/O port |
-| PATCH | `/cameras/{cameraId}/io/ports/{portId}` | Update camera I/O port |
-| GET | `/cameras/{cameraId}/settings` | Get camera settings |
+| GET | `/cameras/{cameraId}/io/ports/{portId}` | Retrieve specific camera I/O port |
+| PATCH | `/cameras/{cameraId}/io/ports/{portId}` | Update camera port configuration |
+| GET | `/cameras/{cameraId}/settings` | Retrieve camera settings |
 | PATCH | `/cameras/{cameraId}/settings` | Update camera settings |
 
-## DEVICES - Bridges (11 endpoints)
+## Devices - Bridges (11 endpoints)
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/bridges` | List bridges |
-| POST | `/bridges` | Create a bridge |
-| POST | `/bridges:bulkUpdate` | Bulk update bridges |
-| GET | `/bridges/{bridgeId}` | Get bridge by ID |
-| PATCH | `/bridges/{bridgeId}` | Update a bridge |
-| DELETE | `/bridges/{bridgeId}` | Delete a bridge |
-| GET | `/bridges/{bridgeId}/metrics` | Get bridge metrics |
-| PATCH | `/bridges/{bridgeId}:swap` | Swap a bridge |
-| POST | `/bridges/{bridgeId}/actions` | Trigger bridge action |
-| GET | `/bridges/{id}/settings` | Get bridge settings |
-| PATCH | `/bridges/{id}/settings` | Update bridge settings |
+| GET | `/bridges` | List bridges with filtering and pagination |
+| POST | `/bridges` | Create bridge for account |
+| POST | `/bridges:bulkUpdate` | Update multiple bridges simultaneously |
+| GET | `/bridges/{bridgeId}` | Retrieve specific bridge |
+| PATCH | `/bridges/{bridgeId}` | Update bridge information |
+| DELETE | `/bridges/{bridgeId}` | Remove bridge from account |
+| GET | `/bridges/{bridgeId}/metrics` | Retrieve bridge metrics |
+| PATCH | `/bridges/{bridgeId}:swap` | Replace bridge with new device |
+| POST | `/bridges/{bridgeId}/actions` | Execute bridge actions (e.g., reboot) |
+| GET | `/bridges/{bridgeId}/settings` | Retrieve bridge operational settings |
+| PATCH | `/bridges/{bridgeId}/settings` | Update bridge settings |
 
-## DEVICES - PTZ (4 endpoints)
-
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/cameras/{cameraId}/ptz/position` | Get current PTZ position |
-| PUT | `/cameras/{cameraId}/ptz/position` | Move PTZ to position |
-| GET | `/cameras/{cameraId}/ptz/settings` | Get PTZ settings |
-| PATCH | `/cameras/{cameraId}/ptz/settings` | Update PTZ settings |
-
-## DEVICES - Speakers (7 endpoints)
+## Devices - PTZ (4 endpoints)
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/speakers` | List speakers |
-| POST | `/speakers` | Add a speaker |
-| GET | `/speakers/{speakerId}` | Get speaker by ID |
-| PATCH | `/speakers/{speakerId}` | Update a speaker |
-| DELETE | `/speakers/{speakerId}` | Delete a speaker |
-| GET | `/speakers/{speakerId}/settings` | Get speaker settings |
+| GET | `/cameras/{cameraId}/ptz/position` | Retrieve current PTZ position |
+| PUT | `/cameras/{cameraId}/ptz/position` | Move camera to position or direction |
+| GET | `/cameras/{cameraId}/ptz/settings` | Retrieve PTZ settings and presets |
+| PATCH | `/cameras/{cameraId}/ptz/settings` | Update PTZ settings and presets |
+
+## Devices - Speakers (7 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/speakers` | List speakers with filtering and pagination |
+| POST | `/speakers` | Create speaker device |
+| GET | `/speakers/{speakerId}` | Retrieve specific speaker |
+| PATCH | `/speakers/{speakerId}` | Update speaker information |
+| DELETE | `/speakers/{speakerId}` | Remove speaker from account |
+| GET | `/speakers/{speakerId}/settings` | Retrieve speaker settings |
 | PATCH | `/speakers/{speakerId}/settings` | Update speaker settings |
 
-## DEVICES - Device I/O (6 endpoints)
+## Devices - Device I/O (6 endpoints)
 
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/devices/{deviceId}/io/ports` | List device I/O ports |
-| GET | `/devices/{deviceId}/io/ports/{portId}` | Get device I/O port |
-| PATCH | `/devices/{deviceId}/io/ports/{portId}` | Update device I/O port |
-| GET | `/devices/{deviceId}/io/ports/{portId}/recordingActions` | List port recording actions |
-| GET | `/devices/{deviceId}/io/ports/{portId}/recordingActions/{cameraId}` | Get port recording action |
-| PATCH | `/devices/{deviceId}/io/ports/{portId}/recordingActions/{cameraId}` | Update port recording action |
+| GET | `/devices/{deviceId}/io/ports/{portId}` | Retrieve specific I/O port |
+| PATCH | `/devices/{deviceId}/io/ports/{portId}` | Update port configuration |
+| GET | `/devices/{deviceId}/io/ports/{portId}/recordingActions` | List cameras recording on port trigger |
+| GET | `/devices/{deviceId}/io/ports/{portId}/recordingActions/{cameraId}` | Retrieve a recording action |
+| PATCH | `/devices/{deviceId}/io/ports/{portId}/recordingActions/{cameraId}` | Update a recording action |
 
-## DEVICES - Switches (5 endpoints)
-
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/switches` | List switches |
-| GET | `/switches/{switchId}` | Get switch by ID |
-| PATCH | `/switches/{switchId}` | Update a switch |
-| POST | `/switches/{switchId}/ports/{portId}/actions` | Trigger switch port action |
-| POST | `/switches/{switchId}/ports/all/actions` | Trigger action on all switch ports |
-
-## DEVICES - Multi Cameras (6 endpoints)
+## Devices - Switches (5 endpoints)
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/multiCameras` | List multi-cameras |
-| POST | `/multiCameras` | Add a multi-camera |
-| GET | `/multiCameras/{multiCameraId}` | Get multi-camera by ID |
-| PATCH | `/multiCameras/{multiCameraId}` | Update a multi-camera |
-| DELETE | `/multiCameras/{multiCameraId}` | Delete a multi-camera |
-| GET | `/multiCameras/{multiCameraId}/channels` | Get multi-camera channels |
+| GET | `/switches` | List switches with pagination |
+| GET | `/switches/{switchId}` | Retrieve specific switch |
+| PATCH | `/switches/{switchId}` | Update switch information |
+| POST | `/switches/{switchId}/ports/{portId}/actions` | Control individual switch port |
+| POST | `/switches/{switchId}/ports/all/actions` | Control all switch ports |
 
-## DEVICES - Available Devices (1 endpoint)
-
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/availableDevices` | List available (unclaimed) devices |
-
-## GROUPING - Layouts (5 endpoints)
+## Devices - Multi Cameras (6 endpoints)
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/layouts` | List layouts |
+| GET | `/multiCameras` | List multi-camera devices |
+| POST | `/multiCameras` | Associate multi-camera with account |
+| GET | `/multiCameras/{multiCameraId}` | Retrieve multi-camera details |
+| DELETE | `/multiCameras/{multiCameraId}` | Remove multi-camera from account |
+| PATCH | `/multiCameras/{multiCameraId}` | Update multi-camera information |
+| GET | `/multiCameras/{multiCameraId}/channels` | Retrieve multi-camera channel information |
+
+## Devices - Available Devices (1 endpoint)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/availableDevices` | List undiscovered devices available for addition |
+
+---
+
+## Grouping - Layouts (5 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/layouts` | Retrieve all layouts associated with the account |
 | POST | `/layouts` | Create a layout |
-| GET | `/layouts/{layoutId}` | Get layout by ID |
-| PATCH | `/layouts/{layoutId}` | Update a layout |
-| DELETE | `/layouts/{layoutId}` | Delete a layout |
+| GET | `/layouts/{layoutId}` | Retrieve info of a specific layout |
+| PATCH | `/layouts/{layoutId}` | Update a specific layout |
+| DELETE | `/layouts/{layoutId}` | Delete an existing layout |
 
-## GROUPING - Tags (1 endpoint)
-
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/tags` | List tags |
-
-## GROUPING - Locations (6 endpoints)
+## Grouping - Tags (1 endpoint)
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/locations` | List locations |
-| POST | `/locations` | Create a location |
-| GET | `/locations/{id}` | Get location by ID |
-| PATCH | `/locations/{id}` | Update a location |
-| DELETE | `/locations/{id}` | Delete a location |
-| GET | `/locations/{id}/locations` | Get location descendants |
+| GET | `/tags` | Retrieve a list of all tags visible to the current user |
 
-## GROUPING - Floors (6 endpoints)
+## Grouping - Locations (6 endpoints)
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/locations/{locationId}/floors` | List floors for a location |
+| GET | `/locations` | Retrieve a list of locations |
+| POST | `/locations` | Create a new location |
+| GET | `/locations/{id}` | Retrieve the location with a specific ID |
+| PATCH | `/locations/{id}` | Update the location with the given ID |
+| DELETE | `/locations/{id}` | Delete the location with the given ID |
+| GET | `/locations/{id}/locations` | Retrieve child locations |
+
+## Grouping - Floors (6 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/locations/{locationId}/floors` | Retrieve the floors at the given location |
 | POST | `/locations/{locationId}/floors` | Create a floor |
-| GET | `/locations/{locationId}/floors/{id}` | Get floor by ID |
-| PATCH | `/locations/{locationId}/floors/{id}` | Update a floor |
-| DELETE | `/locations/{locationId}/floors/{id}` | Delete a floor |
-| GET | `/locations/{locationId}/floors/{id}.{type}` | Get floor image |
+| GET | `/locations/{locationId}/floors/{id}` | Retrieve a specific floor at a specific location |
+| PATCH | `/locations/{locationId}/floors/{id}` | Update one or more fields of the given floor |
+| DELETE | `/locations/{locationId}/floors/{id}` | Delete a specific floor of a specific location |
+| GET | `/locations/{locationId}/floors/{id}.{type}` | Retrieve the floor image of a specific floor |
 
-## GROUPING - Floor Plans (3 endpoints)
-
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/locations/{locationId}/floors/{id}/plans` | List floor plans |
-| POST | `/locations/{locationId}/floors/{id}/plans` | Set a floor plan |
-| DELETE | `/locations/{locationId}/floors/{id}/plans/{planId}` | Delete a floor plan |
-
-## MEDIA - Media (5 endpoints)
+## Grouping - Floor Plans (3 endpoints)
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/media` | List media (recording spans) |
-| GET | `/media/recordedImage.jpeg` | Get recorded image |
-| GET | `/media/recordedImage.jpeg:listFieldValues` | List recorded image overlay field values |
-| GET | `/media/liveImage.jpeg` | Get live image |
-| GET | `/media/session` | Get media session URL |
+| GET | `/locations/{locationId}/floors/{id}/plans` | Retrieve plans of a specific floor |
+| POST | `/locations/{locationId}/floors/{id}/plans` | Create a floor plan for a specific floor |
+| DELETE | `/locations/{locationId}/floors/{id}/plans/{planId}` | Delete a floor plan and its corresponding file |
 
-## MEDIA - Feeds (1 endpoint)
+---
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/feeds` | List feeds (live video streams) |
-
-## MEDIA - Exports (2 endpoints)
+## Media - Media (5 endpoints)
 
 | Method | Path | Description |
 |--------|------|-------------|
-| POST | `/exports` | Create an export job |
-| POST | `/exports/{jobId}:copy` | Retry/copy an export |
+| GET | `/media` | List recording intervals for given type and mediaType |
+| GET | `/media/recordedImage.jpeg` | Retrieve image at specified timestamp |
+| GET | `/media/recordedImage.jpeg:listFieldValues` | List available field values for recorded images |
+| GET | `/media/liveImage.jpeg` | Get new image from device |
+| GET | `/media/session` | Get URL to set media session cookie |
 
-## MEDIA - Jobs (3 endpoints)
-
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/jobs` | List jobs |
-| GET | `/jobs/{jobId}` | Get job by ID |
-| DELETE | `/jobs/{jobId}` | Delete a job |
-
-## MEDIA - Files (11 endpoints)
+## Media - Feeds (1 endpoint)
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/files` | List files |
-| POST | `/files` | Add a file |
-| GET | `/files/{id}` | Get file by ID |
-| PATCH | `/files/{id}` | Update a file |
-| DELETE | `/files/{id}` | Delete a file |
-| GET | `/files/{id}:download` | Download a file |
-| GET | `/deletedFiles` | List trash (deleted files) |
-| GET | `/deletedFiles/{id}` | Get deleted file |
-| DELETE | `/deletedFiles/{id}` | Permanently delete a trash file |
-| DELETE | `/deletedFiles/all` | Permanently delete all trash files |
-| POST | `/deletedFiles/{id}:restore` | Restore a deleted file |
+| GET | `/feeds` | List feeds generated by device(s) |
 
-## MEDIA - Downloads (4 endpoints)
+## Media - Exports (2 endpoints)
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/downloads` | List downloads |
-| GET | `/downloads/{id}` | Get download by ID |
-| PATCH | `/downloads/{id}` | Update a download |
-| GET | `/downloads/{id}:download` | Download a download file |
+| POST | `/exports` | Create and start new video export job |
+| POST | `/exports/{jobId}:copy` | Retry export with modified parameters |
 
-## EVENTS - Events (5 endpoints)
+## Media - Jobs (3 endpoints)
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/events` | List events |
-| POST | `/events` | Create an event |
-| GET | `/events/{id}` | Get event by ID |
-| GET | `/events:listRecentByType` | List recent events by type |
-| GET | `/events:listFieldValues` | List event field values |
+| GET | `/jobs` | List jobs with filtering options |
+| GET | `/jobs/{jobId}` | Get single job details |
+| DELETE | `/jobs/{jobId}` | Delete job regardless of state |
 
-## EVENTS - Event Types (1 endpoint)
+## Media - Files (11 endpoints)
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/eventTypes` | List event types |
+| GET | `/files` | List archived items |
+| POST | `/files` | Add new file to archive |
+| GET | `/files/{id}` | Get file details by ID |
+| PATCH | `/files/{id}` | Modify file details |
+| DELETE | `/files/{id}` | Recycle item by ID |
+| GET | `/files/{id}:download` | Download file or folder |
+| GET | `/deletedFiles` | List deleted files |
+| GET | `/deletedFiles/{id}` | Get recycled item details |
+| DELETE | `/deletedFiles/{id}` | Permanently delete item |
+| DELETE | `/deletedFiles/all` | Clear recycle bin |
+| POST | `/deletedFiles/{id}:restore` | Restore recycled item |
 
-## EVENTS - Event Metrics (1 endpoint)
-
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/eventMetrics` | Get event metrics |
-
-## EVENTS - Event Subscriptions (8 endpoints)
-
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/eventSubscriptions` | List event subscriptions |
-| POST | `/eventSubscriptions` | Create event subscription |
-| GET | `/eventSubscriptions/{id}` | Get event subscription |
-| DELETE | `/eventSubscriptions/{id}` | Delete event subscription |
-| GET | `/eventSubscriptions/{id}/filters` | List subscription filters |
-| POST | `/eventSubscriptions/{id}/filters` | Create subscription filter |
-| GET | `/eventSubscriptions/{id}/filters/{filterId}` | Get subscription filter |
-| DELETE | `/eventSubscriptions/{id}/filters/{filterId}` | Delete subscription filter |
-
-## EVENTS - Alerts (3 endpoints)
+## Media - Downloads (4 endpoints)
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/alerts` | List alerts |
-| GET | `/alerts/{id}` | Get alert by ID |
-| GET | `/alertTypes` | List alert types |
+| GET | `/downloads` | List downloaded items |
+| GET | `/downloads/{id}` | Get download details by ID |
+| PATCH | `/downloads/{id}` | Modify download metadata |
+| GET | `/downloads/{id}:download` | Save download by ID |
 
-## EVENTS - Notifications (3 endpoints)
+---
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/notifications` | List notifications |
-| GET | `/notifications/{id}` | Get notification by ID |
-| PATCH | `/notifications/{id}` | Update a notification |
-
-## AUTOMATIONS - Event Alert Condition Rules (6 endpoints)
+## Events - Events (4 endpoints)
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/eventAlertConditionRules` | List event alert condition rules |
-| POST | `/eventAlertConditionRules` | Create event alert condition rule |
-| GET | `/eventAlertConditionRules:listFieldValues` | List rule field values |
-| GET | `/eventAlertConditionRules/{id}` | Get event alert condition rule |
-| PATCH | `/eventAlertConditionRules/{id}` | Update event alert condition rule |
-| DELETE | `/eventAlertConditionRules/{id}` | Delete event alert condition rule |
+| GET | `/events` | Retrieve events filtered by type, actor, and time range |
+| POST | `/events` | Create a new event for the selected actor |
+| GET | `/events/{id}` | Retrieve a specific event by ID |
+| GET | `/events:listFieldValues` | List available field values for event filtering |
 
-## AUTOMATIONS - Alert Action Rules (5 endpoints)
+## Events - Event Types (1 endpoint)
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/alertActionRules` | List alert action rules |
-| POST | `/alertActionRules` | Create alert action rule |
-| GET | `/alertActionRules/{actionRuleId}` | Get alert action rule |
-| PATCH | `/alertActionRules/{actionRuleId}` | Update alert action rule |
-| DELETE | `/alertActionRules/{actionRuleId}` | Delete alert action rule |
+| GET | `/eventTypes` | List all available event types |
 
-## AUTOMATIONS - Alert Actions (5 endpoints)
+## Events - Event Metrics (1 endpoint)
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/alertActions` | List alert actions |
-| POST | `/alertActions` | Create alert action |
-| GET | `/alertActions/{actionId}` | Get alert action |
-| PATCH | `/alertActions/{actionId}` | Update alert action |
-| DELETE | `/alertActions/{actionId}` | Delete alert action |
+| GET | `/eventMetrics` | Retrieve time-series event metric data for an actor and event type |
 
-## VIDEO SEARCH - Video Analytic Events (7 endpoints)
+## Events - Event Subscriptions (4 endpoints)
 
 | Method | Path | Description |
 |--------|------|-------------|
-| POST | `/videoAnalyticEvents:parse` | Parse video analytics query |
-| POST | `/videoAnalyticEvents:deepSearch` | Deep search video analytics events |
-| POST | `/videoAnalyticEvents:deepSearchGroupByResource` | Deep search grouped by resource |
-| POST | `/videoAnalyticEvents:deepSearchGroupByTime` | Deep search grouped by time |
-| POST | `/videoAnalyticEvents:listFieldValues` | List video analytics field values |
-| GET | `/videoAnalyticEvents:listObjectValues` | List video analytics object values |
-| GET | `/videoAnalyticEvents/{id}` | Get video analytics event by ID |
+| GET | `/eventSubscriptions` | List event subscriptions for the account |
+| POST | `/eventSubscriptions` | Create a new event subscription (SSE or webhook) |
+| GET | `/eventSubscriptions/{id}` | Retrieve a specific event subscription |
+| DELETE | `/eventSubscriptions/{id}` | Delete an event subscription |
 
-## VEHICLE SURVEILLANCE - LPR Events (4 endpoints)
+## Events - Alerts (3 endpoints)
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/lprEvents` | List LPR events |
-| GET | `/lprEvents/{id}` | Get LPR event by ID |
-| GET | `/lprEvents:summary` | Get LPR events summary |
-| GET | `/lprEvents:listFieldValues` | List LPR event field values |
+| GET | `/alerts` | List alerts with filtering and pagination |
+| GET | `/alerts/{id}` | Retrieve a specific alert by ID |
+| GET | `/alertTypes` | List all available alert types |
 
-## VEHICLE SURVEILLANCE - LPR Alert Condition Rules (6 endpoints)
-
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/lprAlertConditionRules` | List LPR alert condition rules |
-| POST | `/lprAlertConditionRules` | Create LPR alert condition rule |
-| GET | `/lprAlertConditionRules:listFieldValues` | List LPR rule field values |
-| GET | `/lprAlertConditionRules/{id}` | Get LPR alert condition rule |
-| PATCH | `/lprAlertConditionRules/{id}` | Update LPR alert condition rule |
-| DELETE | `/lprAlertConditionRules/{id}` | Delete LPR alert condition rule |
-
-## VEHICLE SURVEILLANCE - LPR Vehicle Lists (14 endpoints)
+## Events - Notifications (2 endpoints)
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/lprVehicleLists` | List vehicle lists |
-| POST | `/lprVehicleLists` | Create vehicle list |
-| GET | `/lprVehicleLists:listFields` | List vehicle list fields |
-| GET | `/lprVehicleLists:listFieldValues` | List vehicle list field values |
-| GET | `/lprVehicleLists/{id}` | Get vehicle list by ID |
-| PATCH | `/lprVehicleLists/{id}` | Update vehicle list |
-| DELETE | `/lprVehicleLists/{id}` | Delete vehicle list |
-| GET | `/lprVehicleLists/{id}/vehicles` | List vehicles in a list |
-| POST | `/lprVehicleLists/{id}/vehicles` | Add vehicle to list |
-| POST | `/lprVehicleLists/{id}/vehicles:bulkCreate` | Bulk add vehicles |
-| GET | `/lprVehicleLists/{id}/vehicles/{recordId}` | Get vehicle by ID |
-| PATCH | `/lprVehicleLists/{id}/vehicles/{recordId}` | Update a vehicle |
-| DELETE | `/lprVehicleLists/{id}/vehicles/{recordId}` | Delete a vehicle |
-| GET | `/lprVehicleLists:search` | Search vehicle lists |
+| GET | `/notifications` | List notifications with filtering and pagination |
+| GET | `/notifications/{id}` | Retrieve a specific notification by ID |
 
-## USER & ACCOUNTS - Users (9 endpoints)
+---
+
+## Automations - Event Alert Condition Rules (6 endpoints)
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/users` | List users |
-| POST | `/users` | Create a user |
-| GET | `/users/{userId}` | Get user by ID |
-| PATCH | `/users/{userId}` | Update a user |
-| DELETE | `/users/{userId}` | Delete a user |
-| GET | `/users/self` | Get current user |
-| PATCH | `/users/self` | Update current user |
-| GET | `/users/self/trustedClients` | List trusted OAuth clients |
-| DELETE | `/users/self/trustedClients/{trustedClientId}` | Delete trusted client |
+| POST | `/eventAlertConditionRules` | Create a new rule that produces alerts based on event conditions |
+| GET | `/eventAlertConditionRules` | List configured event alert condition rules |
+| GET | `/eventAlertConditionRules:listFieldValues` | Fetch available field values for alert condition rules |
+| GET | `/eventAlertConditionRules/{id}` | Retrieve details of a specific rule |
+| PATCH | `/eventAlertConditionRules/{id}` | Update a specific alert condition rule |
+| DELETE | `/eventAlertConditionRules/{id}` | Remove a specific alert condition rule |
 
-## USER & ACCOUNTS - Accounts (2 endpoints)
+## Automations - Alert Action Rules (5 endpoints)
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/accounts` | List accounts |
-| DELETE | `/accounts/{id}/credentials/{credentialId}` | Delete account credential |
+| POST | `/alertActionRules` | Register a new alert action rule with the account |
+| GET | `/alertActionRules` | List configured alert action rules |
+| GET | `/alertActionRules/{actionRuleId}` | Retrieve a single alert action rule |
+| PATCH | `/alertActionRules/{actionRuleId}` | Update a single alert action rule |
+| DELETE | `/alertActionRules/{actionRuleId}` | Remove an alert action rule |
 
-## USER & ACCOUNTS - Roles (8 endpoints)
-
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/roles` | List roles |
-| POST | `/roles` | Create a role |
-| GET | `/roles/{roleId}` | Get role by ID |
-| PATCH | `/roles/{roleId}` | Update a role |
-| DELETE | `/roles/{roleId}` | Delete a role |
-| GET | `/roleAssignments` | List role assignments |
-| POST | `/roleAssignments:bulkcreate` | Bulk create role assignments |
-| POST | `/roleAssignments:bulkdelete` | Bulk delete role assignments |
-
-## USER & ACCOUNTS - Audit Log (1 endpoint)
+## Automations - Alert Actions (5 endpoints)
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/auditLogs` | List audit logs |
+| POST | `/alertActions` | Register a new alert action with the account |
+| GET | `/alertActions` | List configured alert actions |
+| GET | `/alertActions/{actionId}` | Retrieve a single alert action |
+| PATCH | `/alertActions/{actionId}` | Update a single alert action |
+| DELETE | `/alertActions/{actionId}` | Remove an alert action |
 
-## USER & ACCOUNTS - Resource Grants (3 endpoints)
+---
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/resourceGrants` | List resource grants |
-| POST | `/resourceGrants:bulkCreate` | Bulk create resource grants |
-| POST | `/resourceGrants:bulkDelete` | Bulk delete resource grants |
-
-## USER & ACCOUNTS - Editions (2 endpoints)
+## Video Search - Video Analytic Events (7 endpoints)
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/editions` | List editions |
-| GET | `/editions/{id}` | Get edition by ID |
+| POST | `/videoAnalyticEvents:parse` | Map natural language queries to object filters for deep search |
+| POST | `/videoAnalyticEvents:deepSearch` | Fetch video analytic events matching defined filters |
+| POST | `/videoAnalyticEvents:deepSearchGroupByResource` | Fetch event frequencies grouped by resource metadata |
+| POST | `/videoAnalyticEvents:deepSearchGroupByTime` | Fetch event frequencies grouped in time periods |
+| POST | `/videoAnalyticEvents:listFieldValues` | Retrieve available deep search query parameters |
+| GET | `/videoAnalyticEvents:listObjectValues` | Fetch available filter attribute values for events |
+| GET | `/videoAnalyticEvents/{id}` | Retrieve specific video analytics event by ID |
 
-## RESELLERS - Authorization Tokens (1 endpoint)
+---
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/authorizationTokens` | Create authorization token (reseller account switching) |
-
-## ACCOUNT SETTINGS - SSO (2 endpoints)
-
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/accounts/self/ssoAuthSettings` | Get SSO auth settings |
-| PATCH | `/accounts/self/ssoAuthSettings` | Update SSO auth settings |
-
-## ACCOUNT SETTINGS - Client Settings (1 endpoint)
+## Vehicle Surveillance - LPR Events (4 endpoints)
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/clientSettings` | Get client settings |
+| GET | `/lprEvents` | Fetch license plate recognition events with filtering |
+| GET | `/lprEvents/{id}` | Retrieve a specific LPR event by ID |
+| GET | `/lprEvents:summary` | Obtain aggregated counts of LPR events across time periods |
+| GET | `/lprEvents:listFieldValues` | List all possible filter values for LPR event attributes |
 
-## SYSTEM - Applications (5 endpoints)
-
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/applications` | List applications |
-| POST | `/applications` | Create an application |
-| GET | `/applications/{applicationId}` | Get application by ID |
-| PATCH | `/applications/{applicationId}` | Update an application |
-| DELETE | `/applications/{applicationId}` | Delete an application |
-
-## SYSTEM - OAuth Clients (5 endpoints)
+## Vehicle Surveillance - LPR Alert Condition Rules (5 endpoints)
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/applications/{applicationId}/oauthClients` | List OAuth clients |
-| POST | `/applications/{applicationId}/oauthClients` | Create OAuth client |
-| GET | `/applications/{applicationId}/oauthClients/{clientId}` | Get OAuth client |
-| PATCH | `/applications/{applicationId}/oauthClients/{clientId}` | Update OAuth client |
-| DELETE | `/applications/{applicationId}/oauthClients/{clientId}` | Delete OAuth client |
+| POST | `/lprAlertConditionRules` | Create a new rule for generating alerts based on LPR conditions |
+| GET | `/lprAlertConditionRules` | Fetch LPR alert condition rules based on a filter |
+| GET | `/lprAlertConditionRules:listFieldValues` | Return possible values across all rule attributes |
+| GET | `/lprAlertConditionRules/{id}` | Retrieve details of a specific LPR rule |
+| PATCH | `/lprAlertConditionRules/{id}` | Update specified properties of an existing LPR rule |
 
-## SYSTEM - Reference Data (2 endpoints)
+---
+
+## User & Accounts - Users (9 endpoints)
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/languages` | List supported languages |
-| GET | `/timeZones` | List supported time zones |
+| GET | `/users` | Retrieve a list of users within the account |
+| POST | `/users` | Create a new user (verification email sent, pending state) |
+| GET | `/users/{userId}` | Retrieve information about a specific user |
+| DELETE | `/users/{userId}` | Delete a user and remove all related references |
+| PATCH | `/users/{userId}` | Update a user's data |
+| GET | `/users/self` | Retrieve information about the current authenticated user |
+| PATCH | `/users/self` | Update current user's profile data |
+| GET | `/users/self/trustedClients` | Retrieve a list of trusted clients |
+| DELETE | `/users/self/trustedClients/{trustedClientId}` | Delete a trusted client device |
+
+## User & Accounts - Accounts (2 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/accounts` | Retrieve a list of accounts the user has access to |
+| DELETE | `/accounts/{id}/credentials/{credentialId}` | Remove a credential from the account |
+
+## User & Accounts - Roles (8 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/roles` | Returns a list of all roles in current user's account |
+| POST | `/roles` | Create a new role with defined permissions |
+| GET | `/roles/{roleId}` | Retrieve a role by its ID |
+| DELETE | `/roles/{roleId}` | Delete a role (only if unassigned) |
+| PATCH | `/roles/{roleId}` | Update role information and permissions |
+| GET | `/roleAssignments` | Returns a list of all role assignments |
+| POST | `/roleAssignments:bulkcreate` | Create multiple role assignments in one request |
+| POST | `/roleAssignments:bulkdelete` | Delete multiple role assignments in one request |
+
+## User & Accounts - Audit Log (1 endpoint)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/auditLogs` | Filter audit events by userId, targetId, type, and timestamp range |
+
+## User & Accounts - Resource Grants (3 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/resourceGrants` | Retrieve a list of resource grants |
+| POST | `/resourceGrants:bulkCreate` | Create multiple resource grants in one request |
+| POST | `/resourceGrants:bulkDelete` | Delete multiple resource grants in one request |
+
+## User & Accounts - Editions (2 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/editions` | Retrieve available editions for the account |
+| GET | `/editions/{id}` | Retrieve a specific edition by ID |
+
+---
+
+## Resellers - Authorization Tokens (1 endpoint)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/authorizationTokens` | Resellers retrieve access tokens for end-user accounts |
+
+---
+
+## Account Settings - SSO (2 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/accounts/self/ssoAuthSettings` | Get Single Sign On Authentication Settings |
+| PATCH | `/accounts/self/ssoAuthSettings` | Update Single Sign On Authentication Settings |
+
+## Account Settings - Client Settings (1 endpoint)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/clientSettings` | Retrieve settings required to let the client use the API |
+
+---
+
+## System - Applications (5 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/applications` | Retrieve all applications accessible by the requesting user |
+| POST | `/applications` | Create new application under user's account |
+| GET | `/applications/{applicationId}` | Retrieve a single application |
+| PATCH | `/applications/{applicationId}` | Update a single application |
+| DELETE | `/applications/{applicationId}` | Delete a single application |
+
+## System - OAuth Clients (5 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/applications/{applicationId}/oauthClients` | Retrieve all OAuth credentials for the given application |
+| POST | `/applications/{applicationId}/oauthClients` | Create OAuth client for application |
+| GET | `/applications/{applicationId}/oauthClients/{clientId}` | Retrieve a specific OAuth client |
+| PATCH | `/applications/{applicationId}/oauthClients/{clientId}` | Update a specific OAuth client |
+| DELETE | `/applications/{applicationId}/oauthClients/{clientId}` | Delete a specific OAuth client |
+
+## System - Reference Data (2 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/languages` | Retrieve a list of languages supported by the service |
+| GET | `/timeZones` | Retrieve a list of the supported time zones |
 
 ---
 
@@ -463,19 +457,18 @@ All paths are prefixed with `/api/v3.0` on the appropriate base URL (e.g., `http
 | Media | Jobs | 3 |
 | Media | Files | 11 |
 | Media | Downloads | 4 |
-| Events | Events | 5 |
+| Events | Events | 4 |
 | Events | Event Types | 1 |
 | Events | Event Metrics | 1 |
-| Events | Event Subscriptions | 8 |
+| Events | Event Subscriptions | 4 |
 | Events | Alerts | 3 |
-| Events | Notifications | 3 |
+| Events | Notifications | 2 |
 | Automations | Event Alert Condition Rules | 6 |
 | Automations | Alert Action Rules | 5 |
 | Automations | Alert Actions | 5 |
 | Video Search | Video Analytic Events | 7 |
 | Vehicle Surveillance | LPR Events | 4 |
-| Vehicle Surveillance | LPR Alert Condition Rules | 6 |
-| Vehicle Surveillance | LPR Vehicle Lists | 14 |
+| Vehicle Surveillance | LPR Alert Condition Rules | 5 |
 | User & Accounts | Users | 9 |
 | User & Accounts | Accounts | 2 |
 | User & Accounts | Roles | 8 |
@@ -488,15 +481,15 @@ All paths are prefixed with `/api/v3.0` on the appropriate base URL (e.g., `http
 | System | Applications | 5 |
 | System | OAuth Clients | 5 |
 | System | Reference Data | 2 |
-| **TOTAL** | | **211** |
+| **TOTAL** | | **190** |
 
 ### By HTTP Method
 
 | Method | Count |
 |--------|-------|
-| GET | 117 |
-| POST | 35 |
-| PATCH | 30 |
-| DELETE | 27 |
+| GET | 99 |
+| POST | 37 |
+| PATCH | 29 |
+| DELETE | 23 |
 | PUT | 2 |
-| **Total** | **211** |
+| **TOTAL** | **190** |

--- a/docs/een-api-coverage.html
+++ b/docs/een-api-coverage.html
@@ -723,8 +723,12 @@ function filterTable() {
     const keys = ['_num','cat','sub','method','path','desc','status','func'];
     const key = keys[sortCol];
     data = data.slice().sort((a, b) => {
-      const av = key === '_num' ? 0 : (a[key] || '');
-      const bv = key === '_num' ? 0 : (b[key] || '');
+      if (key === '_num') {
+        const res = endpoints.indexOf(a) - endpoints.indexOf(b);
+        return sortAsc ? res : -res;
+      }
+      const av = String(a[key] || '');
+      const bv = String(b[key] || '');
       return sortAsc ? av.localeCompare(bv) : bv.localeCompare(av);
     });
   }

--- a/docs/een-api-coverage.html
+++ b/docs/een-api-coverage.html
@@ -3,441 +3,760 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>EEN API v3.0 - Toolkit Coverage Report</title>
+  <title>Eagle Eye Networks API v3.0 — Toolkit Coverage</title>
   <style>
-    * { margin: 0; padding: 0; box-sizing: border-box; }
-    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #f5f7fa; color: #1a1a2e; padding: 24px; }
-    h1 { font-size: 1.6rem; margin-bottom: 8px; }
-    .subtitle { color: #666; margin-bottom: 24px; font-size: 0.9rem; }
-    .stats { display: flex; gap: 16px; margin-bottom: 24px; flex-wrap: wrap; }
-    .stat-card { background: #fff; border-radius: 8px; padding: 16px 24px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); min-width: 140px; }
-    .stat-card .number { font-size: 2rem; font-weight: 700; }
-    .stat-card .label { font-size: 0.8rem; color: #666; text-transform: uppercase; letter-spacing: 0.5px; }
-    .stat-card.green .number { color: #16a34a; }
-    .stat-card.red .number { color: #dc2626; }
-    .stat-card.blue .number { color: #2563eb; }
-    .filter-bar { margin-bottom: 16px; display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
-    .filter-bar label { font-size: 0.85rem; font-weight: 600; }
-    .filter-bar select, .filter-bar input { padding: 6px 12px; border: 1px solid #d1d5db; border-radius: 6px; font-size: 0.85rem; }
-    .filter-bar input { width: 220px; }
-    table { width: 100%; border-collapse: collapse; background: #fff; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); font-size: 0.85rem; }
-    thead { background: #1e293b; color: #fff; }
-    th { padding: 10px 12px; text-align: left; font-weight: 600; cursor: pointer; user-select: none; white-space: nowrap; }
-    th:hover { background: #334155; }
-    td { padding: 8px 12px; border-bottom: 1px solid #f1f5f9; }
-    tr:hover td { background: #f8fafc; }
-    .method { display: inline-block; padding: 2px 8px; border-radius: 4px; font-weight: 700; font-size: 0.75rem; min-width: 56px; text-align: center; }
-    .method-GET { background: #dbeafe; color: #1d4ed8; }
-    .method-POST { background: #dcfce7; color: #166534; }
-    .method-PATCH { background: #fef3c7; color: #92400e; }
-    .method-DELETE { background: #fee2e2; color: #991b1b; }
-    .method-PUT { background: #e0e7ff; color: #3730a3; }
-    .status-impl { color: #16a34a; font-weight: 600; }
-    .status-miss { color: #dc2626; font-weight: 600; }
-    .badge { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 0.75rem; font-weight: 600; }
-    .badge-impl { background: #dcfce7; color: #166534; }
-    .badge-miss { background: #fee2e2; color: #991b1b; }
-    .func { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.8rem; color: #6d28d9; }
-    .category { font-size: 0.8rem; color: #64748b; }
-    .progress-bar { width: 100%; height: 8px; background: #fee2e2; border-radius: 4px; overflow: hidden; margin-top: 8px; }
-    .progress-fill { height: 100%; background: #16a34a; border-radius: 4px; transition: width 0.3s; }
-    footer { margin-top: 24px; font-size: 0.8rem; color: #94a3b8; text-align: center; }
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, sans-serif;
+      background: #f5f7fa;
+      color: #1a202c;
+      min-height: 100vh;
+    }
+
+    header {
+      background: #1a365d;
+      color: white;
+      padding: 24px 32px;
+    }
+
+    header h1 {
+      font-size: 1.5rem;
+      font-weight: 700;
+      margin-bottom: 6px;
+    }
+
+    header p {
+      font-size: 0.875rem;
+      color: #bee3f8;
+    }
+
+    .container {
+      max-width: 100%;
+      margin: 0 auto;
+      padding: 24px 32px;
+    }
+
+    /* Stat cards */
+    .stats {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 16px;
+      margin-bottom: 20px;
+    }
+
+    .stat-card {
+      background: white;
+      border-radius: 8px;
+      padding: 20px;
+      box-shadow: 0 1px 3px rgba(0,0,0,.08);
+    }
+
+    .stat-card.total    { border-top: 4px solid #4299e1; }
+    .stat-card.impl     { border-top: 4px solid #48bb78; }
+    .stat-card.miss     { border-top: 4px solid #fc8181; }
+    .stat-card.coverage { border-top: 4px solid #667eea; }
+
+    .stat-label {
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: .05em;
+      color: #718096;
+      margin-bottom: 8px;
+    }
+
+    .stat-value {
+      font-size: 2rem;
+      font-weight: 700;
+      color: #2d3748;
+      line-height: 1;
+      margin-bottom: 4px;
+    }
+
+    .stat-sub {
+      font-size: 0.8rem;
+      color: #718096;
+    }
+
+    /* Progress bar */
+    .progress-wrap {
+      background: white;
+      border-radius: 8px;
+      padding: 20px;
+      box-shadow: 0 1px 3px rgba(0,0,0,.08);
+      margin-bottom: 20px;
+    }
+
+    .progress-label-row {
+      display: flex;
+      justify-content: space-between;
+      font-size: 0.875rem;
+      color: #4a5568;
+      margin-bottom: 10px;
+    }
+
+    .progress-track {
+      background: #e2e8f0;
+      border-radius: 9999px;
+      height: 12px;
+      overflow: hidden;
+    }
+
+    .progress-fill {
+      background: linear-gradient(90deg, #48bb78, #38a169);
+      border-radius: 9999px;
+      height: 100%;
+      width: 28.9%;
+      transition: width .4s ease;
+    }
+
+    /* Filter bar */
+    .filter-bar {
+      background: white;
+      border-radius: 8px;
+      padding: 16px 20px;
+      box-shadow: 0 1px 3px rgba(0,0,0,.08);
+      margin-bottom: 20px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      align-items: center;
+    }
+
+    .filter-group {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .filter-group label {
+      font-size: 0.8rem;
+      color: #718096;
+    }
+
+    .filter-bar select,
+    .filter-bar input {
+      border: 1px solid #e2e8f0;
+      border-radius: 6px;
+      padding: 6px 10px;
+      font-size: 0.875rem;
+      font-family: inherit;
+      background: white;
+      color: #2d3748;
+      outline: none;
+    }
+
+    .filter-bar select:focus,
+    .filter-bar input:focus {
+      border-color: #4299e1;
+      box-shadow: 0 0 0 3px rgba(66,153,225,.15);
+    }
+
+    .filter-bar input[type="text"] { width: 220px; }
+
+    .filter-count {
+      margin-left: auto;
+      font-size: 0.8rem;
+      color: #718096;
+      align-self: flex-end;
+      padding-bottom: 2px;
+    }
+
+    /* Table */
+    .table-wrap {
+      background: white;
+      border-radius: 8px;
+      box-shadow: 0 1px 3px rgba(0,0,0,.08);
+      overflow-x: auto;
+      margin-bottom: 24px;
+    }
+
+    table {
+      width: 100%;
+      min-width: 1200px;
+      border-collapse: collapse;
+      font-size: 0.875rem;
+    }
+
+    thead {
+      background: #2d3748;
+      color: white;
+    }
+
+    thead th {
+      padding: 12px 14px;
+      text-align: left;
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: .05em;
+      cursor: pointer;
+      user-select: none;
+      white-space: nowrap;
+    }
+
+    thead th:hover { background: #4a5568; }
+
+    .sort-icon { margin-left: 4px; opacity: 0.5; }
+    .sort-icon.active { opacity: 1; }
+
+    tbody tr {
+      border-bottom: 1px solid #edf2f7;
+      transition: background 0.1s;
+    }
+
+    tbody tr:last-child { border-bottom: none; }
+    tbody tr:hover { background: #f7fafc; }
+
+    td { padding: 10px 14px; vertical-align: middle; }
+
+    .td-num  { color: #a0aec0; font-size: 0.75rem; width: 44px; }
+    .td-cat  { color: #4a5568; font-weight: 500; white-space: nowrap; }
+    .td-sub  { color: #718096; white-space: nowrap; }
+    .td-path { font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', monospace; font-size: 0.8rem; color: #2d3748; }
+    .td-desc { color: #4a5568; max-width: 280px; }
+    .td-func { font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', monospace; font-size: 0.78rem; color: #553c9a; white-space: nowrap; }
+
+    /* Badges */
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      padding: 2px 8px;
+      border-radius: 4px;
+      font-size: 0.72rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: .03em;
+      white-space: nowrap;
+    }
+
+    .m-get    { background: #ebf8ff; color: #2b6cb0; }
+    .m-post   { background: #f0fff4; color: #276749; }
+    .m-patch  { background: #fffff0; color: #975a16; }
+    .m-delete { background: #fff5f5; color: #c53030; }
+    .m-put    { background: #f0e6ff; color: #553c9a; }
+
+    .s-impl { background: #f0fff4; color: #276749; }
+    .s-miss { background: #fff5f5; color: #c53030; }
+
+    /* Empty state */
+    .empty-state {
+      text-align: center;
+      padding: 48px;
+      color: #a0aec0;
+    }
+
+    .empty-state svg {
+      width: 48px;
+      height: 48px;
+      margin: 0 auto 16px;
+      display: block;
+      opacity: 0.5;
+    }
+
+    .empty-state p { font-size: 0.9rem; }
+
+    footer {
+      text-align: center;
+      padding: 24px;
+      color: #a0aec0;
+      font-size: 0.8rem;
+    }
   </style>
 </head>
 <body>
 
-<h1>Eagle Eye Networks API v3.0 - Toolkit Coverage</h1>
-<p class="subtitle">Generated: 2026-02-17 | een-api-toolkit implementation status</p>
+<header>
+  <h1>Eagle Eye Networks API v3.0 &mdash; Toolkit Coverage</h1>
+  <p>Generated: 2026-02-21 &nbsp;&middot;&nbsp; Source: <a href="https://developer.eagleeyenetworks.com/reference/using-the-api" style="color:#bee3f8">EEN Developer Portal</a> &nbsp;&middot;&nbsp; <a href="https://github.com/EENCloud/VMS-Developer-Portal" style="color:#bee3f8">OpenAPI Specs</a></p>
+</header>
 
-<div class="stats">
-  <div class="stat-card blue">
-    <div class="number">211</div>
-    <div class="label">Total Endpoints</div>
+<div class="container">
+
+  <div class="stats">
+    <div class="stat-card total">
+      <div class="stat-label">Total Endpoints</div>
+      <div class="stat-value">190</div>
+      <div class="stat-sub">EEN API v3.0</div>
+    </div>
+    <div class="stat-card impl">
+      <div class="stat-label">Implemented</div>
+      <div class="stat-value">55</div>
+      <div class="stat-sub">REST endpoints</div>
+    </div>
+    <div class="stat-card miss">
+      <div class="stat-label">Missing</div>
+      <div class="stat-value">135</div>
+      <div class="stat-sub">not yet implemented</div>
+    </div>
+    <div class="stat-card coverage">
+      <div class="stat-label">Coverage</div>
+      <div class="stat-value">28.9%</div>
+      <div class="stat-sub">55 / 190</div>
+    </div>
   </div>
-  <div class="stat-card green">
-    <div class="number">51</div>
-    <div class="label">Implemented</div>
+
+  <div class="progress-wrap">
+    <div class="progress-label-row">
+      <span>REST API Coverage</span>
+      <span>28.9% (55 of 190 endpoints)</span>
+    </div>
+    <div class="progress-track">
+      <div class="progress-fill"></div>
+    </div>
   </div>
-  <div class="stat-card red">
-    <div class="number">160</div>
-    <div class="label">Missing</div>
+
+  <div class="filter-bar">
+    <div class="filter-group">
+      <label for="f-status">Status</label>
+      <select id="f-status" onchange="filterTable()">
+        <option value="">All</option>
+        <option value="impl">Implemented</option>
+        <option value="miss">Missing</option>
+      </select>
+    </div>
+    <div class="filter-group">
+      <label for="f-cat">Category</label>
+      <select id="f-cat" onchange="filterTable()">
+        <option value="">All</option>
+        <option>Devices</option>
+        <option>Grouping</option>
+        <option>Media</option>
+        <option>Events</option>
+        <option>Automations</option>
+        <option>Video Search</option>
+        <option>Vehicle Surveillance</option>
+        <option>User &amp; Accounts</option>
+        <option>Resellers</option>
+        <option>Account Settings</option>
+        <option>System</option>
+      </select>
+    </div>
+    <div class="filter-group">
+      <label for="f-method">Method</label>
+      <select id="f-method" onchange="filterTable()">
+        <option value="">All</option>
+        <option>GET</option>
+        <option>POST</option>
+        <option>PATCH</option>
+        <option>DELETE</option>
+        <option>PUT</option>
+      </select>
+    </div>
+    <div class="filter-group">
+      <label for="f-search">Search</label>
+      <input type="text" id="f-search" placeholder="path, function, description..." oninput="filterTable()">
+    </div>
+    <div class="filter-count" id="filter-count">Showing 190 of 190</div>
   </div>
-  <div class="stat-card">
-    <div class="number">24.2%</div>
-    <div class="label">Coverage</div>
-    <div class="progress-bar"><div class="progress-fill" style="width:24.2%"></div></div>
+
+  <div class="table-wrap">
+    <table>
+      <thead>
+        <tr>
+          <th class="td-num" onclick="sortTable(0)">#<span class="sort-icon" id="si-0">⇅</span></th>
+          <th onclick="sortTable(1)">Category<span class="sort-icon" id="si-1">⇅</span></th>
+          <th onclick="sortTable(2)">Subcategory<span class="sort-icon" id="si-2">⇅</span></th>
+          <th onclick="sortTable(3)">Method<span class="sort-icon" id="si-3">⇅</span></th>
+          <th onclick="sortTable(4)">Path<span class="sort-icon" id="si-4">⇅</span></th>
+          <th onclick="sortTable(5)">Description<span class="sort-icon" id="si-5">⇅</span></th>
+          <th onclick="sortTable(6)">Status<span class="sort-icon" id="si-6">⇅</span></th>
+          <th onclick="sortTable(7)">Toolkit Function<span class="sort-icon" id="si-7">⇅</span></th>
+        </tr>
+      </thead>
+      <tbody id="tbody"></tbody>
+    </table>
+    <div class="empty-state" id="empty-state" style="display:none">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+        <circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/>
+      </svg>
+      <p>No endpoints match your filters. Try adjusting the search criteria.</p>
+    </div>
   </div>
+
 </div>
-
-<div class="filter-bar">
-  <label>Filter:</label>
-  <select id="statusFilter" onchange="filterTable()">
-    <option value="all">All Endpoints</option>
-    <option value="implemented">Implemented Only</option>
-    <option value="missing">Missing Only</option>
-  </select>
-  <select id="categoryFilter" onchange="filterTable()">
-    <option value="all">All Categories</option>
-    <option value="Devices">Devices</option>
-    <option value="Grouping">Grouping</option>
-    <option value="Media">Media</option>
-    <option value="Events">Events</option>
-    <option value="Automations">Automations</option>
-    <option value="Video Search">Video Search</option>
-    <option value="Vehicle Surveillance">Vehicle Surveillance</option>
-    <option value="User &amp; Accounts">User &amp; Accounts</option>
-    <option value="Resellers">Resellers</option>
-    <option value="Account Settings">Account Settings</option>
-    <option value="System">System</option>
-  </select>
-  <select id="methodFilter" onchange="filterTable()">
-    <option value="all">All Methods</option>
-    <option value="GET">GET</option>
-    <option value="POST">POST</option>
-    <option value="PATCH">PATCH</option>
-    <option value="DELETE">DELETE</option>
-    <option value="PUT">PUT</option>
-  </select>
-  <input type="text" id="searchFilter" placeholder="Search path or function..." oninput="filterTable()">
-</div>
-
-<table id="apiTable">
-  <thead>
-    <tr>
-      <th onclick="sortTable(0)">#</th>
-      <th onclick="sortTable(1)">Category</th>
-      <th onclick="sortTable(2)">Subcategory</th>
-      <th onclick="sortTable(3)">Method</th>
-      <th onclick="sortTable(4)">Path</th>
-      <th onclick="sortTable(5)">Description</th>
-      <th onclick="sortTable(6)">Status</th>
-      <th onclick="sortTable(7)">Toolkit Function</th>
-    </tr>
-  </thead>
-  <tbody id="tableBody">
-  </tbody>
-</table>
 
 <footer>
-  Source: <a href="https://developer.eagleeyenetworks.com/reference/using-the-api">EEN Developer Portal</a> |
-  <a href="https://github.com/EENCloud/VMS-Developer-Portal">OpenAPI Specs</a>
+  Eagle Eye Networks API v3.0 Coverage Report &nbsp;&middot;&nbsp; Generated 2026-02-21 &nbsp;&middot;&nbsp; een-api-toolkit
 </footer>
 
 <script>
 const endpoints = [
-  // DEVICES - Cameras (15)
-  {cat:"Devices",sub:"Cameras",method:"GET",path:"/cameras",desc:"List cameras",status:"impl",func:"getCameras()"},
-  {cat:"Devices",sub:"Cameras",method:"POST",path:"/cameras",desc:"Add a camera",status:"miss",func:""},
-  {cat:"Devices",sub:"Cameras",method:"POST",path:"/cameras:bulkUpdate",desc:"Bulk update cameras",status:"miss",func:""},
-  {cat:"Devices",sub:"Cameras",method:"GET",path:"/cameras/{cameraId}",desc:"Get camera by ID",status:"impl",func:"getCamera()"},
-  {cat:"Devices",sub:"Cameras",method:"PATCH",path:"/cameras/{cameraId}",desc:"Update a camera",status:"miss",func:""},
-  {cat:"Devices",sub:"Cameras",method:"DELETE",path:"/cameras/{cameraId}",desc:"Delete a camera",status:"miss",func:""},
-  {cat:"Devices",sub:"Cameras",method:"PUT",path:"/cameras/{cameraId}/tunnel",desc:"Create/update camera tunnel",status:"miss",func:""},
-  {cat:"Devices",sub:"Cameras",method:"DELETE",path:"/cameras/{cameraId}/tunnel",desc:"Delete camera tunnel",status:"miss",func:""},
-  {cat:"Devices",sub:"Cameras",method:"GET",path:"/cameras/{cameraId}/metrics",desc:"Get camera metrics",status:"miss",func:""},
-  {cat:"Devices",sub:"Cameras",method:"PATCH",path:"/cameras/{cameraId}:swap",desc:"Swap a camera",status:"miss",func:""},
-  {cat:"Devices",sub:"Cameras",method:"GET",path:"/cameras/{cameraId}/io/ports",desc:"List camera I/O ports",status:"miss",func:""},
-  {cat:"Devices",sub:"Cameras",method:"GET",path:"/cameras/{cameraId}/io/ports/{portId}",desc:"Get camera I/O port",status:"miss",func:""},
-  {cat:"Devices",sub:"Cameras",method:"PATCH",path:"/cameras/{cameraId}/io/ports/{portId}",desc:"Update camera I/O port",status:"miss",func:""},
-  {cat:"Devices",sub:"Cameras",method:"GET",path:"/cameras/{cameraId}/settings",desc:"Get camera settings",status:"impl",func:"getCameraSettings()"},
-  {cat:"Devices",sub:"Cameras",method:"PATCH",path:"/cameras/{cameraId}/settings",desc:"Update camera settings",status:"miss",func:""},
-  // DEVICES - Bridges (11)
-  {cat:"Devices",sub:"Bridges",method:"GET",path:"/bridges",desc:"List bridges",status:"impl",func:"getBridges()"},
-  {cat:"Devices",sub:"Bridges",method:"POST",path:"/bridges",desc:"Create a bridge",status:"miss",func:""},
-  {cat:"Devices",sub:"Bridges",method:"POST",path:"/bridges:bulkUpdate",desc:"Bulk update bridges",status:"miss",func:""},
-  {cat:"Devices",sub:"Bridges",method:"GET",path:"/bridges/{bridgeId}",desc:"Get bridge by ID",status:"impl",func:"getBridge()"},
-  {cat:"Devices",sub:"Bridges",method:"PATCH",path:"/bridges/{bridgeId}",desc:"Update a bridge",status:"miss",func:""},
-  {cat:"Devices",sub:"Bridges",method:"DELETE",path:"/bridges/{bridgeId}",desc:"Delete a bridge",status:"miss",func:""},
-  {cat:"Devices",sub:"Bridges",method:"GET",path:"/bridges/{bridgeId}/metrics",desc:"Get bridge metrics",status:"miss",func:""},
-  {cat:"Devices",sub:"Bridges",method:"PATCH",path:"/bridges/{bridgeId}:swap",desc:"Swap a bridge",status:"miss",func:""},
-  {cat:"Devices",sub:"Bridges",method:"POST",path:"/bridges/{bridgeId}/actions",desc:"Trigger bridge action",status:"miss",func:""},
-  {cat:"Devices",sub:"Bridges",method:"GET",path:"/bridges/{id}/settings",desc:"Get bridge settings",status:"miss",func:""},
-  {cat:"Devices",sub:"Bridges",method:"PATCH",path:"/bridges/{id}/settings",desc:"Update bridge settings",status:"miss",func:""},
-  // DEVICES - PTZ (4)
-  {cat:"Devices",sub:"PTZ",method:"GET",path:"/cameras/{cameraId}/ptz/position",desc:"Get current PTZ position",status:"miss",func:""},
-  {cat:"Devices",sub:"PTZ",method:"PUT",path:"/cameras/{cameraId}/ptz/position",desc:"Move PTZ to position",status:"miss",func:""},
-  {cat:"Devices",sub:"PTZ",method:"GET",path:"/cameras/{cameraId}/ptz/settings",desc:"Get PTZ settings",status:"miss",func:""},
-  {cat:"Devices",sub:"PTZ",method:"PATCH",path:"/cameras/{cameraId}/ptz/settings",desc:"Update PTZ settings",status:"miss",func:""},
-  // DEVICES - Speakers (7)
-  {cat:"Devices",sub:"Speakers",method:"GET",path:"/speakers",desc:"List speakers",status:"miss",func:""},
-  {cat:"Devices",sub:"Speakers",method:"POST",path:"/speakers",desc:"Add a speaker",status:"miss",func:""},
-  {cat:"Devices",sub:"Speakers",method:"GET",path:"/speakers/{speakerId}",desc:"Get speaker by ID",status:"miss",func:""},
-  {cat:"Devices",sub:"Speakers",method:"PATCH",path:"/speakers/{speakerId}",desc:"Update a speaker",status:"miss",func:""},
-  {cat:"Devices",sub:"Speakers",method:"DELETE",path:"/speakers/{speakerId}",desc:"Delete a speaker",status:"miss",func:""},
-  {cat:"Devices",sub:"Speakers",method:"GET",path:"/speakers/{speakerId}/settings",desc:"Get speaker settings",status:"miss",func:""},
-  {cat:"Devices",sub:"Speakers",method:"PATCH",path:"/speakers/{speakerId}/settings",desc:"Update speaker settings",status:"miss",func:""},
-  // DEVICES - Device I/O (6)
-  {cat:"Devices",sub:"Device I/O",method:"GET",path:"/devices/{deviceId}/io/ports",desc:"List device I/O ports",status:"miss",func:""},
-  {cat:"Devices",sub:"Device I/O",method:"GET",path:"/devices/{deviceId}/io/ports/{portId}",desc:"Get device I/O port",status:"miss",func:""},
-  {cat:"Devices",sub:"Device I/O",method:"PATCH",path:"/devices/{deviceId}/io/ports/{portId}",desc:"Update device I/O port",status:"miss",func:""},
-  {cat:"Devices",sub:"Device I/O",method:"GET",path:"/devices/{deviceId}/io/ports/{portId}/recordingActions",desc:"List port recording actions",status:"miss",func:""},
-  {cat:"Devices",sub:"Device I/O",method:"GET",path:"/devices/{deviceId}/io/ports/{portId}/recordingActions/{cameraId}",desc:"Get port recording action",status:"miss",func:""},
-  {cat:"Devices",sub:"Device I/O",method:"PATCH",path:"/devices/{deviceId}/io/ports/{portId}/recordingActions/{cameraId}",desc:"Update port recording action",status:"miss",func:""},
-  // DEVICES - Switches (5)
-  {cat:"Devices",sub:"Switches",method:"GET",path:"/switches",desc:"List switches",status:"miss",func:""},
-  {cat:"Devices",sub:"Switches",method:"GET",path:"/switches/{switchId}",desc:"Get switch by ID",status:"miss",func:""},
-  {cat:"Devices",sub:"Switches",method:"PATCH",path:"/switches/{switchId}",desc:"Update a switch",status:"miss",func:""},
-  {cat:"Devices",sub:"Switches",method:"POST",path:"/switches/{switchId}/ports/{portId}/actions",desc:"Trigger switch port action",status:"miss",func:""},
-  {cat:"Devices",sub:"Switches",method:"POST",path:"/switches/{switchId}/ports/all/actions",desc:"Trigger action on all switch ports",status:"miss",func:""},
-  // DEVICES - Multi Cameras (6)
-  {cat:"Devices",sub:"Multi Cameras",method:"GET",path:"/multiCameras",desc:"List multi-cameras",status:"miss",func:""},
-  {cat:"Devices",sub:"Multi Cameras",method:"POST",path:"/multiCameras",desc:"Add a multi-camera",status:"miss",func:""},
-  {cat:"Devices",sub:"Multi Cameras",method:"GET",path:"/multiCameras/{multiCameraId}",desc:"Get multi-camera by ID",status:"miss",func:""},
-  {cat:"Devices",sub:"Multi Cameras",method:"PATCH",path:"/multiCameras/{multiCameraId}",desc:"Update a multi-camera",status:"miss",func:""},
-  {cat:"Devices",sub:"Multi Cameras",method:"DELETE",path:"/multiCameras/{multiCameraId}",desc:"Delete a multi-camera",status:"miss",func:""},
-  {cat:"Devices",sub:"Multi Cameras",method:"GET",path:"/multiCameras/{multiCameraId}/channels",desc:"Get multi-camera channels",status:"miss",func:""},
-  // DEVICES - Available Devices (1)
-  {cat:"Devices",sub:"Available Devices",method:"GET",path:"/availableDevices",desc:"List available (unclaimed) devices",status:"miss",func:""},
-  // GROUPING - Layouts (5)
-  {cat:"Grouping",sub:"Layouts",method:"GET",path:"/layouts",desc:"List layouts",status:"impl",func:"getLayouts()"},
-  {cat:"Grouping",sub:"Layouts",method:"POST",path:"/layouts",desc:"Create a layout",status:"impl",func:"createLayout()"},
-  {cat:"Grouping",sub:"Layouts",method:"GET",path:"/layouts/{layoutId}",desc:"Get layout by ID",status:"impl",func:"getLayout()"},
-  {cat:"Grouping",sub:"Layouts",method:"PATCH",path:"/layouts/{layoutId}",desc:"Update a layout",status:"impl",func:"updateLayout()"},
-  {cat:"Grouping",sub:"Layouts",method:"DELETE",path:"/layouts/{layoutId}",desc:"Delete a layout",status:"impl",func:"deleteLayout()"},
-  // GROUPING - Tags (1)
-  {cat:"Grouping",sub:"Tags",method:"GET",path:"/tags",desc:"List tags",status:"miss",func:""},
-  // GROUPING - Locations (6)
-  {cat:"Grouping",sub:"Locations",method:"GET",path:"/locations",desc:"List locations",status:"miss",func:""},
-  {cat:"Grouping",sub:"Locations",method:"POST",path:"/locations",desc:"Create a location",status:"miss",func:""},
-  {cat:"Grouping",sub:"Locations",method:"GET",path:"/locations/{id}",desc:"Get location by ID",status:"miss",func:""},
-  {cat:"Grouping",sub:"Locations",method:"PATCH",path:"/locations/{id}",desc:"Update a location",status:"miss",func:""},
-  {cat:"Grouping",sub:"Locations",method:"DELETE",path:"/locations/{id}",desc:"Delete a location",status:"miss",func:""},
-  {cat:"Grouping",sub:"Locations",method:"GET",path:"/locations/{id}/locations",desc:"Get location descendants",status:"miss",func:""},
-  // GROUPING - Floors (6)
-  {cat:"Grouping",sub:"Floors",method:"GET",path:"/locations/{locationId}/floors",desc:"List floors",status:"miss",func:""},
-  {cat:"Grouping",sub:"Floors",method:"POST",path:"/locations/{locationId}/floors",desc:"Create a floor",status:"miss",func:""},
-  {cat:"Grouping",sub:"Floors",method:"GET",path:"/locations/{locationId}/floors/{id}",desc:"Get floor by ID",status:"miss",func:""},
-  {cat:"Grouping",sub:"Floors",method:"PATCH",path:"/locations/{locationId}/floors/{id}",desc:"Update a floor",status:"miss",func:""},
-  {cat:"Grouping",sub:"Floors",method:"DELETE",path:"/locations/{locationId}/floors/{id}",desc:"Delete a floor",status:"miss",func:""},
-  {cat:"Grouping",sub:"Floors",method:"GET",path:"/locations/{locationId}/floors/{id}.{type}",desc:"Get floor image",status:"miss",func:""},
-  // GROUPING - Floor Plans (3)
-  {cat:"Grouping",sub:"Floor Plans",method:"GET",path:"/locations/{locationId}/floors/{id}/plans",desc:"List floor plans",status:"miss",func:""},
-  {cat:"Grouping",sub:"Floor Plans",method:"POST",path:"/locations/{locationId}/floors/{id}/plans",desc:"Set a floor plan",status:"miss",func:""},
-  {cat:"Grouping",sub:"Floor Plans",method:"DELETE",path:"/locations/{locationId}/floors/{id}/plans/{planId}",desc:"Delete a floor plan",status:"miss",func:""},
-  // MEDIA - Media (5)
-  {cat:"Media",sub:"Media",method:"GET",path:"/media",desc:"List media (recording spans)",status:"impl",func:"listMedia()"},
-  {cat:"Media",sub:"Media",method:"GET",path:"/media/recordedImage.jpeg",desc:"Get recorded image",status:"impl",func:"getRecordedImage()"},
-  {cat:"Media",sub:"Media",method:"GET",path:"/media/recordedImage.jpeg:listFieldValues",desc:"List overlay field values",status:"miss",func:""},
-  {cat:"Media",sub:"Media",method:"GET",path:"/media/liveImage.jpeg",desc:"Get live image",status:"impl",func:"getLiveImage()"},
-  {cat:"Media",sub:"Media",method:"GET",path:"/media/session",desc:"Get media session URL",status:"impl",func:"getMediaSession()"},
-  // MEDIA - Feeds (1)
-  {cat:"Media",sub:"Feeds",method:"GET",path:"/feeds",desc:"List feeds",status:"impl",func:"listFeeds()"},
-  // MEDIA - Exports (2)
-  {cat:"Media",sub:"Exports",method:"POST",path:"/exports",desc:"Create an export job",status:"impl",func:"createExportJob()"},
-  {cat:"Media",sub:"Exports",method:"POST",path:"/exports/{jobId}:copy",desc:"Retry/copy an export",status:"miss",func:""},
-  // MEDIA - Jobs (3)
-  {cat:"Media",sub:"Jobs",method:"GET",path:"/jobs",desc:"List jobs",status:"impl",func:"listJobs()"},
-  {cat:"Media",sub:"Jobs",method:"GET",path:"/jobs/{jobId}",desc:"Get job by ID",status:"impl",func:"getJob()"},
-  {cat:"Media",sub:"Jobs",method:"DELETE",path:"/jobs/{jobId}",desc:"Delete a job",status:"impl",func:"deleteJob()"},
-  // MEDIA - Files (11)
-  {cat:"Media",sub:"Files",method:"GET",path:"/files",desc:"List files",status:"impl",func:"listFiles()"},
-  {cat:"Media",sub:"Files",method:"POST",path:"/files",desc:"Add a file",status:"impl",func:"addFile()"},
-  {cat:"Media",sub:"Files",method:"GET",path:"/files/{id}",desc:"Get file by ID",status:"impl",func:"getFile()"},
-  {cat:"Media",sub:"Files",method:"PATCH",path:"/files/{id}",desc:"Update a file",status:"miss",func:""},
-  {cat:"Media",sub:"Files",method:"DELETE",path:"/files/{id}",desc:"Delete a file",status:"impl",func:"deleteFile()"},
-  {cat:"Media",sub:"Files",method:"GET",path:"/files/{id}:download",desc:"Download a file",status:"impl",func:"downloadFile()"},
-  {cat:"Media",sub:"Files",method:"GET",path:"/deletedFiles",desc:"List trash",status:"miss",func:""},
-  {cat:"Media",sub:"Files",method:"GET",path:"/deletedFiles/{id}",desc:"Get deleted file",status:"miss",func:""},
-  {cat:"Media",sub:"Files",method:"DELETE",path:"/deletedFiles/{id}",desc:"Permanently delete trash file",status:"miss",func:""},
-  {cat:"Media",sub:"Files",method:"DELETE",path:"/deletedFiles/all",desc:"Empty trash",status:"miss",func:""},
-  {cat:"Media",sub:"Files",method:"POST",path:"/deletedFiles/{id}:restore",desc:"Restore deleted file",status:"miss",func:""},
-  // MEDIA - Downloads (4)
-  {cat:"Media",sub:"Downloads",method:"GET",path:"/downloads",desc:"List downloads",status:"impl",func:"listDownloads()"},
-  {cat:"Media",sub:"Downloads",method:"GET",path:"/downloads/{id}",desc:"Get download by ID",status:"impl",func:"getDownload()"},
-  {cat:"Media",sub:"Downloads",method:"PATCH",path:"/downloads/{id}",desc:"Update a download",status:"miss",func:""},
-  {cat:"Media",sub:"Downloads",method:"GET",path:"/downloads/{id}:download",desc:"Download a download file",status:"impl",func:"downloadDownload()"},
-  // EVENTS - Events (5)
-  {cat:"Events",sub:"Events",method:"GET",path:"/events",desc:"List events",status:"impl",func:"listEvents()"},
-  {cat:"Events",sub:"Events",method:"POST",path:"/events",desc:"Create an event",status:"miss",func:""},
-  {cat:"Events",sub:"Events",method:"GET",path:"/events/{id}",desc:"Get event by ID",status:"impl",func:"getEvent()"},
-  {cat:"Events",sub:"Events",method:"GET",path:"/events:listRecentByType",desc:"List recent events by type",status:"miss",func:""},
-  {cat:"Events",sub:"Events",method:"GET",path:"/events:listFieldValues",desc:"List event field values",status:"impl",func:"listEventFieldValues()"},
-  // EVENTS - Event Types (1)
-  {cat:"Events",sub:"Event Types",method:"GET",path:"/eventTypes",desc:"List event types",status:"impl",func:"listEventTypes()"},
-  // EVENTS - Event Metrics (1)
-  {cat:"Events",sub:"Event Metrics",method:"GET",path:"/eventMetrics",desc:"Get event metrics",status:"impl",func:"getEventMetrics()"},
-  // EVENTS - Event Subscriptions (8)
-  {cat:"Events",sub:"Event Subscriptions",method:"GET",path:"/eventSubscriptions",desc:"List event subscriptions",status:"impl",func:"listEventSubscriptions()"},
-  {cat:"Events",sub:"Event Subscriptions",method:"POST",path:"/eventSubscriptions",desc:"Create event subscription",status:"impl",func:"createEventSubscription()"},
-  {cat:"Events",sub:"Event Subscriptions",method:"GET",path:"/eventSubscriptions/{id}",desc:"Get event subscription",status:"impl",func:"getEventSubscription()"},
-  {cat:"Events",sub:"Event Subscriptions",method:"DELETE",path:"/eventSubscriptions/{id}",desc:"Delete event subscription",status:"impl",func:"deleteEventSubscription()"},
-  {cat:"Events",sub:"Event Subscriptions",method:"GET",path:"/eventSubscriptions/{id}/filters",desc:"List subscription filters",status:"miss",func:""},
-  {cat:"Events",sub:"Event Subscriptions",method:"POST",path:"/eventSubscriptions/{id}/filters",desc:"Create subscription filter",status:"miss",func:""},
-  {cat:"Events",sub:"Event Subscriptions",method:"GET",path:"/eventSubscriptions/{id}/filters/{filterId}",desc:"Get subscription filter",status:"miss",func:""},
-  {cat:"Events",sub:"Event Subscriptions",method:"DELETE",path:"/eventSubscriptions/{id}/filters/{filterId}",desc:"Delete subscription filter",status:"miss",func:""},
-  // EVENTS - Alerts (3)
-  {cat:"Events",sub:"Alerts",method:"GET",path:"/alerts",desc:"List alerts",status:"impl",func:"listAlerts()"},
-  {cat:"Events",sub:"Alerts",method:"GET",path:"/alerts/{id}",desc:"Get alert by ID",status:"impl",func:"getAlert()"},
-  {cat:"Events",sub:"Alerts",method:"GET",path:"/alertTypes",desc:"List alert types",status:"impl",func:"listAlertTypes()"},
-  // EVENTS - Notifications (3)
-  {cat:"Events",sub:"Notifications",method:"GET",path:"/notifications",desc:"List notifications",status:"impl",func:"listNotifications()"},
-  {cat:"Events",sub:"Notifications",method:"GET",path:"/notifications/{id}",desc:"Get notification by ID",status:"impl",func:"getNotification()"},
-  {cat:"Events",sub:"Notifications",method:"PATCH",path:"/notifications/{id}",desc:"Update a notification",status:"miss",func:""},
-  // AUTOMATIONS - Event Alert Condition Rules (6)
-  {cat:"Automations",sub:"Event Alert Condition Rules",method:"GET",path:"/eventAlertConditionRules",desc:"List rules",status:"impl",func:"listEventAlertConditionRules()"},
-  {cat:"Automations",sub:"Event Alert Condition Rules",method:"POST",path:"/eventAlertConditionRules",desc:"Create rule",status:"miss",func:""},
-  {cat:"Automations",sub:"Event Alert Condition Rules",method:"GET",path:"/eventAlertConditionRules:listFieldValues",desc:"List field values",status:"impl",func:"getEventAlertConditionRuleFieldValues()"},
-  {cat:"Automations",sub:"Event Alert Condition Rules",method:"GET",path:"/eventAlertConditionRules/{id}",desc:"Get rule by ID",status:"impl",func:"getEventAlertConditionRule()"},
-  {cat:"Automations",sub:"Event Alert Condition Rules",method:"PATCH",path:"/eventAlertConditionRules/{id}",desc:"Update rule",status:"miss",func:""},
-  {cat:"Automations",sub:"Event Alert Condition Rules",method:"DELETE",path:"/eventAlertConditionRules/{id}",desc:"Delete rule",status:"miss",func:""},
-  // AUTOMATIONS - Alert Action Rules (5)
-  {cat:"Automations",sub:"Alert Action Rules",method:"GET",path:"/alertActionRules",desc:"List alert action rules",status:"impl",func:"listAlertActionRules()"},
-  {cat:"Automations",sub:"Alert Action Rules",method:"POST",path:"/alertActionRules",desc:"Create alert action rule",status:"miss",func:""},
-  {cat:"Automations",sub:"Alert Action Rules",method:"GET",path:"/alertActionRules/{actionRuleId}",desc:"Get alert action rule",status:"impl",func:"getAlertActionRule()"},
-  {cat:"Automations",sub:"Alert Action Rules",method:"PATCH",path:"/alertActionRules/{actionRuleId}",desc:"Update alert action rule",status:"miss",func:""},
-  {cat:"Automations",sub:"Alert Action Rules",method:"DELETE",path:"/alertActionRules/{actionRuleId}",desc:"Delete alert action rule",status:"miss",func:""},
-  // AUTOMATIONS - Alert Actions (5)
-  {cat:"Automations",sub:"Alert Actions",method:"GET",path:"/alertActions",desc:"List alert actions",status:"impl",func:"listAlertActions()"},
-  {cat:"Automations",sub:"Alert Actions",method:"POST",path:"/alertActions",desc:"Create alert action",status:"miss",func:""},
-  {cat:"Automations",sub:"Alert Actions",method:"GET",path:"/alertActions/{actionId}",desc:"Get alert action",status:"impl",func:"getAlertAction()"},
-  {cat:"Automations",sub:"Alert Actions",method:"PATCH",path:"/alertActions/{actionId}",desc:"Update alert action",status:"miss",func:""},
-  {cat:"Automations",sub:"Alert Actions",method:"DELETE",path:"/alertActions/{actionId}",desc:"Delete alert action",status:"miss",func:""},
-  // VIDEO SEARCH (7)
-  {cat:"Video Search",sub:"Video Analytic Events",method:"POST",path:"/videoAnalyticEvents:parse",desc:"Parse video analytics query",status:"miss",func:""},
-  {cat:"Video Search",sub:"Video Analytic Events",method:"POST",path:"/videoAnalyticEvents:deepSearch",desc:"Deep search events",status:"miss",func:""},
-  {cat:"Video Search",sub:"Video Analytic Events",method:"POST",path:"/videoAnalyticEvents:deepSearchGroupByResource",desc:"Deep search by resource",status:"miss",func:""},
-  {cat:"Video Search",sub:"Video Analytic Events",method:"POST",path:"/videoAnalyticEvents:deepSearchGroupByTime",desc:"Deep search by time",status:"miss",func:""},
-  {cat:"Video Search",sub:"Video Analytic Events",method:"POST",path:"/videoAnalyticEvents:listFieldValues",desc:"List field values",status:"miss",func:""},
-  {cat:"Video Search",sub:"Video Analytic Events",method:"GET",path:"/videoAnalyticEvents:listObjectValues",desc:"List object values",status:"miss",func:""},
-  {cat:"Video Search",sub:"Video Analytic Events",method:"GET",path:"/videoAnalyticEvents/{id}",desc:"Get event by ID",status:"miss",func:""},
-  // VEHICLE SURVEILLANCE - LPR Events (4)
-  {cat:"Vehicle Surveillance",sub:"LPR Events",method:"GET",path:"/lprEvents",desc:"List LPR events",status:"miss",func:""},
-  {cat:"Vehicle Surveillance",sub:"LPR Events",method:"GET",path:"/lprEvents/{id}",desc:"Get LPR event by ID",status:"miss",func:""},
-  {cat:"Vehicle Surveillance",sub:"LPR Events",method:"GET",path:"/lprEvents:summary",desc:"Get LPR events summary",status:"miss",func:""},
-  {cat:"Vehicle Surveillance",sub:"LPR Events",method:"GET",path:"/lprEvents:listFieldValues",desc:"List LPR field values",status:"miss",func:""},
-  // VEHICLE SURVEILLANCE - LPR Alert Condition Rules (6)
-  {cat:"Vehicle Surveillance",sub:"LPR Alert Condition Rules",method:"GET",path:"/lprAlertConditionRules",desc:"List LPR rules",status:"miss",func:""},
-  {cat:"Vehicle Surveillance",sub:"LPR Alert Condition Rules",method:"POST",path:"/lprAlertConditionRules",desc:"Create LPR rule",status:"miss",func:""},
-  {cat:"Vehicle Surveillance",sub:"LPR Alert Condition Rules",method:"GET",path:"/lprAlertConditionRules:listFieldValues",desc:"List LPR rule field values",status:"miss",func:""},
-  {cat:"Vehicle Surveillance",sub:"LPR Alert Condition Rules",method:"GET",path:"/lprAlertConditionRules/{id}",desc:"Get LPR rule",status:"miss",func:""},
-  {cat:"Vehicle Surveillance",sub:"LPR Alert Condition Rules",method:"PATCH",path:"/lprAlertConditionRules/{id}",desc:"Update LPR rule",status:"miss",func:""},
-  {cat:"Vehicle Surveillance",sub:"LPR Alert Condition Rules",method:"DELETE",path:"/lprAlertConditionRules/{id}",desc:"Delete LPR rule",status:"miss",func:""},
-  // VEHICLE SURVEILLANCE - LPR Vehicle Lists (14)
-  {cat:"Vehicle Surveillance",sub:"LPR Vehicle Lists",method:"GET",path:"/lprVehicleLists",desc:"List vehicle lists",status:"miss",func:""},
-  {cat:"Vehicle Surveillance",sub:"LPR Vehicle Lists",method:"POST",path:"/lprVehicleLists",desc:"Create vehicle list",status:"miss",func:""},
-  {cat:"Vehicle Surveillance",sub:"LPR Vehicle Lists",method:"GET",path:"/lprVehicleLists:listFields",desc:"List fields",status:"miss",func:""},
-  {cat:"Vehicle Surveillance",sub:"LPR Vehicle Lists",method:"GET",path:"/lprVehicleLists:listFieldValues",desc:"List field values",status:"miss",func:""},
-  {cat:"Vehicle Surveillance",sub:"LPR Vehicle Lists",method:"GET",path:"/lprVehicleLists/{id}",desc:"Get vehicle list",status:"miss",func:""},
-  {cat:"Vehicle Surveillance",sub:"LPR Vehicle Lists",method:"PATCH",path:"/lprVehicleLists/{id}",desc:"Update vehicle list",status:"miss",func:""},
-  {cat:"Vehicle Surveillance",sub:"LPR Vehicle Lists",method:"DELETE",path:"/lprVehicleLists/{id}",desc:"Delete vehicle list",status:"miss",func:""},
-  {cat:"Vehicle Surveillance",sub:"LPR Vehicle Lists",method:"GET",path:"/lprVehicleLists/{id}/vehicles",desc:"List vehicles",status:"miss",func:""},
-  {cat:"Vehicle Surveillance",sub:"LPR Vehicle Lists",method:"POST",path:"/lprVehicleLists/{id}/vehicles",desc:"Add vehicle",status:"miss",func:""},
-  {cat:"Vehicle Surveillance",sub:"LPR Vehicle Lists",method:"POST",path:"/lprVehicleLists/{id}/vehicles:bulkCreate",desc:"Bulk add vehicles",status:"miss",func:""},
-  {cat:"Vehicle Surveillance",sub:"LPR Vehicle Lists",method:"GET",path:"/lprVehicleLists/{id}/vehicles/{recordId}",desc:"Get vehicle",status:"miss",func:""},
-  {cat:"Vehicle Surveillance",sub:"LPR Vehicle Lists",method:"PATCH",path:"/lprVehicleLists/{id}/vehicles/{recordId}",desc:"Update vehicle",status:"miss",func:""},
-  {cat:"Vehicle Surveillance",sub:"LPR Vehicle Lists",method:"DELETE",path:"/lprVehicleLists/{id}/vehicles/{recordId}",desc:"Delete vehicle",status:"miss",func:""},
-  {cat:"Vehicle Surveillance",sub:"LPR Vehicle Lists",method:"GET",path:"/lprVehicleLists:search",desc:"Search vehicle lists",status:"miss",func:""},
-  // USER & ACCOUNTS - Users (9)
-  {cat:"User & Accounts",sub:"Users",method:"GET",path:"/users",desc:"List users",status:"impl",func:"getUsers()"},
-  {cat:"User & Accounts",sub:"Users",method:"POST",path:"/users",desc:"Create a user",status:"miss",func:""},
-  {cat:"User & Accounts",sub:"Users",method:"GET",path:"/users/{userId}",desc:"Get user by ID",status:"impl",func:"getUser()"},
-  {cat:"User & Accounts",sub:"Users",method:"PATCH",path:"/users/{userId}",desc:"Update a user",status:"miss",func:""},
-  {cat:"User & Accounts",sub:"Users",method:"DELETE",path:"/users/{userId}",desc:"Delete a user",status:"miss",func:""},
-  {cat:"User & Accounts",sub:"Users",method:"GET",path:"/users/self",desc:"Get current user",status:"impl",func:"getCurrentUser()"},
-  {cat:"User & Accounts",sub:"Users",method:"PATCH",path:"/users/self",desc:"Update current user",status:"miss",func:""},
-  {cat:"User & Accounts",sub:"Users",method:"GET",path:"/users/self/trustedClients",desc:"List trusted OAuth clients",status:"miss",func:""},
-  {cat:"User & Accounts",sub:"Users",method:"DELETE",path:"/users/self/trustedClients/{trustedClientId}",desc:"Delete trusted client",status:"miss",func:""},
-  // USER & ACCOUNTS - Accounts (2)
-  {cat:"User & Accounts",sub:"Accounts",method:"GET",path:"/accounts",desc:"List accounts",status:"miss",func:""},
-  {cat:"User & Accounts",sub:"Accounts",method:"DELETE",path:"/accounts/{id}/credentials/{credentialId}",desc:"Delete account credential",status:"miss",func:""},
-  // USER & ACCOUNTS - Roles (8)
-  {cat:"User & Accounts",sub:"Roles",method:"GET",path:"/roles",desc:"List roles",status:"miss",func:""},
-  {cat:"User & Accounts",sub:"Roles",method:"POST",path:"/roles",desc:"Create a role",status:"miss",func:""},
-  {cat:"User & Accounts",sub:"Roles",method:"GET",path:"/roles/{roleId}",desc:"Get role by ID",status:"miss",func:""},
-  {cat:"User & Accounts",sub:"Roles",method:"PATCH",path:"/roles/{roleId}",desc:"Update a role",status:"miss",func:""},
-  {cat:"User & Accounts",sub:"Roles",method:"DELETE",path:"/roles/{roleId}",desc:"Delete a role",status:"miss",func:""},
-  {cat:"User & Accounts",sub:"Roles",method:"GET",path:"/roleAssignments",desc:"List role assignments",status:"miss",func:""},
-  {cat:"User & Accounts",sub:"Roles",method:"POST",path:"/roleAssignments:bulkcreate",desc:"Bulk create role assignments",status:"miss",func:""},
-  {cat:"User & Accounts",sub:"Roles",method:"POST",path:"/roleAssignments:bulkdelete",desc:"Bulk delete role assignments",status:"miss",func:""},
-  // USER & ACCOUNTS - Audit Log (1)
-  {cat:"User & Accounts",sub:"Audit Log",method:"GET",path:"/auditLogs",desc:"List audit logs",status:"miss",func:""},
-  // USER & ACCOUNTS - Resource Grants (3)
-  {cat:"User & Accounts",sub:"Resource Grants",method:"GET",path:"/resourceGrants",desc:"List resource grants",status:"miss",func:""},
-  {cat:"User & Accounts",sub:"Resource Grants",method:"POST",path:"/resourceGrants:bulkCreate",desc:"Bulk create grants",status:"miss",func:""},
-  {cat:"User & Accounts",sub:"Resource Grants",method:"POST",path:"/resourceGrants:bulkDelete",desc:"Bulk delete grants",status:"miss",func:""},
-  // USER & ACCOUNTS - Editions (2)
-  {cat:"User & Accounts",sub:"Editions",method:"GET",path:"/editions",desc:"List editions",status:"miss",func:""},
-  {cat:"User & Accounts",sub:"Editions",method:"GET",path:"/editions/{id}",desc:"Get edition by ID",status:"miss",func:""},
-  // RESELLERS (1)
-  {cat:"Resellers",sub:"Authorization Tokens",method:"POST",path:"/authorizationTokens",desc:"Create authorization token",status:"miss",func:""},
-  // ACCOUNT SETTINGS (3)
-  {cat:"Account Settings",sub:"SSO",method:"GET",path:"/accounts/self/ssoAuthSettings",desc:"Get SSO auth settings",status:"miss",func:""},
-  {cat:"Account Settings",sub:"SSO",method:"PATCH",path:"/accounts/self/ssoAuthSettings",desc:"Update SSO auth settings",status:"miss",func:""},
-  {cat:"Account Settings",sub:"Client Settings",method:"GET",path:"/clientSettings",desc:"Get client settings",status:"miss",func:""},
-  // SYSTEM - Applications (5)
-  {cat:"System",sub:"Applications",method:"GET",path:"/applications",desc:"List applications",status:"miss",func:""},
-  {cat:"System",sub:"Applications",method:"POST",path:"/applications",desc:"Create application",status:"miss",func:""},
-  {cat:"System",sub:"Applications",method:"GET",path:"/applications/{applicationId}",desc:"Get application",status:"miss",func:""},
-  {cat:"System",sub:"Applications",method:"PATCH",path:"/applications/{applicationId}",desc:"Update application",status:"miss",func:""},
-  {cat:"System",sub:"Applications",method:"DELETE",path:"/applications/{applicationId}",desc:"Delete application",status:"miss",func:""},
-  // SYSTEM - OAuth Clients (5)
-  {cat:"System",sub:"OAuth Clients",method:"GET",path:"/applications/{appId}/oauthClients",desc:"List OAuth clients",status:"miss",func:""},
-  {cat:"System",sub:"OAuth Clients",method:"POST",path:"/applications/{appId}/oauthClients",desc:"Create OAuth client",status:"miss",func:""},
-  {cat:"System",sub:"OAuth Clients",method:"GET",path:"/applications/{appId}/oauthClients/{clientId}",desc:"Get OAuth client",status:"miss",func:""},
-  {cat:"System",sub:"OAuth Clients",method:"PATCH",path:"/applications/{appId}/oauthClients/{clientId}",desc:"Update OAuth client",status:"miss",func:""},
-  {cat:"System",sub:"OAuth Clients",method:"DELETE",path:"/applications/{appId}/oauthClients/{clientId}",desc:"Delete OAuth client",status:"miss",func:""},
-  // SYSTEM - Reference Data (2)
-  {cat:"System",sub:"Reference Data",method:"GET",path:"/languages",desc:"List supported languages",status:"miss",func:""},
-  {cat:"System",sub:"Reference Data",method:"GET",path:"/timeZones",desc:"List supported time zones",status:"miss",func:""},
+  // ─── Devices - Cameras ───
+  {cat:'Devices',sub:'Cameras',method:'GET',path:'/cameras',desc:'List cameras with filtering, pagination, and include options',status:'impl',func:'getCameras()'},
+  {cat:'Devices',sub:'Cameras',method:'POST',path:'/cameras',desc:'Associate a camera with the account',status:'miss',func:''},
+  {cat:'Devices',sub:'Cameras',method:'POST',path:'/cameras:bulkUpdate',desc:'Update multiple cameras simultaneously',status:'miss',func:''},
+  {cat:'Devices',sub:'Cameras',method:'GET',path:'/cameras/{cameraId}',desc:'Retrieve specific camera details',status:'impl',func:'getCamera()'},
+  {cat:'Devices',sub:'Cameras',method:'DELETE',path:'/cameras/{cameraId}',desc:'Remove camera from account',status:'miss',func:''},
+  {cat:'Devices',sub:'Cameras',method:'PATCH',path:'/cameras/{cameraId}',desc:'Update camera information',status:'miss',func:''},
+  {cat:'Devices',sub:'Cameras',method:'PUT',path:'/cameras/{cameraId}/tunnel',desc:'Open camera tunnel for UI access',status:'miss',func:''},
+  {cat:'Devices',sub:'Cameras',method:'DELETE',path:'/cameras/{cameraId}/tunnel',desc:'Close camera tunnel',status:'miss',func:''},
+  {cat:'Devices',sub:'Cameras',method:'GET',path:'/cameras/{cameraId}/metrics',desc:'Retrieve camera metrics data',status:'miss',func:''},
+  {cat:'Devices',sub:'Cameras',method:'PATCH',path:'/cameras/{cameraId}:swap',desc:'Replace camera with new device',status:'miss',func:''},
+  {cat:'Devices',sub:'Cameras',method:'GET',path:'/cameras/{cameraId}/io/ports',desc:'List camera I/O ports',status:'miss',func:''},
+  {cat:'Devices',sub:'Cameras',method:'GET',path:'/cameras/{cameraId}/io/ports/{portId}',desc:'Retrieve specific camera I/O port',status:'miss',func:''},
+  {cat:'Devices',sub:'Cameras',method:'PATCH',path:'/cameras/{cameraId}/io/ports/{portId}',desc:'Update camera port configuration',status:'miss',func:''},
+  {cat:'Devices',sub:'Cameras',method:'GET',path:'/cameras/{cameraId}/settings',desc:'Retrieve camera settings',status:'impl',func:'getCameraSettings()'},
+  {cat:'Devices',sub:'Cameras',method:'PATCH',path:'/cameras/{cameraId}/settings',desc:'Update camera settings',status:'miss',func:''},
+
+  // ─── Devices - Bridges ───
+  {cat:'Devices',sub:'Bridges',method:'GET',path:'/bridges',desc:'List bridges with filtering and pagination',status:'impl',func:'getBridges()'},
+  {cat:'Devices',sub:'Bridges',method:'POST',path:'/bridges',desc:'Create bridge for account',status:'miss',func:''},
+  {cat:'Devices',sub:'Bridges',method:'POST',path:'/bridges:bulkUpdate',desc:'Update multiple bridges simultaneously',status:'miss',func:''},
+  {cat:'Devices',sub:'Bridges',method:'GET',path:'/bridges/{bridgeId}',desc:'Retrieve specific bridge',status:'impl',func:'getBridge()'},
+  {cat:'Devices',sub:'Bridges',method:'PATCH',path:'/bridges/{bridgeId}',desc:'Update bridge information',status:'miss',func:''},
+  {cat:'Devices',sub:'Bridges',method:'DELETE',path:'/bridges/{bridgeId}',desc:'Remove bridge from account',status:'miss',func:''},
+  {cat:'Devices',sub:'Bridges',method:'GET',path:'/bridges/{bridgeId}/metrics',desc:'Retrieve bridge metrics',status:'miss',func:''},
+  {cat:'Devices',sub:'Bridges',method:'PATCH',path:'/bridges/{bridgeId}:swap',desc:'Replace bridge with new device',status:'miss',func:''},
+  {cat:'Devices',sub:'Bridges',method:'POST',path:'/bridges/{bridgeId}/actions',desc:'Execute bridge actions (e.g., reboot)',status:'miss',func:''},
+  {cat:'Devices',sub:'Bridges',method:'GET',path:'/bridges/{bridgeId}/settings',desc:'Retrieve bridge operational settings',status:'miss',func:''},
+  {cat:'Devices',sub:'Bridges',method:'PATCH',path:'/bridges/{bridgeId}/settings',desc:'Update bridge settings',status:'miss',func:''},
+
+  // ─── Devices - PTZ ───
+  {cat:'Devices',sub:'PTZ',method:'GET',path:'/cameras/{cameraId}/ptz/position',desc:'Retrieve current PTZ position',status:'impl',func:'getPtzPosition()'},
+  {cat:'Devices',sub:'PTZ',method:'PUT',path:'/cameras/{cameraId}/ptz/position',desc:'Move camera to position or direction',status:'impl',func:'movePtz()'},
+  {cat:'Devices',sub:'PTZ',method:'GET',path:'/cameras/{cameraId}/ptz/settings',desc:'Retrieve PTZ settings and presets',status:'impl',func:'getPtzSettings()'},
+  {cat:'Devices',sub:'PTZ',method:'PATCH',path:'/cameras/{cameraId}/ptz/settings',desc:'Update PTZ settings and presets',status:'impl',func:'updatePtzSettings()'},
+
+  // ─── Devices - Speakers ───
+  {cat:'Devices',sub:'Speakers',method:'GET',path:'/speakers',desc:'List speakers with filtering and pagination',status:'miss',func:''},
+  {cat:'Devices',sub:'Speakers',method:'POST',path:'/speakers',desc:'Create speaker device',status:'miss',func:''},
+  {cat:'Devices',sub:'Speakers',method:'GET',path:'/speakers/{speakerId}',desc:'Retrieve specific speaker',status:'miss',func:''},
+  {cat:'Devices',sub:'Speakers',method:'PATCH',path:'/speakers/{speakerId}',desc:'Update speaker information',status:'miss',func:''},
+  {cat:'Devices',sub:'Speakers',method:'DELETE',path:'/speakers/{speakerId}',desc:'Remove speaker from account',status:'miss',func:''},
+  {cat:'Devices',sub:'Speakers',method:'GET',path:'/speakers/{speakerId}/settings',desc:'Retrieve speaker settings',status:'miss',func:''},
+  {cat:'Devices',sub:'Speakers',method:'PATCH',path:'/speakers/{speakerId}/settings',desc:'Update speaker settings',status:'miss',func:''},
+
+  // ─── Devices - Device I/O ───
+  {cat:'Devices',sub:'Device I/O',method:'GET',path:'/devices/{deviceId}/io/ports',desc:'List device I/O ports',status:'miss',func:''},
+  {cat:'Devices',sub:'Device I/O',method:'GET',path:'/devices/{deviceId}/io/ports/{portId}',desc:'Retrieve specific I/O port',status:'miss',func:''},
+  {cat:'Devices',sub:'Device I/O',method:'PATCH',path:'/devices/{deviceId}/io/ports/{portId}',desc:'Update port configuration',status:'miss',func:''},
+  {cat:'Devices',sub:'Device I/O',method:'GET',path:'/devices/{deviceId}/io/ports/{portId}/recordingActions',desc:'List cameras recording on port trigger',status:'miss',func:''},
+  {cat:'Devices',sub:'Device I/O',method:'GET',path:'/devices/{deviceId}/io/ports/{portId}/recordingActions/{cameraId}',desc:'Retrieve a recording action',status:'miss',func:''},
+  {cat:'Devices',sub:'Device I/O',method:'PATCH',path:'/devices/{deviceId}/io/ports/{portId}/recordingActions/{cameraId}',desc:'Update a recording action',status:'miss',func:''},
+
+  // ─── Devices - Switches ───
+  {cat:'Devices',sub:'Switches',method:'GET',path:'/switches',desc:'List switches with pagination',status:'miss',func:''},
+  {cat:'Devices',sub:'Switches',method:'GET',path:'/switches/{switchId}',desc:'Retrieve specific switch',status:'miss',func:''},
+  {cat:'Devices',sub:'Switches',method:'PATCH',path:'/switches/{switchId}',desc:'Update switch information',status:'miss',func:''},
+  {cat:'Devices',sub:'Switches',method:'POST',path:'/switches/{switchId}/ports/{portId}/actions',desc:'Control individual switch port',status:'miss',func:''},
+  {cat:'Devices',sub:'Switches',method:'POST',path:'/switches/{switchId}/ports/all/actions',desc:'Control all switch ports',status:'miss',func:''},
+
+  // ─── Devices - Multi Cameras ───
+  {cat:'Devices',sub:'Multi Cameras',method:'GET',path:'/multiCameras',desc:'List multi-camera devices',status:'miss',func:''},
+  {cat:'Devices',sub:'Multi Cameras',method:'POST',path:'/multiCameras',desc:'Associate multi-camera with account',status:'miss',func:''},
+  {cat:'Devices',sub:'Multi Cameras',method:'GET',path:'/multiCameras/{multiCameraId}',desc:'Retrieve multi-camera details',status:'miss',func:''},
+  {cat:'Devices',sub:'Multi Cameras',method:'DELETE',path:'/multiCameras/{multiCameraId}',desc:'Remove multi-camera from account',status:'miss',func:''},
+  {cat:'Devices',sub:'Multi Cameras',method:'PATCH',path:'/multiCameras/{multiCameraId}',desc:'Update multi-camera information',status:'miss',func:''},
+  {cat:'Devices',sub:'Multi Cameras',method:'GET',path:'/multiCameras/{multiCameraId}/channels',desc:'Retrieve multi-camera channel information',status:'miss',func:''},
+
+  // ─── Devices - Available Devices ───
+  {cat:'Devices',sub:'Available Devices',method:'GET',path:'/availableDevices',desc:'List undiscovered devices available for addition',status:'miss',func:''},
+
+  // ─── Grouping - Layouts ───
+  {cat:'Grouping',sub:'Layouts',method:'GET',path:'/layouts',desc:'Retrieve all layouts associated with the account',status:'impl',func:'getLayouts()'},
+  {cat:'Grouping',sub:'Layouts',method:'POST',path:'/layouts',desc:'Create a layout',status:'impl',func:'createLayout()'},
+  {cat:'Grouping',sub:'Layouts',method:'GET',path:'/layouts/{layoutId}',desc:'Retrieve info of a specific layout',status:'impl',func:'getLayout()'},
+  {cat:'Grouping',sub:'Layouts',method:'PATCH',path:'/layouts/{layoutId}',desc:'Update a specific layout',status:'impl',func:'updateLayout()'},
+  {cat:'Grouping',sub:'Layouts',method:'DELETE',path:'/layouts/{layoutId}',desc:'Delete an existing layout',status:'impl',func:'deleteLayout()'},
+
+  // ─── Grouping - Tags ───
+  {cat:'Grouping',sub:'Tags',method:'GET',path:'/tags',desc:'Retrieve a list of all tags visible to the current user',status:'miss',func:''},
+
+  // ─── Grouping - Locations ───
+  {cat:'Grouping',sub:'Locations',method:'GET',path:'/locations',desc:'Retrieve a list of locations',status:'miss',func:''},
+  {cat:'Grouping',sub:'Locations',method:'POST',path:'/locations',desc:'Create a new location',status:'miss',func:''},
+  {cat:'Grouping',sub:'Locations',method:'GET',path:'/locations/{id}',desc:'Retrieve the location with a specific ID',status:'miss',func:''},
+  {cat:'Grouping',sub:'Locations',method:'PATCH',path:'/locations/{id}',desc:'Update the location with the given ID',status:'miss',func:''},
+  {cat:'Grouping',sub:'Locations',method:'DELETE',path:'/locations/{id}',desc:'Delete the location with the given ID',status:'miss',func:''},
+  {cat:'Grouping',sub:'Locations',method:'GET',path:'/locations/{id}/locations',desc:'Retrieve child locations',status:'miss',func:''},
+
+  // ─── Grouping - Floors ───
+  {cat:'Grouping',sub:'Floors',method:'GET',path:'/locations/{locationId}/floors',desc:'Retrieve the floors at the given location',status:'miss',func:''},
+  {cat:'Grouping',sub:'Floors',method:'POST',path:'/locations/{locationId}/floors',desc:'Create a floor',status:'miss',func:''},
+  {cat:'Grouping',sub:'Floors',method:'GET',path:'/locations/{locationId}/floors/{id}',desc:'Retrieve a specific floor at a specific location',status:'miss',func:''},
+  {cat:'Grouping',sub:'Floors',method:'PATCH',path:'/locations/{locationId}/floors/{id}',desc:'Update one or more fields of the given floor',status:'miss',func:''},
+  {cat:'Grouping',sub:'Floors',method:'DELETE',path:'/locations/{locationId}/floors/{id}',desc:'Delete a specific floor of a specific location',status:'miss',func:''},
+  {cat:'Grouping',sub:'Floors',method:'GET',path:'/locations/{locationId}/floors/{id}.{type}',desc:'Retrieve the floor image of a specific floor',status:'miss',func:''},
+
+  // ─── Grouping - Floor Plans ───
+  {cat:'Grouping',sub:'Floor Plans',method:'GET',path:'/locations/{locationId}/floors/{id}/plans',desc:'Retrieve plans of a specific floor',status:'miss',func:''},
+  {cat:'Grouping',sub:'Floor Plans',method:'POST',path:'/locations/{locationId}/floors/{id}/plans',desc:'Create a floor plan for a specific floor',status:'miss',func:''},
+  {cat:'Grouping',sub:'Floor Plans',method:'DELETE',path:'/locations/{locationId}/floors/{id}/plans/{planId}',desc:'Delete a floor plan and its corresponding file',status:'miss',func:''},
+
+  // ─── Media - Media ───
+  {cat:'Media',sub:'Media',method:'GET',path:'/media',desc:'List recording intervals for given type and mediaType',status:'impl',func:'listMedia()'},
+  {cat:'Media',sub:'Media',method:'GET',path:'/media/recordedImage.jpeg',desc:'Retrieve image at specified timestamp',status:'impl',func:'getRecordedImage()'},
+  {cat:'Media',sub:'Media',method:'GET',path:'/media/recordedImage.jpeg:listFieldValues',desc:'List available field values for recorded images',status:'miss',func:''},
+  {cat:'Media',sub:'Media',method:'GET',path:'/media/liveImage.jpeg',desc:'Get new image from device',status:'impl',func:'getLiveImage()'},
+  {cat:'Media',sub:'Media',method:'GET',path:'/media/session',desc:'Get URL to set media session cookie',status:'impl',func:'getMediaSession()'},
+
+  // ─── Media - Feeds ───
+  {cat:'Media',sub:'Feeds',method:'GET',path:'/feeds',desc:'List feeds generated by device(s)',status:'impl',func:'listFeeds()'},
+
+  // ─── Media - Exports ───
+  {cat:'Media',sub:'Exports',method:'POST',path:'/exports',desc:'Create and start new video export job',status:'impl',func:'createExportJob()'},
+  {cat:'Media',sub:'Exports',method:'POST',path:'/exports/{jobId}:copy',desc:'Retry export with modified parameters',status:'miss',func:''},
+
+  // ─── Media - Jobs ───
+  {cat:'Media',sub:'Jobs',method:'GET',path:'/jobs',desc:'List jobs with filtering options',status:'impl',func:'listJobs()'},
+  {cat:'Media',sub:'Jobs',method:'GET',path:'/jobs/{jobId}',desc:'Get single job details',status:'impl',func:'getJob()'},
+  {cat:'Media',sub:'Jobs',method:'DELETE',path:'/jobs/{jobId}',desc:'Delete job regardless of state',status:'impl',func:'deleteJob()'},
+
+  // ─── Media - Files ───
+  {cat:'Media',sub:'Files',method:'GET',path:'/files',desc:'List archived items',status:'impl',func:'listFiles()'},
+  {cat:'Media',sub:'Files',method:'POST',path:'/files',desc:'Add new file to archive',status:'impl',func:'addFile()'},
+  {cat:'Media',sub:'Files',method:'GET',path:'/files/{id}',desc:'Get file details by ID',status:'impl',func:'getFile()'},
+  {cat:'Media',sub:'Files',method:'PATCH',path:'/files/{id}',desc:'Modify file details',status:'miss',func:''},
+  {cat:'Media',sub:'Files',method:'DELETE',path:'/files/{id}',desc:'Recycle item by ID',status:'impl',func:'deleteFile()'},
+  {cat:'Media',sub:'Files',method:'GET',path:'/files/{id}:download',desc:'Download file or folder',status:'impl',func:'downloadFile()'},
+  {cat:'Media',sub:'Files',method:'GET',path:'/deletedFiles',desc:'List deleted files',status:'miss',func:''},
+  {cat:'Media',sub:'Files',method:'GET',path:'/deletedFiles/{id}',desc:'Get recycled item details',status:'miss',func:''},
+  {cat:'Media',sub:'Files',method:'DELETE',path:'/deletedFiles/{id}',desc:'Permanently delete item',status:'miss',func:''},
+  {cat:'Media',sub:'Files',method:'DELETE',path:'/deletedFiles/all',desc:'Clear recycle bin',status:'miss',func:''},
+  {cat:'Media',sub:'Files',method:'POST',path:'/deletedFiles/{id}:restore',desc:'Restore recycled item',status:'miss',func:''},
+
+  // ─── Media - Downloads ───
+  {cat:'Media',sub:'Downloads',method:'GET',path:'/downloads',desc:'List downloaded items',status:'impl',func:'listDownloads()'},
+  {cat:'Media',sub:'Downloads',method:'GET',path:'/downloads/{id}',desc:'Get download details by ID',status:'impl',func:'getDownload()'},
+  {cat:'Media',sub:'Downloads',method:'PATCH',path:'/downloads/{id}',desc:'Modify download metadata',status:'miss',func:''},
+  {cat:'Media',sub:'Downloads',method:'GET',path:'/downloads/{id}:download',desc:'Save download by ID',status:'impl',func:'downloadDownload()'},
+
+  // ─── Events - Events ───
+  {cat:'Events',sub:'Events',method:'GET',path:'/events',desc:'Retrieve events filtered by type, actor, and time range',status:'impl',func:'listEvents()'},
+  {cat:'Events',sub:'Events',method:'POST',path:'/events',desc:'Create a new event for the selected actor',status:'miss',func:''},
+  {cat:'Events',sub:'Events',method:'GET',path:'/events/{id}',desc:'Retrieve a specific event by ID',status:'impl',func:'getEvent()'},
+  {cat:'Events',sub:'Events',method:'GET',path:'/events:listFieldValues',desc:'List available field values for event filtering',status:'impl',func:'listEventFieldValues()'},
+
+  // ─── Events - Event Types ───
+  {cat:'Events',sub:'Event Types',method:'GET',path:'/eventTypes',desc:'List all available event types',status:'impl',func:'listEventTypes()'},
+
+  // ─── Events - Event Metrics ───
+  {cat:'Events',sub:'Event Metrics',method:'GET',path:'/eventMetrics',desc:'Retrieve time-series event metric data for an actor and event type',status:'impl',func:'getEventMetrics()'},
+
+  // ─── Events - Event Subscriptions ───
+  {cat:'Events',sub:'Event Subscriptions',method:'GET',path:'/eventSubscriptions',desc:'List event subscriptions for the account',status:'impl',func:'listEventSubscriptions()'},
+  {cat:'Events',sub:'Event Subscriptions',method:'POST',path:'/eventSubscriptions',desc:'Create a new event subscription (SSE or webhook)',status:'impl',func:'createEventSubscription()'},
+  {cat:'Events',sub:'Event Subscriptions',method:'GET',path:'/eventSubscriptions/{id}',desc:'Retrieve a specific event subscription',status:'impl',func:'getEventSubscription()'},
+  {cat:'Events',sub:'Event Subscriptions',method:'DELETE',path:'/eventSubscriptions/{id}',desc:'Delete an event subscription',status:'impl',func:'deleteEventSubscription()'},
+
+  // ─── Events - Alerts ───
+  {cat:'Events',sub:'Alerts',method:'GET',path:'/alerts',desc:'List alerts with filtering and pagination',status:'impl',func:'listAlerts()'},
+  {cat:'Events',sub:'Alerts',method:'GET',path:'/alerts/{id}',desc:'Retrieve a specific alert by ID',status:'impl',func:'getAlert()'},
+  {cat:'Events',sub:'Alerts',method:'GET',path:'/alertTypes',desc:'List all available alert types',status:'impl',func:'listAlertTypes()'},
+
+  // ─── Events - Notifications ───
+  {cat:'Events',sub:'Notifications',method:'GET',path:'/notifications',desc:'List notifications with filtering and pagination',status:'impl',func:'listNotifications()'},
+  {cat:'Events',sub:'Notifications',method:'GET',path:'/notifications/{id}',desc:'Retrieve a specific notification by ID',status:'impl',func:'getNotification()'},
+
+  // ─── Automations - Event Alert Condition Rules ───
+  {cat:'Automations',sub:'Event Alert Cond. Rules',method:'POST',path:'/eventAlertConditionRules',desc:'Create a new rule that produces alerts based on event conditions',status:'miss',func:''},
+  {cat:'Automations',sub:'Event Alert Cond. Rules',method:'GET',path:'/eventAlertConditionRules',desc:'List configured event alert condition rules',status:'impl',func:'listEventAlertConditionRules()'},
+  {cat:'Automations',sub:'Event Alert Cond. Rules',method:'GET',path:'/eventAlertConditionRules:listFieldValues',desc:'Fetch available field values for alert condition rules',status:'impl',func:'getEventAlertConditionRuleFieldValues()'},
+  {cat:'Automations',sub:'Event Alert Cond. Rules',method:'GET',path:'/eventAlertConditionRules/{id}',desc:'Retrieve details of a specific rule',status:'impl',func:'getEventAlertConditionRule()'},
+  {cat:'Automations',sub:'Event Alert Cond. Rules',method:'PATCH',path:'/eventAlertConditionRules/{id}',desc:'Update a specific alert condition rule',status:'miss',func:''},
+  {cat:'Automations',sub:'Event Alert Cond. Rules',method:'DELETE',path:'/eventAlertConditionRules/{id}',desc:'Remove a specific alert condition rule',status:'miss',func:''},
+
+  // ─── Automations - Alert Action Rules ───
+  {cat:'Automations',sub:'Alert Action Rules',method:'POST',path:'/alertActionRules',desc:'Register a new alert action rule with the account',status:'miss',func:''},
+  {cat:'Automations',sub:'Alert Action Rules',method:'GET',path:'/alertActionRules',desc:'List configured alert action rules',status:'impl',func:'listAlertActionRules()'},
+  {cat:'Automations',sub:'Alert Action Rules',method:'GET',path:'/alertActionRules/{actionRuleId}',desc:'Retrieve a single alert action rule',status:'impl',func:'getAlertActionRule()'},
+  {cat:'Automations',sub:'Alert Action Rules',method:'PATCH',path:'/alertActionRules/{actionRuleId}',desc:'Update a single alert action rule',status:'miss',func:''},
+  {cat:'Automations',sub:'Alert Action Rules',method:'DELETE',path:'/alertActionRules/{actionRuleId}',desc:'Remove an alert action rule',status:'miss',func:''},
+
+  // ─── Automations - Alert Actions ───
+  {cat:'Automations',sub:'Alert Actions',method:'POST',path:'/alertActions',desc:'Register a new alert action with the account',status:'miss',func:''},
+  {cat:'Automations',sub:'Alert Actions',method:'GET',path:'/alertActions',desc:'List configured alert actions',status:'impl',func:'listAlertActions()'},
+  {cat:'Automations',sub:'Alert Actions',method:'GET',path:'/alertActions/{actionId}',desc:'Retrieve a single alert action',status:'impl',func:'getAlertAction()'},
+  {cat:'Automations',sub:'Alert Actions',method:'PATCH',path:'/alertActions/{actionId}',desc:'Update a single alert action',status:'miss',func:''},
+  {cat:'Automations',sub:'Alert Actions',method:'DELETE',path:'/alertActions/{actionId}',desc:'Remove an alert action',status:'miss',func:''},
+
+  // ─── Video Search - Video Analytic Events ───
+  {cat:'Video Search',sub:'Video Analytic Events',method:'POST',path:'/videoAnalyticEvents:parse',desc:'Map natural language queries to object filters for deep search',status:'miss',func:''},
+  {cat:'Video Search',sub:'Video Analytic Events',method:'POST',path:'/videoAnalyticEvents:deepSearch',desc:'Fetch video analytic events matching defined filters',status:'miss',func:''},
+  {cat:'Video Search',sub:'Video Analytic Events',method:'POST',path:'/videoAnalyticEvents:deepSearchGroupByResource',desc:'Fetch event frequencies grouped by resource metadata',status:'miss',func:''},
+  {cat:'Video Search',sub:'Video Analytic Events',method:'POST',path:'/videoAnalyticEvents:deepSearchGroupByTime',desc:'Fetch event frequencies grouped in time periods',status:'miss',func:''},
+  {cat:'Video Search',sub:'Video Analytic Events',method:'POST',path:'/videoAnalyticEvents:listFieldValues',desc:'Retrieve available deep search query parameters',status:'miss',func:''},
+  {cat:'Video Search',sub:'Video Analytic Events',method:'GET',path:'/videoAnalyticEvents:listObjectValues',desc:'Fetch available filter attribute values for events',status:'miss',func:''},
+  {cat:'Video Search',sub:'Video Analytic Events',method:'GET',path:'/videoAnalyticEvents/{id}',desc:'Retrieve specific video analytics event by ID',status:'miss',func:''},
+
+  // ─── Vehicle Surveillance - LPR Events ───
+  {cat:'Vehicle Surveillance',sub:'LPR Events',method:'GET',path:'/lprEvents',desc:'Fetch license plate recognition events with filtering',status:'miss',func:''},
+  {cat:'Vehicle Surveillance',sub:'LPR Events',method:'GET',path:'/lprEvents/{id}',desc:'Retrieve a specific LPR event by ID',status:'miss',func:''},
+  {cat:'Vehicle Surveillance',sub:'LPR Events',method:'GET',path:'/lprEvents:summary',desc:'Obtain aggregated counts of LPR events across time periods',status:'miss',func:''},
+  {cat:'Vehicle Surveillance',sub:'LPR Events',method:'GET',path:'/lprEvents:listFieldValues',desc:'List all possible filter values for LPR event attributes',status:'miss',func:''},
+
+  // ─── Vehicle Surveillance - LPR Alert Condition Rules ───
+  {cat:'Vehicle Surveillance',sub:'LPR Alert Cond. Rules',method:'POST',path:'/lprAlertConditionRules',desc:'Create a new rule for generating alerts based on LPR conditions',status:'miss',func:''},
+  {cat:'Vehicle Surveillance',sub:'LPR Alert Cond. Rules',method:'GET',path:'/lprAlertConditionRules',desc:'Fetch LPR alert condition rules based on a filter',status:'miss',func:''},
+  {cat:'Vehicle Surveillance',sub:'LPR Alert Cond. Rules',method:'GET',path:'/lprAlertConditionRules:listFieldValues',desc:'Return possible values across all rule attributes',status:'miss',func:''},
+  {cat:'Vehicle Surveillance',sub:'LPR Alert Cond. Rules',method:'GET',path:'/lprAlertConditionRules/{id}',desc:'Retrieve details of a specific LPR rule',status:'miss',func:''},
+  {cat:'Vehicle Surveillance',sub:'LPR Alert Cond. Rules',method:'PATCH',path:'/lprAlertConditionRules/{id}',desc:'Update specified properties of an existing LPR rule',status:'miss',func:''},
+
+  // ─── User & Accounts - Users ───
+  {cat:'User & Accounts',sub:'Users',method:'GET',path:'/users',desc:'Retrieve a list of users within the account',status:'impl',func:'getUsers()'},
+  {cat:'User & Accounts',sub:'Users',method:'POST',path:'/users',desc:'Create a new user (verification email sent, pending state)',status:'miss',func:''},
+  {cat:'User & Accounts',sub:'Users',method:'GET',path:'/users/{userId}',desc:'Retrieve information about a specific user',status:'impl',func:'getUser()'},
+  {cat:'User & Accounts',sub:'Users',method:'DELETE',path:'/users/{userId}',desc:'Delete a user and remove all related references',status:'miss',func:''},
+  {cat:'User & Accounts',sub:'Users',method:'PATCH',path:'/users/{userId}',desc:"Update a user's data",status:'miss',func:''},
+  {cat:'User & Accounts',sub:'Users',method:'GET',path:'/users/self',desc:'Retrieve information about the current authenticated user',status:'impl',func:'getCurrentUser()'},
+  {cat:'User & Accounts',sub:'Users',method:'PATCH',path:'/users/self',desc:"Update current user's profile data",status:'miss',func:''},
+  {cat:'User & Accounts',sub:'Users',method:'GET',path:'/users/self/trustedClients',desc:'Retrieve a list of trusted clients',status:'miss',func:''},
+  {cat:'User & Accounts',sub:'Users',method:'DELETE',path:'/users/self/trustedClients/{trustedClientId}',desc:'Delete a trusted client device',status:'miss',func:''},
+
+  // ─── User & Accounts - Accounts ───
+  {cat:'User & Accounts',sub:'Accounts',method:'GET',path:'/accounts',desc:'Retrieve a list of accounts the user has access to',status:'miss',func:''},
+  {cat:'User & Accounts',sub:'Accounts',method:'DELETE',path:'/accounts/{id}/credentials/{credentialId}',desc:'Remove a credential from the account',status:'miss',func:''},
+
+  // ─── User & Accounts - Roles ───
+  {cat:'User & Accounts',sub:'Roles',method:'GET',path:'/roles',desc:"Returns a list of all roles in current user's account",status:'miss',func:''},
+  {cat:'User & Accounts',sub:'Roles',method:'POST',path:'/roles',desc:'Create a new role with defined permissions',status:'miss',func:''},
+  {cat:'User & Accounts',sub:'Roles',method:'GET',path:'/roles/{roleId}',desc:'Retrieve a role by its ID',status:'miss',func:''},
+  {cat:'User & Accounts',sub:'Roles',method:'DELETE',path:'/roles/{roleId}',desc:'Delete a role (only if unassigned)',status:'miss',func:''},
+  {cat:'User & Accounts',sub:'Roles',method:'PATCH',path:'/roles/{roleId}',desc:'Update role information and permissions',status:'miss',func:''},
+  {cat:'User & Accounts',sub:'Roles',method:'GET',path:'/roleAssignments',desc:'Returns a list of all role assignments',status:'miss',func:''},
+  {cat:'User & Accounts',sub:'Roles',method:'POST',path:'/roleAssignments:bulkcreate',desc:'Create multiple role assignments in one request',status:'miss',func:''},
+  {cat:'User & Accounts',sub:'Roles',method:'POST',path:'/roleAssignments:bulkdelete',desc:'Delete multiple role assignments in one request',status:'miss',func:''},
+
+  // ─── User & Accounts - Audit Log ───
+  {cat:'User & Accounts',sub:'Audit Log',method:'GET',path:'/auditLogs',desc:'Filter audit events by userId, targetId, type, and timestamp range',status:'miss',func:''},
+
+  // ─── User & Accounts - Resource Grants ───
+  {cat:'User & Accounts',sub:'Resource Grants',method:'GET',path:'/resourceGrants',desc:'Retrieve a list of resource grants',status:'miss',func:''},
+  {cat:'User & Accounts',sub:'Resource Grants',method:'POST',path:'/resourceGrants:bulkCreate',desc:'Create multiple resource grants in one request',status:'miss',func:''},
+  {cat:'User & Accounts',sub:'Resource Grants',method:'POST',path:'/resourceGrants:bulkDelete',desc:'Delete multiple resource grants in one request',status:'miss',func:''},
+
+  // ─── User & Accounts - Editions ───
+  {cat:'User & Accounts',sub:'Editions',method:'GET',path:'/editions',desc:'Retrieve available editions for the account',status:'miss',func:''},
+  {cat:'User & Accounts',sub:'Editions',method:'GET',path:'/editions/{id}',desc:'Retrieve a specific edition by ID',status:'miss',func:''},
+
+  // ─── Resellers - Authorization Tokens ───
+  {cat:'Resellers',sub:'Authorization Tokens',method:'POST',path:'/authorizationTokens',desc:'Resellers retrieve access tokens for end-user accounts',status:'miss',func:''},
+
+  // ─── Account Settings - SSO ───
+  {cat:'Account Settings',sub:'SSO',method:'GET',path:'/accounts/self/ssoAuthSettings',desc:'Get Single Sign On Authentication Settings',status:'miss',func:''},
+  {cat:'Account Settings',sub:'SSO',method:'PATCH',path:'/accounts/self/ssoAuthSettings',desc:'Update Single Sign On Authentication Settings',status:'miss',func:''},
+
+  // ─── Account Settings - Client Settings ───
+  {cat:'Account Settings',sub:'Client Settings',method:'GET',path:'/clientSettings',desc:'Retrieve settings required to let the client use the API',status:'miss',func:''},
+
+  // ─── System - Applications ───
+  {cat:'System',sub:'Applications',method:'GET',path:'/applications',desc:'Retrieve all applications accessible by the requesting user',status:'miss',func:''},
+  {cat:'System',sub:'Applications',method:'POST',path:'/applications',desc:'Create new application under user\'s account',status:'miss',func:''},
+  {cat:'System',sub:'Applications',method:'GET',path:'/applications/{applicationId}',desc:'Retrieve a single application',status:'miss',func:''},
+  {cat:'System',sub:'Applications',method:'PATCH',path:'/applications/{applicationId}',desc:'Update a single application',status:'miss',func:''},
+  {cat:'System',sub:'Applications',method:'DELETE',path:'/applications/{applicationId}',desc:'Delete a single application',status:'miss',func:''},
+
+  // ─── System - OAuth Clients ───
+  {cat:'System',sub:'OAuth Clients',method:'GET',path:'/applications/{applicationId}/oauthClients',desc:'Retrieve all OAuth credentials for the given application',status:'miss',func:''},
+  {cat:'System',sub:'OAuth Clients',method:'POST',path:'/applications/{applicationId}/oauthClients',desc:'Create OAuth client for application',status:'miss',func:''},
+  {cat:'System',sub:'OAuth Clients',method:'GET',path:'/applications/{applicationId}/oauthClients/{clientId}',desc:'Retrieve a specific OAuth client',status:'miss',func:''},
+  {cat:'System',sub:'OAuth Clients',method:'PATCH',path:'/applications/{applicationId}/oauthClients/{clientId}',desc:'Update a specific OAuth client',status:'miss',func:''},
+  {cat:'System',sub:'OAuth Clients',method:'DELETE',path:'/applications/{applicationId}/oauthClients/{clientId}',desc:'Delete a specific OAuth client',status:'miss',func:''},
+
+  // ─── System - Reference Data ───
+  {cat:'System',sub:'Reference Data',method:'GET',path:'/languages',desc:'Retrieve a list of languages supported by the service',status:'miss',func:''},
+  {cat:'System',sub:'Reference Data',method:'GET',path:'/timeZones',desc:'Retrieve a list of the supported time zones',status:'miss',func:''},
 ];
 
+function methodBadge(m) {
+  const cls = {GET:'m-get',POST:'m-post',PATCH:'m-patch',DELETE:'m-delete',PUT:'m-put'}[m] || 'm-get';
+  return `<span class="badge ${cls}">${m}</span>`;
+}
+
+function statusBadge(s) {
+  return s === 'impl'
+    ? '<span class="badge s-impl">Implemented</span>'
+    : '<span class="badge s-miss">Missing</span>';
+}
+
+let sortCol = -1;
+let sortAsc = true;
+
 function renderTable(data) {
-  const tbody = document.getElementById('tableBody');
-  tbody.innerHTML = '';
-  data.forEach((e, i) => {
-    const tr = document.createElement('tr');
-    tr.dataset.status = e.status;
-    tr.dataset.category = e.cat;
-    tr.dataset.method = e.method;
-    tr.innerHTML = `
-      <td>${i + 1}</td>
-      <td class="category">${e.cat}</td>
-      <td class="category">${e.sub}</td>
-      <td><span class="method method-${e.method}">${e.method}</span></td>
-      <td><code>${e.path}</code></td>
-      <td>${e.desc}</td>
-      <td><span class="badge ${e.status === 'impl' ? 'badge-impl' : 'badge-miss'}">${e.status === 'impl' ? 'Implemented' : 'Missing'}</span></td>
-      <td class="func">${e.func}</td>
-    `;
-    tbody.appendChild(tr);
-  });
+  const tbody = document.getElementById('tbody');
+  const empty = document.getElementById('empty-state');
+  const count = document.getElementById('filter-count');
+
+  if (data.length === 0) {
+    tbody.innerHTML = '';
+    empty.style.display = 'block';
+    count.textContent = 'Showing 0 of ' + endpoints.length;
+    return;
+  }
+
+  empty.style.display = 'none';
+  count.textContent = 'Showing ' + data.length + ' of ' + endpoints.length;
+
+  tbody.innerHTML = data.map((ep, i) => `
+    <tr>
+      <td class="td-num">${i + 1}</td>
+      <td class="td-cat">${ep.cat}</td>
+      <td class="td-sub">${ep.sub}</td>
+      <td>${methodBadge(ep.method)}</td>
+      <td class="td-path">${ep.path}</td>
+      <td class="td-desc">${ep.desc}</td>
+      <td>${statusBadge(ep.status)}</td>
+      <td class="td-func">${ep.func}</td>
+    </tr>
+  `).join('');
 }
 
 function filterTable() {
-  const status = document.getElementById('statusFilter').value;
-  const category = document.getElementById('categoryFilter').value;
-  const method = document.getElementById('methodFilter').value;
-  const search = document.getElementById('searchFilter').value.toLowerCase();
+  const status = document.getElementById('f-status').value;
+  const cat    = document.getElementById('f-cat').value;
+  const method = document.getElementById('f-method').value;
+  const search = document.getElementById('f-search').value.toLowerCase();
 
-  const filtered = endpoints.filter(e => {
-    if (status !== 'all' && ((status === 'implemented' && e.status !== 'impl') || (status === 'missing' && e.status !== 'miss'))) return false;
-    if (category !== 'all' && e.cat !== category) return false;
-    if (method !== 'all' && e.method !== method) return false;
-    if (search && !e.path.toLowerCase().includes(search) && !e.func.toLowerCase().includes(search) && !e.desc.toLowerCase().includes(search)) return false;
+  let data = endpoints.filter(ep => {
+    if (status && ep.status !== status) return false;
+    if (cat    && ep.cat !== cat)       return false;
+    if (method && ep.method !== method) return false;
+    if (search) {
+      const haystack = (ep.path + ' ' + ep.func + ' ' + ep.desc + ' ' + ep.sub).toLowerCase();
+      if (!haystack.includes(search)) return false;
+    }
     return true;
   });
 
-  renderTable(filtered);
+  if (sortCol >= 0) {
+    const keys = ['_num','cat','sub','method','path','desc','status','func'];
+    const key = keys[sortCol];
+    data = data.slice().sort((a, b) => {
+      const av = key === '_num' ? 0 : (a[key] || '');
+      const bv = key === '_num' ? 0 : (b[key] || '');
+      return sortAsc ? av.localeCompare(bv) : bv.localeCompare(av);
+    });
+  }
+
+  renderTable(data);
 }
 
-let sortDir = {};
 function sortTable(col) {
-  const keys = ['idx','cat','sub','method','path','desc','status','func'];
-  const key = keys[col];
-  sortDir[key] = !(sortDir[key] || false);
-  const dir = sortDir[key] ? 1 : -1;
+  // Update sort icons
+  for (let i = 0; i < 8; i++) {
+    const el = document.getElementById('si-' + i);
+    if (el) { el.textContent = '⇅'; el.classList.remove('active'); }
+  }
 
-  endpoints.sort((a, b) => {
-    let va = key === 'idx' ? endpoints.indexOf(a) : a[key];
-    let vb = key === 'idx' ? endpoints.indexOf(b) : b[key];
-    return va < vb ? -dir : va > vb ? dir : 0;
-  });
+  if (sortCol === col) {
+    sortAsc = !sortAsc;
+  } else {
+    sortCol = col;
+    sortAsc = true;
+  }
+
+  const el = document.getElementById('si-' + col);
+  if (el) {
+    el.textContent = sortAsc ? '▲' : '▼';
+    el.classList.add('active');
+  }
 
   filterTable();
 }
 
+// Initial render
 renderTable(endpoints);
 </script>
-
 </body>
 </html>

--- a/docs/een-api-implemented.md
+++ b/docs/een-api-implemented.md
@@ -1,218 +1,264 @@
 # een-api-toolkit - Implemented EEN API Endpoints
 
-> Generated: 2026-02-17
+> Generated: 2026-02-21
 > Toolkit version: see `package.json`
 
-This document lists all EEN API v3.0 endpoints implemented by the `een-api-toolkit` library.
+REST endpoint coverage: **55 of 190 EEN API endpoints implemented (28.9%)**
+
+Note on auth proxy functions: these communicate with the OAuth proxy server, not the EEN API directly, and are not counted in the EEN API coverage totals.
+
+Note on SSE: `connectToEventSubscription()` uses Server-Sent Events over a fetch stream, not a REST endpoint. It is listed separately and not counted in REST coverage totals.
 
 ---
 
 ## Authentication (via OAuth Proxy)
 
-These functions communicate with the OAuth proxy server, not the EEN API directly.
+These functions call the OAuth proxy server (`VITE_PROXY_URL`), not the EEN API. They are NOT counted in EEN API coverage.
 
-| Function | Proxy Endpoint | Source |
-|----------|---------------|--------|
-| `getAccessToken(code)` | POST `/proxy/getAccessToken` | `src/auth/service.ts` |
-| `refreshToken()` | POST `/proxy/refreshAccessToken` | `src/auth/service.ts` |
-| `revokeToken()` | POST `/proxy/revokeAccessToken` | `src/auth/service.ts` |
-| `handleAuthCallback(code, state)` | (uses getAccessToken) | `src/auth/service.ts` |
+| Proxy Endpoint | Toolkit Function | Source |
+|----------------|-----------------|--------|
+| `POST /proxy/getAccessToken` | `getAccessToken()` | `src/auth/service.ts` |
+| `POST /proxy/refreshAccessToken` | `refreshToken()` | `src/auth/service.ts` |
+| `POST /proxy/revoke` | `revokeToken()` | `src/auth/service.ts` |
+| (orchestrates OAuth callback) | `handleAuthCallback()` | `src/auth/service.ts` |
 
-## Users (3 endpoints)
+---
+
+## Devices - PTZ (4 of 4 endpoints)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/cameras/{cameraId}/ptz/position` | `getPtzPosition()` | `src/ptz/service.ts` |
+| PUT | `/api/v3.0/cameras/{cameraId}/ptz/position` | `movePtz()` | `src/ptz/service.ts` |
+| GET | `/api/v3.0/cameras/{cameraId}/ptz/settings` | `getPtzSettings()` | `src/ptz/service.ts` |
+| PATCH | `/api/v3.0/cameras/{cameraId}/ptz/settings` | `updatePtzSettings()` | `src/ptz/service.ts` |
+
+## Devices - Cameras (3 of 15 endpoints)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/cameras` | `getCameras()` | `src/cameras/service.ts` |
+| GET | `/api/v3.0/cameras/{cameraId}` | `getCamera()` | `src/cameras/service.ts` |
+| GET | `/api/v3.0/cameras/{cameraId}/settings` | `getCameraSettings()` | `src/cameras/service.ts` |
+
+## Devices - Bridges (2 of 11 endpoints)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/bridges` | `getBridges()` | `src/bridges/service.ts` |
+| GET | `/api/v3.0/bridges/{bridgeId}` | `getBridge()` | `src/bridges/service.ts` |
+
+---
+
+## Grouping - Layouts (5 of 5 endpoints)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/layouts` | `getLayouts()` | `src/layouts/service.ts` |
+| POST | `/api/v3.0/layouts` | `createLayout()` | `src/layouts/service.ts` |
+| GET | `/api/v3.0/layouts/{layoutId}` | `getLayout()` | `src/layouts/service.ts` |
+| PATCH | `/api/v3.0/layouts/{layoutId}` | `updateLayout()` | `src/layouts/service.ts` |
+| DELETE | `/api/v3.0/layouts/{layoutId}` | `deleteLayout()` | `src/layouts/service.ts` |
+
+---
+
+## Media - Media (4 of 5 endpoints)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/media` | `listMedia()` | `src/media/service.ts` |
+| GET | `/api/v3.0/media/liveImage.jpeg` | `getLiveImage()` | `src/media/service.ts` |
+| GET | `/api/v3.0/media/recordedImage.jpeg` | `getRecordedImage()` | `src/media/service.ts` |
+| GET | `/api/v3.0/media/session` | `getMediaSession()` | `src/media/service.ts` |
+
+## Media - Feeds (1 of 1 endpoint)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/feeds` | `listFeeds()` | `src/feeds/service.ts` |
+
+## Media - Exports (1 of 2 endpoints)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| POST | `/api/v3.0/exports` | `createExportJob()` | `src/exports/service.ts` |
+
+## Media - Jobs (3 of 3 endpoints)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/jobs` | `listJobs()` | `src/jobs/service.ts` |
+| GET | `/api/v3.0/jobs/{jobId}` | `getJob()` | `src/jobs/service.ts` |
+| DELETE | `/api/v3.0/jobs/{jobId}` | `deleteJob()` | `src/jobs/service.ts` |
+
+## Media - Files (5 of 11 endpoints)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/files` | `listFiles()` | `src/files/service.ts` |
+| POST | `/api/v3.0/files` | `addFile()` | `src/files/service.ts` |
+| GET | `/api/v3.0/files/{id}` | `getFile()` | `src/files/service.ts` |
+| GET | `/api/v3.0/files/{id}:download` | `downloadFile()` | `src/files/service.ts` |
+| DELETE | `/api/v3.0/files/{id}` | `deleteFile()` | `src/files/service.ts` |
+
+## Media - Downloads (3 of 4 endpoints)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/downloads` | `listDownloads()` | `src/downloads/service.ts` |
+| GET | `/api/v3.0/downloads/{id}` | `getDownload()` | `src/downloads/service.ts` |
+| GET | `/api/v3.0/downloads/{id}:download` | `downloadDownload()` | `src/downloads/service.ts` |
+
+---
+
+## Events - Events (3 of 4 endpoints)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/events` | `listEvents()` | `src/events/service.ts` |
+| GET | `/api/v3.0/events/{id}` | `getEvent()` | `src/events/service.ts` |
+| GET | `/api/v3.0/events:listFieldValues` | `listEventFieldValues()` | `src/events/service.ts` |
+
+## Events - Event Types (1 of 1 endpoint)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/eventTypes` | `listEventTypes()` | `src/events/service.ts` |
+
+## Events - Event Metrics (1 of 1 endpoint)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/eventMetrics` | `getEventMetrics()` | `src/eventMetrics/service.ts` |
+
+## Events - Event Subscriptions (4 of 4 endpoints)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/eventSubscriptions` | `listEventSubscriptions()` | `src/eventSubscriptions/service.ts` |
+| POST | `/api/v3.0/eventSubscriptions` | `createEventSubscription()` | `src/eventSubscriptions/service.ts` |
+| GET | `/api/v3.0/eventSubscriptions/{id}` | `getEventSubscription()` | `src/eventSubscriptions/service.ts` |
+| DELETE | `/api/v3.0/eventSubscriptions/{id}` | `deleteEventSubscription()` | `src/eventSubscriptions/service.ts` |
+
+**SSE Connection (not a REST endpoint):**
+
+| Type | Description | Toolkit Function | Source |
+|------|-------------|-----------------|--------|
+| SSE | Connect to event subscription stream via Server-Sent Events | `connectToEventSubscription()` | `src/eventSubscriptions/service.ts` |
+
+## Events - Alerts (3 of 3 endpoints)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/alerts` | `listAlerts()` | `src/alerts/service.ts` |
+| GET | `/api/v3.0/alerts/{id}` | `getAlert()` | `src/alerts/service.ts` |
+| GET | `/api/v3.0/alertTypes` | `listAlertTypes()` | `src/alerts/service.ts` |
+
+## Events - Notifications (2 of 2 endpoints)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/notifications` | `listNotifications()` | `src/notifications/service.ts` |
+| GET | `/api/v3.0/notifications/{id}` | `getNotification()` | `src/notifications/service.ts` |
+
+---
+
+## Automations - Event Alert Condition Rules (3 of 6 endpoints)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/eventAlertConditionRules` | `listEventAlertConditionRules()` | `src/automations/service.ts` |
+| GET | `/api/v3.0/eventAlertConditionRules:listFieldValues` | `getEventAlertConditionRuleFieldValues()` | `src/automations/service.ts` |
+| GET | `/api/v3.0/eventAlertConditionRules/{id}` | `getEventAlertConditionRule()` | `src/automations/service.ts` |
+
+> **Note:** The toolkit also implements `GET /api/v3.0/alertConditionRules` (`listAlertConditionRules()`) and `GET /api/v3.0/alertConditionRules/{id}` (`getAlertConditionRule()`). The `/alertConditionRules` path is not present in the official OpenAPI specs — it may be an undocumented or deprecated endpoint variant. Use `/eventAlertConditionRules` for documented behavior.
+
+## Automations - Alert Action Rules (2 of 5 endpoints)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/alertActionRules` | `listAlertActionRules()` | `src/automations/service.ts` |
+| GET | `/api/v3.0/alertActionRules/{actionRuleId}` | `getAlertActionRule()` | `src/automations/service.ts` |
+
+## Automations - Alert Actions (2 of 5 endpoints)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/alertActions` | `listAlertActions()` | `src/automations/service.ts` |
+| GET | `/api/v3.0/alertActions/{actionId}` | `getAlertAction()` | `src/automations/service.ts` |
+
+---
+
+## User & Accounts - Users (3 of 9 endpoints)
 
 | Method | EEN API Path | Toolkit Function | Source |
 |--------|-------------|-----------------|--------|
 | GET | `/api/v3.0/users/self` | `getCurrentUser()` | `src/users/service.ts` |
-| GET | `/api/v3.0/users` | `getUsers(params?)` | `src/users/service.ts` |
-| GET | `/api/v3.0/users/{userId}` | `getUser(userId, params?)` | `src/users/service.ts` |
-
-## Cameras (3 endpoints)
-
-| Method | EEN API Path | Toolkit Function | Source |
-|--------|-------------|-----------------|--------|
-| GET | `/api/v3.0/cameras` | `getCameras(params?)` | `src/cameras/service.ts` |
-| GET | `/api/v3.0/cameras/{cameraId}` | `getCamera(cameraId, params?)` | `src/cameras/service.ts` |
-| GET | `/api/v3.0/cameras/{cameraId}/settings` | `getCameraSettings(cameraId, params?)` | `src/cameras/service.ts` |
-
-## Bridges (2 endpoints)
-
-| Method | EEN API Path | Toolkit Function | Source |
-|--------|-------------|-----------------|--------|
-| GET | `/api/v3.0/bridges` | `getBridges(params?)` | `src/bridges/service.ts` |
-| GET | `/api/v3.0/bridges/{bridgeId}` | `getBridge(bridgeId, params?)` | `src/bridges/service.ts` |
-
-## Layouts (5 endpoints)
-
-| Method | EEN API Path | Toolkit Function | Source |
-|--------|-------------|-----------------|--------|
-| GET | `/api/v3.0/layouts` | `getLayouts(params?)` | `src/layouts/service.ts` |
-| GET | `/api/v3.0/layouts/{layoutId}` | `getLayout(layoutId, params?)` | `src/layouts/service.ts` |
-| POST | `/api/v3.0/layouts` | `createLayout(params)` | `src/layouts/service.ts` |
-| PATCH | `/api/v3.0/layouts/{layoutId}` | `updateLayout(layoutId, params)` | `src/layouts/service.ts` |
-| DELETE | `/api/v3.0/layouts/{layoutId}` | `deleteLayout(layoutId)` | `src/layouts/service.ts` |
-
-## Media (4 endpoints)
-
-| Method | EEN API Path | Toolkit Function | Source |
-|--------|-------------|-----------------|--------|
-| GET | `/api/v3.0/media` | `listMedia(params)` | `src/media/service.ts` |
-| GET | `/api/v3.0/media/liveImage.jpeg` | `getLiveImage(params)` | `src/media/service.ts` |
-| GET | `/api/v3.0/media/recordedImage.jpeg` | `getRecordedImage(params)` | `src/media/service.ts` |
-| GET | `/api/v3.0/media/session` | `getMediaSession()` | `src/media/service.ts` |
-
-Note: `initMediaSession()` is a higher-level wrapper around `getMediaSession()`.
-
-## Feeds (1 endpoint)
-
-| Method | EEN API Path | Toolkit Function | Source |
-|--------|-------------|-----------------|--------|
-| GET | `/api/v3.0/feeds` | `listFeeds(params?)` | `src/feeds/service.ts` |
-
-## Events (3 endpoints)
-
-| Method | EEN API Path | Toolkit Function | Source |
-|--------|-------------|-----------------|--------|
-| GET | `/api/v3.0/events` | `listEvents(params)` | `src/events/service.ts` |
-| GET | `/api/v3.0/events/{eventId}` | `getEvent(eventId, params?)` | `src/events/service.ts` |
-| GET | `/api/v3.0/events:listFieldValues` | `listEventFieldValues(params)` | `src/events/service.ts` |
-
-## Event Types (1 endpoint)
-
-| Method | EEN API Path | Toolkit Function | Source |
-|--------|-------------|-----------------|--------|
-| GET | `/api/v3.0/eventTypes` | `listEventTypes(params?)` | `src/events/service.ts` |
-
-## Event Metrics (1 endpoint)
-
-| Method | EEN API Path | Toolkit Function | Source |
-|--------|-------------|-----------------|--------|
-| GET | `/api/v3.0/eventMetrics` | `getEventMetrics(params)` | `src/eventMetrics/service.ts` |
-
-## Alerts (3 endpoints)
-
-| Method | EEN API Path | Toolkit Function | Source |
-|--------|-------------|-----------------|--------|
-| GET | `/api/v3.0/alerts` | `listAlerts(params?)` | `src/alerts/service.ts` |
-| GET | `/api/v3.0/alerts/{alertId}` | `getAlert(alertId, params?)` | `src/alerts/service.ts` |
-| GET | `/api/v3.0/alertTypes` | `listAlertTypes(params?)` | `src/alerts/service.ts` |
-
-## Notifications (2 endpoints)
-
-| Method | EEN API Path | Toolkit Function | Source |
-|--------|-------------|-----------------|--------|
-| GET | `/api/v3.0/notifications` | `listNotifications(params?)` | `src/notifications/service.ts` |
-| GET | `/api/v3.0/notifications/{notificationId}` | `getNotification(notificationId)` | `src/notifications/service.ts` |
-
-## Event Subscriptions (4 endpoints + SSE)
-
-| Method | EEN API Path | Toolkit Function | Source |
-|--------|-------------|-----------------|--------|
-| GET | `/api/v3.0/eventSubscriptions` | `listEventSubscriptions(params?)` | `src/eventSubscriptions/service.ts` |
-| GET | `/api/v3.0/eventSubscriptions/{id}` | `getEventSubscription(id)` | `src/eventSubscriptions/service.ts` |
-| POST | `/api/v3.0/eventSubscriptions` | `createEventSubscription(params)` | `src/eventSubscriptions/service.ts` |
-| DELETE | `/api/v3.0/eventSubscriptions/{id}` | `deleteEventSubscription(id)` | `src/eventSubscriptions/service.ts` |
-| SSE | (SSE URL from subscription) | `connectToEventSubscription(url, options)` | `src/eventSubscriptions/service.ts` |
-
-## Automations - Event Alert Condition Rules (3 endpoints)
-
-| Method | EEN API Path | Toolkit Function | Source |
-|--------|-------------|-----------------|--------|
-| GET | `/api/v3.0/eventAlertConditionRules` | `listEventAlertConditionRules(params?)` | `src/automations/service.ts` |
-| GET | `/api/v3.0/eventAlertConditionRules:listFieldValues` | `getEventAlertConditionRuleFieldValues(params?)` | `src/automations/service.ts` |
-| GET | `/api/v3.0/eventAlertConditionRules/{ruleId}` | `getEventAlertConditionRule(ruleId)` | `src/automations/service.ts` |
-
-## Automations - Alert Condition Rules (2 endpoints)
-
-> Note: These endpoints (`/alertConditionRules`) are not listed in the official EEN OpenAPI specifications or developer portal. They may be internal or deprecated endpoints.
-
-| Method | EEN API Path | Toolkit Function | Source |
-|--------|-------------|-----------------|--------|
-| GET | `/api/v3.0/alertConditionRules` | `listAlertConditionRules(params?)` | `src/automations/service.ts` |
-| GET | `/api/v3.0/alertConditionRules/{ruleId}` | `getAlertConditionRule(ruleId, params?)` | `src/automations/service.ts` |
-
-## Automations - Alert Action Rules (2 endpoints)
-
-| Method | EEN API Path | Toolkit Function | Source |
-|--------|-------------|-----------------|--------|
-| GET | `/api/v3.0/alertActionRules` | `listAlertActionRules(params?)` | `src/automations/service.ts` |
-| GET | `/api/v3.0/alertActionRules/{ruleId}` | `getAlertActionRule(ruleId)` | `src/automations/service.ts` |
-
-## Automations - Alert Actions (2 endpoints)
-
-| Method | EEN API Path | Toolkit Function | Source |
-|--------|-------------|-----------------|--------|
-| GET | `/api/v3.0/alertActions` | `listAlertActions(params?)` | `src/automations/service.ts` |
-| GET | `/api/v3.0/alertActions/{actionId}` | `getAlertAction(actionId)` | `src/automations/service.ts` |
-
-## Exports (1 endpoint)
-
-| Method | EEN API Path | Toolkit Function | Source |
-|--------|-------------|-----------------|--------|
-| POST | `/api/v3.0/exports` | `createExportJob(params)` | `src/exports/service.ts` |
-
-## Jobs (3 endpoints)
-
-| Method | EEN API Path | Toolkit Function | Source |
-|--------|-------------|-----------------|--------|
-| GET | `/api/v3.0/jobs` | `listJobs(params?)` | `src/jobs/service.ts` |
-| GET | `/api/v3.0/jobs/{jobId}` | `getJob(jobId, params?)` | `src/jobs/service.ts` |
-| DELETE | `/api/v3.0/jobs/{jobId}` | `deleteJob(jobId)` | `src/jobs/service.ts` |
-
-## Files (5 endpoints)
-
-| Method | EEN API Path | Toolkit Function | Source |
-|--------|-------------|-----------------|--------|
-| GET | `/api/v3.0/files` | `listFiles(params?)` | `src/files/service.ts` |
-| GET | `/api/v3.0/files/{fileId}` | `getFile(fileId, params?)` | `src/files/service.ts` |
-| POST | `/api/v3.0/files` | `addFile(params)` | `src/files/service.ts` |
-| GET | `/api/v3.0/files/{fileId}:download` | `downloadFile(fileId)` | `src/files/service.ts` |
-| DELETE | `/api/v3.0/files/{fileId}` | `deleteFile(fileId)` | `src/files/service.ts` |
-
-## Downloads (3 endpoints)
-
-| Method | EEN API Path | Toolkit Function | Source |
-|--------|-------------|-----------------|--------|
-| GET | `/api/v3.0/downloads` | `listDownloads(params?)` | `src/downloads/service.ts` |
-| GET | `/api/v3.0/downloads/{downloadId}` | `getDownload(downloadId, params?)` | `src/downloads/service.ts` |
-| GET | `/api/v3.0/downloads/{downloadId}:download` | `downloadDownload(downloadId)` | `src/downloads/service.ts` |
+| GET | `/api/v3.0/users` | `getUsers()` | `src/users/service.ts` |
+| GET | `/api/v3.0/users/{userId}` | `getUser()` | `src/users/service.ts` |
 
 ---
 
 ## Summary
 
-| Category | Implemented Endpoints |
-|----------|----------------------|
-| Users | 3 |
-| Cameras | 3 |
-| Bridges | 2 |
-| Layouts | 5 |
-| Media | 4 |
-| Feeds | 1 |
-| Events | 3 |
-| Event Types | 1 |
-| Event Metrics | 1 |
-| Alerts | 3 |
-| Notifications | 2 |
-| Event Subscriptions | 4 (+SSE) |
-| Event Alert Condition Rules | 3 |
-| Alert Condition Rules | 2 (undocumented) |
-| Alert Action Rules | 2 |
-| Alert Actions | 2 |
-| Exports | 1 |
-| Jobs | 3 |
-| Files | 5 |
-| Downloads | 3 |
-| **Total (official EEN API)** | **51** |
-| Auth (proxy, not EEN API) | 4 |
-| SSE connection | 1 |
-| Alert Condition Rules (undocumented) | 2 |
+### Coverage by Category
+
+| Category | Implemented | Total | Coverage |
+|----------|-------------|-------|---------|
+| Devices - Cameras | 3 | 15 | 20% |
+| Devices - Bridges | 2 | 11 | 18% |
+| Devices - PTZ | 4 | 4 | 100% |
+| Devices - Speakers | 0 | 7 | 0% |
+| Devices - Device I/O | 0 | 6 | 0% |
+| Devices - Switches | 0 | 5 | 0% |
+| Devices - Multi Cameras | 0 | 6 | 0% |
+| Devices - Available Devices | 0 | 1 | 0% |
+| Grouping - Layouts | 5 | 5 | 100% |
+| Grouping - Tags | 0 | 1 | 0% |
+| Grouping - Locations | 0 | 6 | 0% |
+| Grouping - Floors | 0 | 6 | 0% |
+| Grouping - Floor Plans | 0 | 3 | 0% |
+| Media - Media | 4 | 5 | 80% |
+| Media - Feeds | 1 | 1 | 100% |
+| Media - Exports | 1 | 2 | 50% |
+| Media - Jobs | 3 | 3 | 100% |
+| Media - Files | 5 | 11 | 45% |
+| Media - Downloads | 3 | 4 | 75% |
+| Events - Events | 3 | 4 | 75% |
+| Events - Event Types | 1 | 1 | 100% |
+| Events - Event Metrics | 1 | 1 | 100% |
+| Events - Event Subscriptions | 4 | 4 | 100% |
+| Events - Alerts | 3 | 3 | 100% |
+| Events - Notifications | 2 | 2 | 100% |
+| Automations - Event Alert Condition Rules | 3 | 6 | 50% |
+| Automations - Alert Action Rules | 2 | 5 | 40% |
+| Automations - Alert Actions | 2 | 5 | 40% |
+| Video Search - Video Analytic Events | 0 | 7 | 0% |
+| Vehicle Surveillance - LPR Events | 0 | 4 | 0% |
+| Vehicle Surveillance - LPR Alert Condition Rules | 0 | 5 | 0% |
+| User & Accounts - Users | 3 | 9 | 33% |
+| User & Accounts - Accounts | 0 | 2 | 0% |
+| User & Accounts - Roles | 0 | 8 | 0% |
+| User & Accounts - Audit Log | 0 | 1 | 0% |
+| User & Accounts - Resource Grants | 0 | 3 | 0% |
+| User & Accounts - Editions | 0 | 2 | 0% |
+| Resellers - Authorization Tokens | 0 | 1 | 0% |
+| Account Settings - SSO | 0 | 2 | 0% |
+| Account Settings - Client Settings | 0 | 1 | 0% |
+| System - Applications | 0 | 5 | 0% |
+| System - OAuth Clients | 0 | 5 | 0% |
+| System - Reference Data | 0 | 2 | 0% |
+| **TOTAL** | **55** | **190** | **28.9%** |
 
 ### By HTTP Method
 
-| Method | Count |
-|--------|-------|
-| GET | 42 |
-| POST | 4 |
-| PATCH | 1 |
-| DELETE | 4 |
-| **Total** | **51** |
+| Method | Implemented | Total in API | Coverage |
+|--------|-------------|--------------|---------|
+| GET | 42 | 99 | 42.4% |
+| POST | 5 | 37 | 13.5% |
+| PATCH | 3 | 29 | 10.3% |
+| DELETE | 3 | 23 | 13.0% |
+| PUT | 1 | 2 | 50.0% |
+| **TOTAL** | **54** | **190** | **28.4%** |
+
+> Note: Method totals above differ slightly from the section totals because `connectToEventSubscription()` (SSE, not REST) and the undocumented `alertConditionRules` endpoints are excluded from the method count.

--- a/docs/een-api-missing.md
+++ b/docs/een-api-missing.md
@@ -1,462 +1,491 @@
 # een-api-toolkit - Missing EEN API Endpoints
 
-> Generated: 2026-02-17
-> Coverage: 51 of 211 endpoints implemented (24.2%)
-
-This document lists EEN API v3.0 endpoints that are **not yet implemented** by the `een-api-toolkit` library.
+> Generated: 2026-02-21
+> Coverage: 55 of 190 endpoints implemented (28.9%)
+> Missing: 135 endpoints
 
 ---
 
-## DEVICES - Cameras (12 of 15 missing)
+## Devices - Cameras (12 of 15 missing)
 
-Implemented: GET list, GET by ID, GET settings
+Implemented: `GET /cameras`, `GET /cameras/{cameraId}`, `GET /cameras/{cameraId}/settings`
 
 | Method | Path | Description |
 |--------|------|-------------|
-| POST | `/cameras` | Add a camera |
-| POST | `/cameras:bulkUpdate` | Bulk update cameras |
-| PATCH | `/cameras/{cameraId}` | Update a camera |
-| DELETE | `/cameras/{cameraId}` | Delete a camera |
-| PUT | `/cameras/{cameraId}/tunnel` | Create/update camera tunnel |
-| DELETE | `/cameras/{cameraId}/tunnel` | Delete camera tunnel |
-| GET | `/cameras/{cameraId}/metrics` | Get camera metrics |
-| PATCH | `/cameras/{cameraId}:swap` | Swap a camera |
+| POST | `/cameras` | Associate a camera with the account |
+| POST | `/cameras:bulkUpdate` | Update multiple cameras simultaneously |
+| DELETE | `/cameras/{cameraId}` | Remove camera from account |
+| PATCH | `/cameras/{cameraId}` | Update camera information |
+| PUT | `/cameras/{cameraId}/tunnel` | Open camera tunnel for UI access |
+| DELETE | `/cameras/{cameraId}/tunnel` | Close camera tunnel |
+| GET | `/cameras/{cameraId}/metrics` | Retrieve camera metrics data |
+| PATCH | `/cameras/{cameraId}:swap` | Replace camera with new device |
 | GET | `/cameras/{cameraId}/io/ports` | List camera I/O ports |
-| GET | `/cameras/{cameraId}/io/ports/{portId}` | Get camera I/O port |
-| PATCH | `/cameras/{cameraId}/io/ports/{portId}` | Update camera I/O port |
+| GET | `/cameras/{cameraId}/io/ports/{portId}` | Retrieve specific camera I/O port |
+| PATCH | `/cameras/{cameraId}/io/ports/{portId}` | Update camera port configuration |
 | PATCH | `/cameras/{cameraId}/settings` | Update camera settings |
 
-## DEVICES - Bridges (9 of 11 missing)
+## Devices - Bridges (9 of 11 missing)
 
-Implemented: GET list, GET by ID
-
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/bridges` | Create a bridge |
-| POST | `/bridges:bulkUpdate` | Bulk update bridges |
-| PATCH | `/bridges/{bridgeId}` | Update a bridge |
-| DELETE | `/bridges/{bridgeId}` | Delete a bridge |
-| GET | `/bridges/{bridgeId}/metrics` | Get bridge metrics |
-| PATCH | `/bridges/{bridgeId}:swap` | Swap a bridge |
-| POST | `/bridges/{bridgeId}/actions` | Trigger bridge action |
-| GET | `/bridges/{id}/settings` | Get bridge settings |
-| PATCH | `/bridges/{id}/settings` | Update bridge settings |
-
-## DEVICES - PTZ (4 of 4 missing - entire section)
+Implemented: `GET /bridges`, `GET /bridges/{bridgeId}`
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/cameras/{cameraId}/ptz/position` | Get current PTZ position |
-| PUT | `/cameras/{cameraId}/ptz/position` | Move PTZ to position |
-| GET | `/cameras/{cameraId}/ptz/settings` | Get PTZ settings |
-| PATCH | `/cameras/{cameraId}/ptz/settings` | Update PTZ settings |
+| POST | `/bridges` | Create bridge for account |
+| POST | `/bridges:bulkUpdate` | Update multiple bridges simultaneously |
+| PATCH | `/bridges/{bridgeId}` | Update bridge information |
+| DELETE | `/bridges/{bridgeId}` | Remove bridge from account |
+| GET | `/bridges/{bridgeId}/metrics` | Retrieve bridge metrics |
+| PATCH | `/bridges/{bridgeId}:swap` | Replace bridge with new device |
+| POST | `/bridges/{bridgeId}/actions` | Execute bridge actions (e.g., reboot) |
+| GET | `/bridges/{bridgeId}/settings` | Retrieve bridge operational settings |
+| PATCH | `/bridges/{bridgeId}/settings` | Update bridge settings |
 
-## DEVICES - Speakers (7 of 7 missing - entire section)
+## Devices - Speakers (7 of 7 missing)
+
+Implemented: none
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/speakers` | List speakers |
-| POST | `/speakers` | Add a speaker |
-| GET | `/speakers/{speakerId}` | Get speaker by ID |
-| PATCH | `/speakers/{speakerId}` | Update a speaker |
-| DELETE | `/speakers/{speakerId}` | Delete a speaker |
-| GET | `/speakers/{speakerId}/settings` | Get speaker settings |
+| GET | `/speakers` | List speakers with filtering and pagination |
+| POST | `/speakers` | Create speaker device |
+| GET | `/speakers/{speakerId}` | Retrieve specific speaker |
+| PATCH | `/speakers/{speakerId}` | Update speaker information |
+| DELETE | `/speakers/{speakerId}` | Remove speaker from account |
+| GET | `/speakers/{speakerId}/settings` | Retrieve speaker settings |
 | PATCH | `/speakers/{speakerId}/settings` | Update speaker settings |
 
-## DEVICES - Device I/O (6 of 6 missing - entire section)
+## Devices - Device I/O (6 of 6 missing)
+
+Implemented: none
 
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/devices/{deviceId}/io/ports` | List device I/O ports |
-| GET | `/devices/{deviceId}/io/ports/{portId}` | Get device I/O port |
-| PATCH | `/devices/{deviceId}/io/ports/{portId}` | Update device I/O port |
-| GET | `/devices/{deviceId}/io/ports/{portId}/recordingActions` | List port recording actions |
-| GET | `/devices/{deviceId}/io/ports/{portId}/recordingActions/{cameraId}` | Get port recording action |
-| PATCH | `/devices/{deviceId}/io/ports/{portId}/recordingActions/{cameraId}` | Update port recording action |
+| GET | `/devices/{deviceId}/io/ports/{portId}` | Retrieve specific I/O port |
+| PATCH | `/devices/{deviceId}/io/ports/{portId}` | Update port configuration |
+| GET | `/devices/{deviceId}/io/ports/{portId}/recordingActions` | List cameras recording on port trigger |
+| GET | `/devices/{deviceId}/io/ports/{portId}/recordingActions/{cameraId}` | Retrieve a recording action |
+| PATCH | `/devices/{deviceId}/io/ports/{portId}/recordingActions/{cameraId}` | Update a recording action |
 
-## DEVICES - Switches (5 of 5 missing - entire section)
+## Devices - Switches (5 of 5 missing)
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/switches` | List switches |
-| GET | `/switches/{switchId}` | Get switch by ID |
-| PATCH | `/switches/{switchId}` | Update a switch |
-| POST | `/switches/{switchId}/ports/{portId}/actions` | Trigger switch port action |
-| POST | `/switches/{switchId}/ports/all/actions` | Trigger action on all switch ports |
-
-## DEVICES - Multi Cameras (6 of 6 missing - entire section)
+Implemented: none
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/multiCameras` | List multi-cameras |
-| POST | `/multiCameras` | Add a multi-camera |
-| GET | `/multiCameras/{multiCameraId}` | Get multi-camera by ID |
-| PATCH | `/multiCameras/{multiCameraId}` | Update a multi-camera |
-| DELETE | `/multiCameras/{multiCameraId}` | Delete a multi-camera |
-| GET | `/multiCameras/{multiCameraId}/channels` | Get multi-camera channels |
+| GET | `/switches` | List switches with pagination |
+| GET | `/switches/{switchId}` | Retrieve specific switch |
+| PATCH | `/switches/{switchId}` | Update switch information |
+| POST | `/switches/{switchId}/ports/{portId}/actions` | Control individual switch port |
+| POST | `/switches/{switchId}/ports/all/actions` | Control all switch ports |
 
-## DEVICES - Available Devices (1 of 1 missing)
+## Devices - Multi Cameras (6 of 6 missing)
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/availableDevices` | List available (unclaimed) devices |
-
-## GROUPING - Tags (1 of 1 missing)
+Implemented: none
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/tags` | List tags |
+| GET | `/multiCameras` | List multi-camera devices |
+| POST | `/multiCameras` | Associate multi-camera with account |
+| GET | `/multiCameras/{multiCameraId}` | Retrieve multi-camera details |
+| DELETE | `/multiCameras/{multiCameraId}` | Remove multi-camera from account |
+| PATCH | `/multiCameras/{multiCameraId}` | Update multi-camera information |
+| GET | `/multiCameras/{multiCameraId}/channels` | Retrieve multi-camera channel information |
 
-## GROUPING - Locations (6 of 6 missing - entire section)
+## Devices - Available Devices (1 of 1 missing)
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/locations` | List locations |
-| POST | `/locations` | Create a location |
-| GET | `/locations/{id}` | Get location by ID |
-| PATCH | `/locations/{id}` | Update a location |
-| DELETE | `/locations/{id}` | Delete a location |
-| GET | `/locations/{id}/locations` | Get location descendants |
-
-## GROUPING - Floors (6 of 6 missing - entire section)
+Implemented: none
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/locations/{locationId}/floors` | List floors for a location |
+| GET | `/availableDevices` | List undiscovered devices available for addition |
+
+---
+
+## Grouping - Tags (1 of 1 missing)
+
+Implemented: none
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/tags` | Retrieve a list of all tags visible to the current user |
+
+## Grouping - Locations (6 of 6 missing)
+
+Implemented: none
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/locations` | Retrieve a list of locations |
+| POST | `/locations` | Create a new location |
+| GET | `/locations/{id}` | Retrieve the location with a specific ID |
+| PATCH | `/locations/{id}` | Update the location with the given ID |
+| DELETE | `/locations/{id}` | Delete the location with the given ID |
+| GET | `/locations/{id}/locations` | Retrieve child locations |
+
+## Grouping - Floors (6 of 6 missing)
+
+Implemented: none
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/locations/{locationId}/floors` | Retrieve the floors at the given location |
 | POST | `/locations/{locationId}/floors` | Create a floor |
-| GET | `/locations/{locationId}/floors/{id}` | Get floor by ID |
-| PATCH | `/locations/{locationId}/floors/{id}` | Update a floor |
-| DELETE | `/locations/{locationId}/floors/{id}` | Delete a floor |
-| GET | `/locations/{locationId}/floors/{id}.{type}` | Get floor image |
+| GET | `/locations/{locationId}/floors/{id}` | Retrieve a specific floor at a specific location |
+| PATCH | `/locations/{locationId}/floors/{id}` | Update one or more fields of the given floor |
+| DELETE | `/locations/{locationId}/floors/{id}` | Delete a specific floor of a specific location |
+| GET | `/locations/{locationId}/floors/{id}.{type}` | Retrieve the floor image of a specific floor |
 
-## GROUPING - Floor Plans (3 of 3 missing - entire section)
+## Grouping - Floor Plans (3 of 3 missing)
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/locations/{locationId}/floors/{id}/plans` | List floor plans |
-| POST | `/locations/{locationId}/floors/{id}/plans` | Set a floor plan |
-| DELETE | `/locations/{locationId}/floors/{id}/plans/{planId}` | Delete a floor plan |
-
-## MEDIA - Media (1 of 5 missing)
-
-Implemented: GET list, GET liveImage, GET recordedImage, GET session
+Implemented: none
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/media/recordedImage.jpeg:listFieldValues` | List recorded image overlay field values |
+| GET | `/locations/{locationId}/floors/{id}/plans` | Retrieve plans of a specific floor |
+| POST | `/locations/{locationId}/floors/{id}/plans` | Create a floor plan for a specific floor |
+| DELETE | `/locations/{locationId}/floors/{id}/plans/{planId}` | Delete a floor plan and its corresponding file |
 
-## MEDIA - Exports (1 of 2 missing)
+---
 
-Implemented: POST create
+## Media - Media (1 of 5 missing)
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/exports/{jobId}:copy` | Retry/copy an export |
-
-## MEDIA - Files (6 of 11 missing)
-
-Implemented: GET list, GET by ID, POST add, GET download, DELETE
+Implemented: `GET /media`, `GET /media/liveImage.jpeg`, `GET /media/recordedImage.jpeg`, `GET /media/session`
 
 | Method | Path | Description |
 |--------|------|-------------|
-| PATCH | `/files/{id}` | Update a file |
-| GET | `/deletedFiles` | List trash (deleted files) |
-| GET | `/deletedFiles/{id}` | Get deleted file |
-| DELETE | `/deletedFiles/{id}` | Permanently delete a trash file |
-| DELETE | `/deletedFiles/all` | Permanently delete all trash files |
-| POST | `/deletedFiles/{id}:restore` | Restore a deleted file |
+| GET | `/media/recordedImage.jpeg:listFieldValues` | List available field values for recorded images |
 
-## MEDIA - Downloads (1 of 4 missing)
+## Media - Exports (1 of 2 missing)
 
-Implemented: GET list, GET by ID, GET download
+Implemented: `POST /exports`
 
 | Method | Path | Description |
 |--------|------|-------------|
-| PATCH | `/downloads/{id}` | Update a download |
+| POST | `/exports/{jobId}:copy` | Retry export with modified parameters |
 
-## EVENTS - Events (2 of 5 missing)
+## Media - Files (6 of 11 missing)
 
-Implemented: GET list, GET by ID, GET listFieldValues
-
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/events` | Create an event |
-| GET | `/events:listRecentByType` | List recent events by type |
-
-## EVENTS - Event Subscriptions (4 of 8 missing)
-
-Implemented: GET list, GET by ID, POST create, DELETE
+Implemented: `GET /files`, `POST /files`, `GET /files/{id}`, `GET /files/{id}:download`, `DELETE /files/{id}`
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/eventSubscriptions/{id}/filters` | List subscription filters |
-| POST | `/eventSubscriptions/{id}/filters` | Create subscription filter |
-| GET | `/eventSubscriptions/{id}/filters/{filterId}` | Get subscription filter |
-| DELETE | `/eventSubscriptions/{id}/filters/{filterId}` | Delete subscription filter |
+| PATCH | `/files/{id}` | Modify file details |
+| GET | `/deletedFiles` | List deleted files |
+| GET | `/deletedFiles/{id}` | Get recycled item details |
+| DELETE | `/deletedFiles/{id}` | Permanently delete item |
+| DELETE | `/deletedFiles/all` | Clear recycle bin |
+| POST | `/deletedFiles/{id}:restore` | Restore recycled item |
 
-## EVENTS - Notifications (1 of 3 missing)
+## Media - Downloads (1 of 4 missing)
 
-Implemented: GET list, GET by ID
-
-| Method | Path | Description |
-|--------|------|-------------|
-| PATCH | `/notifications/{id}` | Update a notification |
-
-## AUTOMATIONS - Event Alert Condition Rules (3 of 6 missing)
-
-Implemented: GET list, GET listFieldValues, GET by ID
+Implemented: `GET /downloads`, `GET /downloads/{id}`, `GET /downloads/{id}:download`
 
 | Method | Path | Description |
 |--------|------|-------------|
-| POST | `/eventAlertConditionRules` | Create event alert condition rule |
-| PATCH | `/eventAlertConditionRules/{id}` | Update event alert condition rule |
-| DELETE | `/eventAlertConditionRules/{id}` | Delete event alert condition rule |
+| PATCH | `/downloads/{id}` | Modify download metadata |
 
-## AUTOMATIONS - Alert Action Rules (3 of 5 missing)
+---
 
-Implemented: GET list, GET by ID
+## Events - Events (1 of 4 missing)
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/alertActionRules` | Create alert action rule |
-| PATCH | `/alertActionRules/{actionRuleId}` | Update alert action rule |
-| DELETE | `/alertActionRules/{actionRuleId}` | Delete alert action rule |
-
-## AUTOMATIONS - Alert Actions (3 of 5 missing)
-
-Implemented: GET list, GET by ID
+Implemented: `GET /events`, `GET /events/{id}`, `GET /events:listFieldValues`
 
 | Method | Path | Description |
 |--------|------|-------------|
-| POST | `/alertActions` | Create alert action |
-| PATCH | `/alertActions/{actionId}` | Update alert action |
-| DELETE | `/alertActions/{actionId}` | Delete alert action |
+| POST | `/events` | Create a new event for the selected actor |
 
-## VIDEO SEARCH - Video Analytic Events (7 of 7 missing - entire section)
+---
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/videoAnalyticEvents:parse` | Parse video analytics query |
-| POST | `/videoAnalyticEvents:deepSearch` | Deep search video analytics events |
-| POST | `/videoAnalyticEvents:deepSearchGroupByResource` | Deep search grouped by resource |
-| POST | `/videoAnalyticEvents:deepSearchGroupByTime` | Deep search grouped by time |
-| POST | `/videoAnalyticEvents:listFieldValues` | List video analytics field values |
-| GET | `/videoAnalyticEvents:listObjectValues` | List video analytics object values |
-| GET | `/videoAnalyticEvents/{id}` | Get video analytics event by ID |
+## Automations - Event Alert Condition Rules (3 of 6 missing)
 
-## VEHICLE SURVEILLANCE - LPR Events (4 of 4 missing - entire section)
+Implemented: `GET /eventAlertConditionRules`, `GET /eventAlertConditionRules:listFieldValues`, `GET /eventAlertConditionRules/{id}`
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/lprEvents` | List LPR events |
-| GET | `/lprEvents/{id}` | Get LPR event by ID |
-| GET | `/lprEvents:summary` | Get LPR events summary |
-| GET | `/lprEvents:listFieldValues` | List LPR event field values |
+| POST | `/eventAlertConditionRules` | Create a new rule that produces alerts based on event conditions |
+| PATCH | `/eventAlertConditionRules/{id}` | Update a specific alert condition rule |
+| DELETE | `/eventAlertConditionRules/{id}` | Remove a specific alert condition rule |
 
-## VEHICLE SURVEILLANCE - LPR Alert Condition Rules (6 of 6 missing - entire section)
+## Automations - Alert Action Rules (3 of 5 missing)
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/lprAlertConditionRules` | List LPR alert condition rules |
-| POST | `/lprAlertConditionRules` | Create LPR alert condition rule |
-| GET | `/lprAlertConditionRules:listFieldValues` | List LPR rule field values |
-| GET | `/lprAlertConditionRules/{id}` | Get LPR alert condition rule |
-| PATCH | `/lprAlertConditionRules/{id}` | Update LPR alert condition rule |
-| DELETE | `/lprAlertConditionRules/{id}` | Delete LPR alert condition rule |
-
-## VEHICLE SURVEILLANCE - LPR Vehicle Lists (14 of 14 missing - entire section)
+Implemented: `GET /alertActionRules`, `GET /alertActionRules/{actionRuleId}`
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/lprVehicleLists` | List vehicle lists |
-| POST | `/lprVehicleLists` | Create vehicle list |
-| GET | `/lprVehicleLists:listFields` | List vehicle list fields |
-| GET | `/lprVehicleLists:listFieldValues` | List vehicle list field values |
-| GET | `/lprVehicleLists/{id}` | Get vehicle list by ID |
-| PATCH | `/lprVehicleLists/{id}` | Update vehicle list |
-| DELETE | `/lprVehicleLists/{id}` | Delete vehicle list |
-| GET | `/lprVehicleLists/{id}/vehicles` | List vehicles in a list |
-| POST | `/lprVehicleLists/{id}/vehicles` | Add vehicle to list |
-| POST | `/lprVehicleLists/{id}/vehicles:bulkCreate` | Bulk add vehicles |
-| GET | `/lprVehicleLists/{id}/vehicles/{recordId}` | Get vehicle by ID |
-| PATCH | `/lprVehicleLists/{id}/vehicles/{recordId}` | Update a vehicle |
-| DELETE | `/lprVehicleLists/{id}/vehicles/{recordId}` | Delete a vehicle |
-| GET | `/lprVehicleLists:search` | Search vehicle lists |
+| POST | `/alertActionRules` | Register a new alert action rule with the account |
+| PATCH | `/alertActionRules/{actionRuleId}` | Update a single alert action rule |
+| DELETE | `/alertActionRules/{actionRuleId}` | Remove an alert action rule |
 
-## USER & ACCOUNTS - Users (6 of 9 missing)
+## Automations - Alert Actions (3 of 5 missing)
 
-Implemented: GET list, GET by ID, GET self
+Implemented: `GET /alertActions`, `GET /alertActions/{actionId}`
 
 | Method | Path | Description |
 |--------|------|-------------|
-| POST | `/users` | Create a user |
-| PATCH | `/users/{userId}` | Update a user |
-| DELETE | `/users/{userId}` | Delete a user |
-| PATCH | `/users/self` | Update current user |
-| GET | `/users/self/trustedClients` | List trusted OAuth clients |
-| DELETE | `/users/self/trustedClients/{trustedClientId}` | Delete trusted client |
+| POST | `/alertActions` | Register a new alert action with the account |
+| PATCH | `/alertActions/{actionId}` | Update a single alert action |
+| DELETE | `/alertActions/{actionId}` | Remove an alert action |
 
-## USER & ACCOUNTS - Accounts (2 of 2 missing - entire section)
+---
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/accounts` | List accounts |
-| DELETE | `/accounts/{id}/credentials/{credentialId}` | Delete account credential |
+## Video Search - Video Analytic Events (7 of 7 missing)
 
-## USER & ACCOUNTS - Roles (8 of 8 missing - entire section)
+Implemented: none
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/roles` | List roles |
-| POST | `/roles` | Create a role |
-| GET | `/roles/{roleId}` | Get role by ID |
-| PATCH | `/roles/{roleId}` | Update a role |
-| DELETE | `/roles/{roleId}` | Delete a role |
-| GET | `/roleAssignments` | List role assignments |
-| POST | `/roleAssignments:bulkcreate` | Bulk create role assignments |
-| POST | `/roleAssignments:bulkdelete` | Bulk delete role assignments |
+| POST | `/videoAnalyticEvents:parse` | Map natural language queries to object filters for deep search |
+| POST | `/videoAnalyticEvents:deepSearch` | Fetch video analytic events matching defined filters |
+| POST | `/videoAnalyticEvents:deepSearchGroupByResource` | Fetch event frequencies grouped by resource metadata |
+| POST | `/videoAnalyticEvents:deepSearchGroupByTime` | Fetch event frequencies grouped in time periods |
+| POST | `/videoAnalyticEvents:listFieldValues` | Retrieve available deep search query parameters |
+| GET | `/videoAnalyticEvents:listObjectValues` | Fetch available filter attribute values for events |
+| GET | `/videoAnalyticEvents/{id}` | Retrieve specific video analytics event by ID |
 
-## USER & ACCOUNTS - Audit Log (1 of 1 missing)
+---
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/auditLogs` | List audit logs |
+## Vehicle Surveillance - LPR Events (4 of 4 missing)
 
-## USER & ACCOUNTS - Resource Grants (3 of 3 missing - entire section)
+Implemented: none
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/resourceGrants` | List resource grants |
-| POST | `/resourceGrants:bulkCreate` | Bulk create resource grants |
-| POST | `/resourceGrants:bulkDelete` | Bulk delete resource grants |
+| GET | `/lprEvents` | Fetch license plate recognition events with filtering |
+| GET | `/lprEvents/{id}` | Retrieve a specific LPR event by ID |
+| GET | `/lprEvents:summary` | Obtain aggregated counts of LPR events across time periods |
+| GET | `/lprEvents:listFieldValues` | List all possible filter values for LPR event attributes |
 
-## USER & ACCOUNTS - Editions (2 of 2 missing - entire section)
+## Vehicle Surveillance - LPR Alert Condition Rules (5 of 5 missing)
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/editions` | List editions |
-| GET | `/editions/{id}` | Get edition by ID |
-
-## RESELLERS - Authorization Tokens (1 of 1 missing)
+Implemented: none
 
 | Method | Path | Description |
 |--------|------|-------------|
-| POST | `/authorizationTokens` | Create authorization token |
+| POST | `/lprAlertConditionRules` | Create a new rule for generating alerts based on LPR conditions |
+| GET | `/lprAlertConditionRules` | Fetch LPR alert condition rules based on a filter |
+| GET | `/lprAlertConditionRules:listFieldValues` | Return possible values across all rule attributes |
+| GET | `/lprAlertConditionRules/{id}` | Retrieve details of a specific LPR rule |
+| PATCH | `/lprAlertConditionRules/{id}` | Update specified properties of an existing LPR rule |
 
-## ACCOUNT SETTINGS - SSO (2 of 2 missing - entire section)
+---
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/accounts/self/ssoAuthSettings` | Get SSO auth settings |
-| PATCH | `/accounts/self/ssoAuthSettings` | Update SSO auth settings |
+## User & Accounts - Users (6 of 9 missing)
 
-## ACCOUNT SETTINGS - Client Settings (1 of 1 missing)
-
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/clientSettings` | Get client settings |
-
-## SYSTEM - Applications (5 of 5 missing - entire section)
+Implemented: `GET /users/self`, `GET /users`, `GET /users/{userId}`
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/applications` | List applications |
-| POST | `/applications` | Create an application |
-| GET | `/applications/{applicationId}` | Get application by ID |
-| PATCH | `/applications/{applicationId}` | Update an application |
-| DELETE | `/applications/{applicationId}` | Delete an application |
+| POST | `/users` | Create a new user (verification email sent, pending state) |
+| DELETE | `/users/{userId}` | Delete a user and remove all related references |
+| PATCH | `/users/{userId}` | Update a user's data |
+| PATCH | `/users/self` | Update current user's profile data |
+| GET | `/users/self/trustedClients` | Retrieve a list of trusted clients |
+| DELETE | `/users/self/trustedClients/{trustedClientId}` | Delete a trusted client device |
 
-## SYSTEM - OAuth Clients (5 of 5 missing - entire section)
+## User & Accounts - Accounts (2 of 2 missing)
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/applications/{applicationId}/oauthClients` | List OAuth clients |
-| POST | `/applications/{applicationId}/oauthClients` | Create OAuth client |
-| GET | `/applications/{applicationId}/oauthClients/{clientId}` | Get OAuth client |
-| PATCH | `/applications/{applicationId}/oauthClients/{clientId}` | Update OAuth client |
-| DELETE | `/applications/{applicationId}/oauthClients/{clientId}` | Delete OAuth client |
-
-## SYSTEM - Reference Data (2 of 2 missing - entire section)
+Implemented: none
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/languages` | List supported languages |
-| GET | `/timeZones` | List supported time zones |
+| GET | `/accounts` | Retrieve a list of accounts the user has access to |
+| DELETE | `/accounts/{id}/credentials/{credentialId}` | Remove a credential from the account |
+
+## User & Accounts - Roles (8 of 8 missing)
+
+Implemented: none
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/roles` | Returns a list of all roles in current user's account |
+| POST | `/roles` | Create a new role with defined permissions |
+| GET | `/roles/{roleId}` | Retrieve a role by its ID |
+| DELETE | `/roles/{roleId}` | Delete a role (only if unassigned) |
+| PATCH | `/roles/{roleId}` | Update role information and permissions |
+| GET | `/roleAssignments` | Returns a list of all role assignments |
+| POST | `/roleAssignments:bulkcreate` | Create multiple role assignments in one request |
+| POST | `/roleAssignments:bulkdelete` | Delete multiple role assignments in one request |
+
+## User & Accounts - Audit Log (1 of 1 missing)
+
+Implemented: none
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/auditLogs` | Filter audit events by userId, targetId, type, and timestamp range |
+
+## User & Accounts - Resource Grants (3 of 3 missing)
+
+Implemented: none
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/resourceGrants` | Retrieve a list of resource grants |
+| POST | `/resourceGrants:bulkCreate` | Create multiple resource grants in one request |
+| POST | `/resourceGrants:bulkDelete` | Delete multiple resource grants in one request |
+
+## User & Accounts - Editions (2 of 2 missing)
+
+Implemented: none
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/editions` | Retrieve available editions for the account |
+| GET | `/editions/{id}` | Retrieve a specific edition by ID |
+
+---
+
+## Resellers - Authorization Tokens (1 of 1 missing)
+
+Implemented: none
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/authorizationTokens` | Resellers retrieve access tokens for end-user accounts |
+
+---
+
+## Account Settings - SSO (2 of 2 missing)
+
+Implemented: none
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/accounts/self/ssoAuthSettings` | Get Single Sign On Authentication Settings |
+| PATCH | `/accounts/self/ssoAuthSettings` | Update Single Sign On Authentication Settings |
+
+## Account Settings - Client Settings (1 of 1 missing)
+
+Implemented: none
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/clientSettings` | Retrieve settings required to let the client use the API |
+
+---
+
+## System - Applications (5 of 5 missing)
+
+Implemented: none
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/applications` | Retrieve all applications accessible by the requesting user |
+| POST | `/applications` | Create new application under user's account |
+| GET | `/applications/{applicationId}` | Retrieve a single application |
+| PATCH | `/applications/{applicationId}` | Update a single application |
+| DELETE | `/applications/{applicationId}` | Delete a single application |
+
+## System - OAuth Clients (5 of 5 missing)
+
+Implemented: none
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/applications/{applicationId}/oauthClients` | Retrieve all OAuth credentials for the given application |
+| POST | `/applications/{applicationId}/oauthClients` | Create OAuth client for application |
+| GET | `/applications/{applicationId}/oauthClients/{clientId}` | Retrieve a specific OAuth client |
+| PATCH | `/applications/{applicationId}/oauthClients/{clientId}` | Update a specific OAuth client |
+| DELETE | `/applications/{applicationId}/oauthClients/{clientId}` | Delete a specific OAuth client |
+
+## System - Reference Data (2 of 2 missing)
+
+Implemented: none
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/languages` | Retrieve a list of languages supported by the service |
+| GET | `/timeZones` | Retrieve a list of the supported time zones |
 
 ---
 
 ## Summary
 
-| Status | Count |
-|--------|-------|
-| Implemented | 51 |
-| Missing | 160 |
-| **Total EEN API endpoints** | **211** |
-| **Coverage** | **24.2%** |
+### Coverage by Category
 
-### Missing by Category
+| Category | Implemented | Missing | Total | Coverage |
+|----------|-------------|---------|-------|---------|
+| Devices - Cameras | 3 | 12 | 15 | 20% |
+| Devices - Bridges | 2 | 9 | 11 | 18% |
+| Devices - PTZ | 4 | 0 | 4 | 100% |
+| Devices - Speakers | 0 | 7 | 7 | 0% |
+| Devices - Device I/O | 0 | 6 | 6 | 0% |
+| Devices - Switches | 0 | 5 | 5 | 0% |
+| Devices - Multi Cameras | 0 | 6 | 6 | 0% |
+| Devices - Available Devices | 0 | 1 | 1 | 0% |
+| Grouping - Layouts | 5 | 0 | 5 | 100% |
+| Grouping - Tags | 0 | 1 | 1 | 0% |
+| Grouping - Locations | 0 | 6 | 6 | 0% |
+| Grouping - Floors | 0 | 6 | 6 | 0% |
+| Grouping - Floor Plans | 0 | 3 | 3 | 0% |
+| Media - Media | 4 | 1 | 5 | 80% |
+| Media - Feeds | 1 | 0 | 1 | 100% |
+| Media - Exports | 1 | 1 | 2 | 50% |
+| Media - Jobs | 3 | 0 | 3 | 100% |
+| Media - Files | 5 | 6 | 11 | 45% |
+| Media - Downloads | 3 | 1 | 4 | 75% |
+| Events - Events | 3 | 1 | 4 | 75% |
+| Events - Event Types | 1 | 0 | 1 | 100% |
+| Events - Event Metrics | 1 | 0 | 1 | 100% |
+| Events - Event Subscriptions | 4 | 0 | 4 | 100% |
+| Events - Alerts | 3 | 0 | 3 | 100% |
+| Events - Notifications | 2 | 0 | 2 | 100% |
+| Automations - Event Alert Condition Rules | 3 | 3 | 6 | 50% |
+| Automations - Alert Action Rules | 2 | 3 | 5 | 40% |
+| Automations - Alert Actions | 2 | 3 | 5 | 40% |
+| Video Search - Video Analytic Events | 0 | 7 | 7 | 0% |
+| Vehicle Surveillance - LPR Events | 0 | 4 | 4 | 0% |
+| Vehicle Surveillance - LPR Alert Condition Rules | 0 | 5 | 5 | 0% |
+| User & Accounts - Users | 3 | 6 | 9 | 33% |
+| User & Accounts - Accounts | 0 | 2 | 2 | 0% |
+| User & Accounts - Roles | 0 | 8 | 8 | 0% |
+| User & Accounts - Audit Log | 0 | 1 | 1 | 0% |
+| User & Accounts - Resource Grants | 0 | 3 | 3 | 0% |
+| User & Accounts - Editions | 0 | 2 | 2 | 0% |
+| Resellers - Authorization Tokens | 0 | 1 | 1 | 0% |
+| Account Settings - SSO | 0 | 2 | 2 | 0% |
+| Account Settings - Client Settings | 0 | 1 | 1 | 0% |
+| System - Applications | 0 | 5 | 5 | 0% |
+| System - OAuth Clients | 0 | 5 | 5 | 0% |
+| System - Reference Data | 0 | 2 | 2 | 0% |
+| **TOTAL** | **55** | **135** | **190** | **28.9%** |
 
-| Category | Missing | Total | Coverage |
-|----------|---------|-------|----------|
-| Cameras | 12 | 15 | 20% |
-| Bridges | 9 | 11 | 18% |
-| PTZ | 4 | 4 | 0% |
-| Speakers | 7 | 7 | 0% |
-| Device I/O | 6 | 6 | 0% |
-| Switches | 5 | 5 | 0% |
-| Multi Cameras | 6 | 6 | 0% |
-| Available Devices | 1 | 1 | 0% |
-| Layouts | 0 | 5 | 100% |
-| Tags | 1 | 1 | 0% |
-| Locations | 6 | 6 | 0% |
-| Floors | 6 | 6 | 0% |
-| Floor Plans | 3 | 3 | 0% |
-| Media | 1 | 5 | 80% |
-| Feeds | 0 | 1 | 100% |
-| Exports | 1 | 2 | 50% |
-| Jobs | 0 | 3 | 100% |
-| Files | 6 | 11 | 45% |
-| Downloads | 1 | 4 | 75% |
-| Events | 2 | 5 | 60% |
-| Event Types | 0 | 1 | 100% |
-| Event Metrics | 0 | 1 | 100% |
-| Event Subscriptions | 4 | 8 | 50% |
-| Alerts | 0 | 3 | 100% |
-| Notifications | 1 | 3 | 67% |
-| Event Alert Condition Rules | 3 | 6 | 50% |
-| Alert Action Rules | 3 | 5 | 40% |
-| Alert Actions | 3 | 5 | 40% |
-| Video Analytic Events | 7 | 7 | 0% |
-| LPR Events | 4 | 4 | 0% |
-| LPR Alert Condition Rules | 6 | 6 | 0% |
-| LPR Vehicle Lists | 14 | 14 | 0% |
-| Users | 6 | 9 | 33% |
-| Accounts | 2 | 2 | 0% |
-| Roles | 8 | 8 | 0% |
-| Audit Log | 1 | 1 | 0% |
-| Resource Grants | 3 | 3 | 0% |
-| Editions | 2 | 2 | 0% |
-| Authorization Tokens | 1 | 1 | 0% |
-| SSO | 2 | 2 | 0% |
-| Client Settings | 1 | 1 | 0% |
-| Applications | 5 | 5 | 0% |
-| OAuth Clients | 5 | 5 | 0% |
-| Reference Data | 2 | 2 | 0% |
+### Fully Implemented Sections (100% coverage)
 
-### Fully Implemented Sections
-
-- Layouts (5/5)
-- Feeds (1/1)
-- Jobs (3/3)
-- Event Types (1/1)
-- Event Metrics (1/1)
-- Alerts (3/3)
+- Devices - PTZ (4/4)
+- Grouping - Layouts (5/5)
+- Media - Feeds (1/1)
+- Media - Jobs (3/3)
+- Events - Event Types (1/1)
+- Events - Event Metrics (1/1)
+- Events - Event Subscriptions (4/4)
+- Events - Alerts (3/3)
+- Events - Notifications (2/2)
 
 ### Entirely Missing Sections (0% coverage)
 
-- PTZ, Speakers, Device I/O, Switches, Multi Cameras, Available Devices
-- Tags, Locations, Floors, Floor Plans
-- Video Analytic Events, LPR Events, LPR Alert Condition Rules, LPR Vehicle Lists
-- Accounts, Roles, Audit Log, Resource Grants, Editions
-- Authorization Tokens, SSO, Client Settings
-- Applications, OAuth Clients, Reference Data
+- Devices - Speakers
+- Devices - Device I/O
+- Devices - Switches
+- Devices - Multi Cameras
+- Devices - Available Devices
+- Grouping - Tags
+- Grouping - Locations
+- Grouping - Floors
+- Grouping - Floor Plans
+- Video Search - Video Analytic Events
+- Vehicle Surveillance - LPR Events
+- Vehicle Surveillance - LPR Alert Condition Rules
+- User & Accounts - Accounts
+- User & Accounts - Roles
+- User & Accounts - Audit Log
+- User & Accounts - Resource Grants
+- User & Accounts - Editions
+- Resellers - Authorization Tokens
+- Account Settings - SSO
+- Account Settings - Client Settings
+- System - Applications
+- System - OAuth Clients
+- System - Reference Data

--- a/examples/vue-ptz/README.md
+++ b/examples/vue-ptz/README.md
@@ -214,7 +214,7 @@ let pageToken: string | undefined
 do {
   const result = await getCameras({ pageSize: 100, include: ['capabilities'], pageToken })
   for (const cam of result.data?.results || []) {
-    if (cam.capabilities?.ptz?.capable) ptzCameras.push(cam)
+    if (cam.capabilities?.ptz?.capable && !cam.capabilities?.ptz?.fisheye) ptzCameras.push(cam)
   }
   pageToken = result.data?.nextPageToken ?? undefined
 } while (pageToken)

--- a/examples/vue-ptz/src/components/CameraSelector.vue
+++ b/examples/vue-ptz/src/components/CameraSelector.vue
@@ -35,7 +35,7 @@ async function loadPtzCameras() {
 
     const allCameras = result.data?.results || []
     for (const cam of allCameras) {
-      if (cam.capabilities?.ptz?.capable) {
+      if (cam.capabilities?.ptz?.capable && !cam.capabilities?.ptz?.fisheye) {
         ptzCameras.push(cam)
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.92",
+  "version": "0.3.93",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit",
-      "version": "0.3.92",
+      "version": "0.3.93",
       "license": "MIT",
       "bin": {
         "een-setup-agents": "scripts/setup-agents.ts"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.94",
+  "version": "0.3.95",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit",
-      "version": "0.3.94",
+      "version": "0.3.95",
       "license": "MIT",
       "bin": {
         "een-setup-agents": "scripts/setup-agents.ts"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.93",
+  "version": "0.3.94",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit",
-      "version": "0.3.93",
+      "version": "0.3.94",
       "license": "MIT",
       "bin": {
         "een-setup-agents": "scripts/setup-agents.ts"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.96",
+  "version": "0.3.97",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit",
-      "version": "0.3.96",
+      "version": "0.3.97",
       "license": "MIT",
       "bin": {
         "een-setup-agents": "scripts/setup-agents.ts"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.91",
+  "version": "0.3.92",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit",
-      "version": "0.3.91",
+      "version": "0.3.92",
       "license": "MIT",
       "bin": {
         "een-setup-agents": "scripts/setup-agents.ts"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.95",
+  "version": "0.3.96",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-api-toolkit",
-      "version": "0.3.95",
+      "version": "0.3.96",
       "license": "MIT",
       "bin": {
         "een-setup-agents": "scripts/setup-agents.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.91",
+  "version": "0.3.92",
   "description": "EEN Video platform API v3.0 library for Vue 3",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.95",
+  "version": "0.3.96",
   "description": "EEN Video platform API v3.0 library for Vue 3",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.93",
+  "version": "0.3.94",
   "description": "EEN Video platform API v3.0 library for Vue 3",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.92",
+  "version": "0.3.93",
   "description": "EEN Video platform API v3.0 library for Vue 3",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.94",
+  "version": "0.3.95",
   "description": "EEN Video platform API v3.0 library for Vue 3",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-api-toolkit",
-  "version": "0.3.96",
+  "version": "0.3.97",
   "description": "EEN Video platform API v3.0 library for Vue 3",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/scripts/generate-ai-context.ts
+++ b/scripts/generate-ai-context.ts
@@ -3555,6 +3555,20 @@ function handleVideoClick(event: MouseEvent) {
 | FORBIDDEN | No permission | Show access denied |
 | VALIDATION_ERROR | Empty camera ID | Fix input |
 
+## Fisheye Camera Exclusion
+
+**IMPORTANT:** Fisheye cameras report \`capabilities.ptz.capable: true\` but are NOT true PTZ cameras.
+Always exclude fisheye cameras when checking PTZ capability:
+
+\`\`\`typescript
+const isPtzCapable = computed(() => {
+  const ptz = camera.capabilities?.ptz
+  return ptz?.capable === true && ptz?.fisheye !== true
+})
+\`\`\`
+
+Also check \`effectivePermissions.controlPTZ\` to verify the user has permission to move the camera.
+
 ---
 
 ## Reference Examples

--- a/scripts/generate-ai-context.ts
+++ b/scripts/generate-ai-context.ts
@@ -1092,6 +1092,17 @@ interface Camera {
   deviceInfo?: CameraDeviceInfo
   shareDetails?: CameraShareDetails
   devicePosition?: CameraDevicePosition
+  capabilities?: {
+    ptz?: {
+      capable?: boolean
+      fisheye?: boolean
+      panTilt?: boolean
+      zoom?: boolean
+      positionMove?: boolean
+      directionMove?: boolean
+      centerOnMove?: boolean
+    }
+  }
   createdAt?: string
   updatedAt?: string
 }
@@ -3561,8 +3572,10 @@ function handleVideoClick(event: MouseEvent) {
 Always exclude fisheye cameras when checking PTZ capability:
 
 \`\`\`typescript
+import { computed } from 'vue'
+
 const isPtzCapable = computed(() => {
-  const ptz = camera.capabilities?.ptz
+  const ptz = camera.value?.capabilities?.ptz
   return ptz?.capable === true && ptz?.fisheye !== true
 })
 \`\`\`

--- a/src/__tests__/cameras.test.ts
+++ b/src/__tests__/cameras.test.ts
@@ -150,6 +150,21 @@ describe('Camera types', () => {
       expect(isPtzCapable).toBe(false)
     })
 
+    it('should treat missing fisheye field as non-fisheye', () => {
+      const camera: Camera = {
+        id: 'cam-ptz',
+        name: 'PTZ Camera',
+        accountId: 'acc-456',
+        capabilities: { ptz: { capable: true } }
+      }
+
+      const ptz = camera.capabilities?.ptz
+      const isPtzCapable = ptz?.capable === true && ptz?.fisheye !== true
+
+      expect(ptz?.fisheye).toBeUndefined()
+      expect(isPtzCapable).toBe(true)
+    })
+
     it('should accept null for bridgeId and locationId', () => {
       const camera: Camera = {
         id: 'cam-direct',

--- a/src/__tests__/cameras.test.ts
+++ b/src/__tests__/cameras.test.ts
@@ -102,6 +102,54 @@ describe('Camera types', () => {
       expect(camera.recordingModes?.continuous).toBe(true)
     })
 
+    it('should accept PTZ capability fields including fisheye', () => {
+      const ptzCamera: Camera = {
+        id: 'cam-ptz',
+        name: 'PTZ Camera',
+        accountId: 'acc-456',
+        capabilities: {
+          ptz: {
+            capable: true,
+            fisheye: false,
+            panTilt: true,
+            zoom: true,
+            positionMove: true,
+            directionMove: true,
+            centerOnMove: true
+          }
+        }
+      }
+
+      expect(ptzCamera.capabilities?.ptz?.capable).toBe(true)
+      expect(ptzCamera.capabilities?.ptz?.fisheye).toBe(false)
+      expect(ptzCamera.capabilities?.ptz?.panTilt).toBe(true)
+      expect(ptzCamera.capabilities?.ptz?.zoom).toBe(true)
+      expect(ptzCamera.capabilities?.ptz?.positionMove).toBe(true)
+      expect(ptzCamera.capabilities?.ptz?.directionMove).toBe(true)
+      expect(ptzCamera.capabilities?.ptz?.centerOnMove).toBe(true)
+    })
+
+    it('should identify fisheye cameras as non-PTZ', () => {
+      const fisheyeCamera: Camera = {
+        id: 'cam-fisheye',
+        name: 'Fisheye Camera',
+        accountId: 'acc-456',
+        capabilities: {
+          ptz: {
+            capable: true,
+            fisheye: true
+          }
+        }
+      }
+
+      const ptz = fisheyeCamera.capabilities?.ptz
+      const isPtzCapable = ptz?.capable === true && ptz?.fisheye !== true
+
+      expect(ptz?.capable).toBe(true)
+      expect(ptz?.fisheye).toBe(true)
+      expect(isPtzCapable).toBe(false)
+    })
+
     it('should accept null for bridgeId and locationId', () => {
       const camera: Camera = {
         id: 'cam-direct',

--- a/src/types/camera.ts
+++ b/src/types/camera.ts
@@ -229,6 +229,18 @@ export interface Camera {
     ptz?: {
       /** Whether this camera supports PTZ controls */
       capable?: boolean
+      /** Whether this is a fisheye camera (not a true PTZ camera) */
+      fisheye?: boolean
+      /** Whether the camera supports pan/tilt movements */
+      panTilt?: boolean
+      /** Whether the camera supports zoom */
+      zoom?: boolean
+      /** Whether the camera supports absolute position moves */
+      positionMove?: boolean
+      /** Whether the camera supports directional moves */
+      directionMove?: boolean
+      /** Whether the camera supports center-on moves */
+      centerOnMove?: boolean
     }
   }
   /** List of enabled analytics on this camera */


### PR DESCRIPTION
## Summary
- Add fisheye camera exclusion to PTZ type definitions, agent docs, AI reference docs, and vue-ptz example
- Add PTZ sub-capability fields (`fisheye`, `panTilt`, `zoom`, `positionMove`, `directionMove`, `centerOnMove`) to `Camera.capabilities.ptz` type
- Regenerate API coverage docs with full-width layout and scrollbar fix

## Version
v0.3.96

## Commits
- `1d9da62` docs: regenerate API coverage docs with full-width layout and scrollbar fix
- `044c9ae` docs: add fisheye camera exclusion guidance to PTZ agent
- `f65ff2e` fix: add PTZ sub-capability fields to Camera type and update docs
- `6ecf253` fix: address review findings for PTZ fisheye guidance
- `97cf632` fix: exclude fisheye cameras from PTZ selector in vue-ptz example

## Test Results
- Lint: passed (1 pre-existing warning)
- Unit tests: 683/683 passed
- Build: passed
- E2E: 12/12 example apps passed
- Security: no vulnerabilities (type/docs changes only)
- Confidential data scan: clean across 280 changed .md files

🤖 Generated with [Claude Code](https://claude.com/claude-code)