### PR TITLE
Bump github/codeql-action from 4.32.3 to 4.32.4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,14 +25,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@9e907b5e64f6b83e7804b09294d44122997950d6 # v4.32.3
+        uses: github/codeql-action/init@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@9e907b5e64f6b83e7804b09294d44122997950d6 # v4.32.3
+        uses: github/codeql-action/autobuild@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@9e907b5e64f6b83e7804b09294d44122997950d6 # v4.32.3
+        uses: github/codeql-action/analyze@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- Bumps `github/codeql-action` SHA pins from v4.32.3 to v4.32.4 in `.github/workflows/codeql.yml`
- Dependabot-originated update merged via develop

## Details
- **Version**: v0.3.101
- **Commits**:
  - `b3ddb541` chore(deps): bump github/codeql-action from 4.32.3 to 4.32.4
  - `cd3c541f` Merge pull request #131

## Test Results
- Lint: passed (0 errors, 1 pre-existing warning)
- Unit tests: 684/684 passed
- Build: passed
- E2E: 12/12 example apps passed locally
- Security: no concerns (SHA pin update only)
- Docs: no .md files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)