### PR TITLE
build(deps): vite-plugin-dts v5 + lift Node floor to 20.19

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ This is a TypeScript library ("Toolkit") implementing the Eagle Eye Networks (EE
 - **Testing**: Vitest (unit), Playwright (E2E)
 - **Linting**: ESLint only (no Prettier)
 - **Node.js**: Minimum version 20 LTS
-- **TypeScript**: Pinned to ~5.8.x (required for API Extractor compatibility in vite-plugin-dts)
+- **TypeScript**: Pinned to ~5.8.x (kept within the range API Extractor supports; `@microsoft/api-extractor` powers the rolled-up `.d.ts` via vite-plugin-dts v5's `bundleTypes`)
 - **Dependencies**: Always use latest stable versions of imported packages
 
 ## Common Commands

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@typescript-eslint/eslint-plugin": "^8.51.0",
         "@typescript-eslint/parser": "^8.51.0",
         "@vitejs/plugin-vue": "^6.0.0",
-        "@vue/language-core": "^3.3.4",
+        "@vue/language-core": "3.3.4",
         "@vue/tsconfig": "^0.9.0",
         "dotenv": "^17.2.3",
         "eslint": "^9.0.0",
@@ -41,7 +41,7 @@
         "vue-tsc": "^3.2.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
         "pinia": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,11 +14,13 @@
       "devDependencies": {
         "@eslint/js": "^9.0.0",
         "@marp-team/marp-cli": "^4.2.3",
+        "@microsoft/api-extractor": "^7.58.9",
         "@playwright/test": "1.60.0",
         "@types/node": "^25.0.3",
         "@typescript-eslint/eslint-plugin": "^8.51.0",
         "@typescript-eslint/parser": "^8.51.0",
         "@vitejs/plugin-vue": "^6.0.0",
+        "@vue/language-core": "^3.3.4",
         "@vue/tsconfig": "^0.9.0",
         "dotenv": "^17.2.3",
         "eslint": "^9.0.0",
@@ -32,7 +34,7 @@
         "typedoc-plugin-markdown": "^4.9.0",
         "typescript": "~5.8.0",
         "vite": "^8.0.1",
-        "vite-plugin-dts": "^4.5.4",
+        "vite-plugin-dts": "^5.0.2",
         "vitest": "^4.0.16",
         "vue": "^3.4.0",
         "vue-eslint-parser": "^10.2.0",
@@ -1178,12 +1180,55 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@marp-team/marp-cli": {
       "version": "4.4.0",
@@ -2525,17 +2570,6 @@
         "@vue/shared": "3.5.38"
       }
     },
-    "node_modules/@vue/compiler-vue2": {
-      "version": "2.7.16",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-vue2/-/compiler-vue2-2.7.16.tgz",
-      "integrity": "sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "de-indent": "^1.0.2",
-        "he": "^1.2.0"
-      }
-    },
     "node_modules/@vue/devtools-api": {
       "version": "7.7.9",
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
@@ -2573,68 +2607,19 @@
       }
     },
     "node_modules/@vue/language-core": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.2.0.tgz",
-      "integrity": "sha512-O1ZZFaaBGkKbsRfnVH1ifOK1/1BUkyK+3SQsfnh6PmMmD4qJcTU8godCeA96jjDRTL6zgnK7YzCHfaUlH2r0Mw==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.4.tgz",
+      "integrity": "sha512-IuHqQ5zGGOE7CXP72VX6A42IVeIzYv4WAhO6arej11TRNqtdZfGyH8Yr2FOCaDX0dSQG+JwULLoFHGY1igYVjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@volar/language-core": "~2.4.11",
+        "@volar/language-core": "2.4.28",
         "@vue/compiler-dom": "^3.5.0",
-        "@vue/compiler-vue2": "^2.7.16",
         "@vue/shared": "^3.5.0",
-        "alien-signals": "^0.4.9",
-        "minimatch": "^9.0.3",
+        "alien-signals": "^3.2.0",
         "muggle-string": "^0.4.1",
-        "path-browserify": "^1.0.1"
-      },
-      "peerDependencies": {
-        "typescript": "*"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vue/language-core/node_modules/alien-signals": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-0.4.14.tgz",
-      "integrity": "sha512-itUAVzhczTmP2U5yX67xVpsbbOiquusbWVyA9N+sy6+r6YVbFkahXvNCeEPWEOMhwDYwbVbGHFkVL03N9I5g+Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vue/language-core/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vue/language-core/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@vue/language-core/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "path-browserify": "^1.0.1",
+        "picomatch": "^4.0.4"
       }
     },
     "node_modules/@vue/reactivity": {
@@ -3342,13 +3327,6 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
-    },
-    "node_modules/de-indent": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
-      "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -4199,16 +4177,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "he": "bin/he"
       }
     },
     "node_modules/highlight.js": {
@@ -6499,6 +6467,22 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/unplugin": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
+      "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "acorn": "^8.15.0",
+        "picomatch": "^4.0.3",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -6595,28 +6579,81 @@
       }
     },
     "node_modules/vite-plugin-dts": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-4.5.4.tgz",
-      "integrity": "sha512-d4sOM8M/8z7vRXHHq/ebbblfaxENjogAAekcfcDCCwAyvGqnPrc7f4NZbvItS+g4WTgerW0xDwSz5qz11JT3vg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-5.0.2.tgz",
+      "integrity": "sha512-lNeHS+dwGju6eRmNvZQt8Shwv9j3m98hbHse/lIbLq9q3yE2DcIOBBYQEVUF6tS0kOmv+VA9Z5FqmzFnGe4U8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@microsoft/api-extractor": "^7.50.1",
+        "unplugin-dts": "1.0.2"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": ">=7",
+        "rollup": ">=3",
+        "vite": ">=3"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-plugin-dts/node_modules/unplugin-dts": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unplugin-dts/-/unplugin-dts-1.0.2.tgz",
+      "integrity": "sha512-VbNiMD0LMl/t6nJueGtrCp79N7ZO1nquxj/FUybJDnKwZGsnW2wjdwBSzA3QEHujoxmxZIptsG43hL7LzXE96w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "@rollup/pluginutils": "^5.1.4",
-        "@volar/typescript": "^2.4.11",
-        "@vue/language-core": "2.2.0",
+        "@volar/typescript": "^2.4.26",
         "compare-versions": "^6.1.1",
         "debug": "^4.4.0",
         "kolorist": "^1.8.0",
-        "local-pkg": "^1.0.0",
-        "magic-string": "^0.30.17"
+        "local-pkg": "^1.1.1",
+        "magic-string": "^0.30.17",
+        "unplugin": "^2.3.2"
       },
       "peerDependencies": {
-        "typescript": "*",
-        "vite": "*"
+        "@microsoft/api-extractor": ">=7",
+        "@rspack/core": "^1",
+        "@vue/language-core": "~3.1.5",
+        "esbuild": "*",
+        "rolldown": "*",
+        "rollup": ">=3",
+        "typescript": ">=4",
+        "vite": ">=3",
+        "webpack": "^4 || ^5"
       },
       "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@rspack/core": {
+          "optional": true
+        },
+        "@vue/language-core": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "rolldown": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        },
         "vite": {
+          "optional": true
+        },
+        "webpack": {
           "optional": true
         }
       }
@@ -6809,22 +6846,6 @@
         "typescript": ">=5.0.0"
       }
     },
-    "node_modules/vue-tsc/node_modules/@vue/language-core": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.4.tgz",
-      "integrity": "sha512-IuHqQ5zGGOE7CXP72VX6A42IVeIzYv4WAhO6arej11TRNqtdZfGyH8Yr2FOCaDX0dSQG+JwULLoFHGY1igYVjQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@volar/language-core": "2.4.28",
-        "@vue/compiler-dom": "^3.5.0",
-        "@vue/shared": "^3.5.0",
-        "alien-signals": "^3.2.0",
-        "muggle-string": "^0.4.1",
-        "path-browserify": "^1.0.1",
-        "picomatch": "^4.0.4"
-      }
-    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
@@ -6864,6 +6885,13 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/whatwg-mimetype": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -56,11 +56,13 @@
   "devDependencies": {
     "@eslint/js": "^9.0.0",
     "@marp-team/marp-cli": "^4.2.3",
+    "@microsoft/api-extractor": "^7.58.9",
     "@playwright/test": "1.60.0",
     "@types/node": "^25.0.3",
     "@typescript-eslint/eslint-plugin": "^8.51.0",
     "@typescript-eslint/parser": "^8.51.0",
     "@vitejs/plugin-vue": "^6.0.0",
+    "@vue/language-core": "^3.3.4",
     "@vue/tsconfig": "^0.9.0",
     "dotenv": "^17.2.3",
     "eslint": "^9.0.0",
@@ -74,7 +76,7 @@
     "typedoc-plugin-markdown": "^4.9.0",
     "typescript": "~5.8.0",
     "vite": "^8.0.1",
-    "vite-plugin-dts": "^4.5.4",
+    "vite-plugin-dts": "^5.0.2",
     "vitest": "^4.0.16",
     "vue": "^3.4.0",
     "vue-eslint-parser": "^10.2.0",
@@ -97,6 +99,6 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.19.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@typescript-eslint/eslint-plugin": "^8.51.0",
     "@typescript-eslint/parser": "^8.51.0",
     "@vitejs/plugin-vue": "^6.0.0",
-    "@vue/language-core": "^3.3.4",
+    "@vue/language-core": "3.3.4",
     "@vue/tsconfig": "^0.9.0",
     "dotenv": "^17.2.3",
     "eslint": "^9.0.0",

--- a/scripts/verify-package.sh
+++ b/scripts/verify-package.sh
@@ -79,6 +79,18 @@ else
   echo "   ✗ Missing expected exports in declarations"
   exit 1
 fi
+
+# Type-check the rolled-up declaration itself. grep only proves names are
+# present; this catches dangling/broken type references in the bundled
+# .d.ts (the failure mode an API Extractor / vite-plugin-dts change can
+# introduce). Run isolated so it does not pick up the repo tsconfig globs.
+if npx tsc --noEmit --skipLibCheck dist/index.d.ts > /tmp/dts-typecheck.log 2>&1; then
+  echo "   ✓ Bundled declaration type-checks (no dangling references)"
+else
+  echo "   ✗ Bundled declaration failed to type-check:"
+  cat /tmp/dts-typecheck.log
+  exit 1
+fi
 echo ""
 
 # Step 5: Verify ESM and CJS syntax

--- a/scripts/verify-package.sh
+++ b/scripts/verify-package.sh
@@ -83,12 +83,19 @@ fi
 # Type-check the rolled-up declaration itself. grep only proves names are
 # present; this catches dangling/broken type references in the bundled
 # .d.ts (the failure mode an API Extractor / vite-plugin-dts change can
-# introduce). Run isolated so it does not pick up the repo tsconfig globs.
-if npx tsc --noEmit --skipLibCheck dist/index.d.ts > /tmp/dts-typecheck.log 2>&1; then
+# introduce). NOTE: do NOT add --skipLibCheck here — it suppresses the
+# semantic checking of .d.ts files, which is exactly the dangling-reference
+# check we want (verified: a TS2304 in dist/index.d.ts passes under
+# --skipLibCheck but fails without it). A clean rolled-up build resolves
+# vue/pinia/node types without error, so the gate stays quiet when correct.
+DTS_LOG=$(mktemp)
+if npx tsc --noEmit dist/index.d.ts > "$DTS_LOG" 2>&1; then
   echo "   ✓ Bundled declaration type-checks (no dangling references)"
+  rm -f "$DTS_LOG"
 else
   echo "   ✗ Bundled declaration failed to type-check:"
-  cat /tmp/dts-typecheck.log
+  cat "$DTS_LOG"
+  rm -f "$DTS_LOG"
   exit 1
 fi
 echo ""

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,10 @@ export default defineConfig({
   plugins: [
     vue(),
     dts({
-      rollupTypes: true,
+      // vite-plugin-dts v5 renamed `rollupTypes` to `bundleTypes`
+      // (powered by @microsoft/api-extractor) — produces a single
+      // rolled-up dist/index.d.ts.
+      bundleTypes: true,
       tsconfigPath: './tsconfig.json'
     })
   ],


### PR DESCRIPTION
## Summary

Completes the `vite-plugin-dts` 4.x → **5.x** upgrade that Dependabot reopened as #171 (deferred from the dependency-maintenance release because v5 changes the declaration build). Also lifts the Node `engines` floor, addressing the code-review observation on the previous release.

### vite-plugin-dts 5 migration
v5 is built on `unplugin-dts` and renames `rollupTypes` → **`bundleTypes`**, and no longer bundles API Extractor. The rolled-up `.d.ts` build therefore needs two dev deps as (optional) peers:
- `@microsoft/api-extractor` ^7.58.9 — powers `bundleTypes`
- `@vue/language-core` 3.3.4 — the Vue declaration path imports it directly; pinned to match `vue-tsc` 3.3.4

`vite.config.ts`: `rollupTypes: true` → `bundleTypes: true`.

**Verified:** the build still emits a single rolled-up `dist/index.d.ts` (~231 KB, **0 per-module re-exports**), the generated declaration **type-checks with no dangling references** (`tsc --noEmit dist/index.d.ts`), and `verify-package` confirms the key exports. Runtime output (`index.js`/`index.cjs`) is byte-identical — no shipped runtime change.

### Node engines floor
`>=20.0.0` → **`>=20.19.0`** — matches the transitive dev-tooling requirement (vite 8 / rolldown, jsdom's css stack) flagged in the v0.3.109 review, eliminating `EBADENGINE` warnings for contributors on early 20.x patches. (Still Node 20 LTS, just a later patch.)

## Test Results

| Check | Result |
|---|---|
| Lint | ✅ 0 errors (1 pre-existing warning) |
| Typecheck | ✅ |
| Generated `.d.ts` self type-check | ✅ no dangling refs |
| Unit | ✅ 704/704 |
| Build + verify-package | ✅ rolled-up single `.d.ts`, secret guard |
| Toolkit E2E (live API) | ✅ 72 passed, 1 skipped |

Closes the work tracked by #171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)